### PR TITLE
feat: implement external model reconciler for Istio-based egress routing (#5)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,6 +102,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20260127142750-a19766b6e2d4 // indirect
 	k8s.io/utils v0.0.0-20260108192941-914a6e750570 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
+	sigs.k8s.io/gateway-api v1.5.1 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -255,6 +255,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUo
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4iqwZ80=
 sigs.k8s.io/controller-runtime v0.23.3/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
+sigs.k8s.io/gateway-api v1.5.1 h1:RqVRIlkhLhUO8wOHKTLnTJA6o/1un4po4/6M1nRzdd0=
+sigs.k8s.io/gateway-api v1.5.1/go.mod h1:GvCETiaMAlLym5CovLxGjS0NysqFk3+Yuq3/rh6QL2o=
 sigs.k8s.io/gateway-api-inference-extension v0.0.0-20260318135032-876ac9d909d0 h1:F1fYVhxwRQhQnf8PEkwGJoDj8uTDZ88mNe9r6qqYKNA=
 sigs.k8s.io/gateway-api-inference-extension v0.0.0-20260318135032-876ac9d909d0/go.mod h1:KBw2Ke/uiMHEWHmG2th8j0dEfMEFeuzQ+Wa2CNPMfGw=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=

--- a/pkg/reconciler/externalmodel/README.md
+++ b/pkg/reconciler/externalmodel/README.md
@@ -1,0 +1,101 @@
+# External Model Reconciler
+
+Watches `MaaSModelRef` CRs with `kind: ExternalModel` and creates the Istio
+resources required to route traffic from the MaaS gateway to an external AI
+model provider.
+
+## What It Creates
+
+For each `ExternalModel` MaaSModelRef, the reconciler creates:
+
+| # | Resource | Purpose |
+|---|----------|---------|
+| 1 | ExternalName Service | DNS bridge so HTTPRoute backendRef can reference the external host |
+| 2 | ServiceEntry | Registers the external FQDN in the Istio mesh (required for REGISTRY_ONLY) |
+| 3 | DestinationRule | TLS origination (skipped when `tls: false`) |
+| 4 | HTTPRoute | Routes `/external/<provider>/*` to the provider, sets Host header |
+
+Resources are created in the gateway namespace (`openshift-ingress`), which is
+cross-namespace from the MaaSModelRef. Since Kubernetes garbage collection does
+not follow cross-namespace OwnerReferences, the reconciler uses a **finalizer**
+to explicitly delete all managed resources when the CR is removed.
+
+## MaaSModelRef Spec
+
+Until the CRD is enriched with external model fields (tracked separately), the
+reconciler reads configuration from annotations:
+
+```yaml
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSModelRef
+metadata:
+  name: gpt-4o-mini
+  namespace: opendatahub
+  annotations:
+    maas.opendatahub.io/provider: "openai"
+    maas.opendatahub.io/endpoint: "api.openai.com"
+    maas.opendatahub.io/port: "443"                         # default
+    maas.opendatahub.io/tls: "true"                         # default
+    maas.opendatahub.io/path-prefix: "/external/openai/"    # default: /external/<provider>/
+    maas.opendatahub.io/extra-headers: "anthropic-version=2023-06-01"  # optional
+spec:
+  modelRef:
+    kind: ExternalModel
+    name: gpt-4o-mini
+```
+
+When the CRD is updated, the reconciler will read from `spec` fields instead.
+
+## Annotation Reference
+
+| Annotation | Required | Default | Example |
+|------------|----------|---------|---------|
+| `maas.opendatahub.io/endpoint` | Yes | - | `api.openai.com` |
+| `maas.opendatahub.io/provider` | No | `spec.modelRef.name` | `openai` |
+| `maas.opendatahub.io/port` | No | `443` | `8000` |
+| `maas.opendatahub.io/tls` | No | `true` | `false` |
+| `maas.opendatahub.io/path-prefix` | No | `/external/<provider>/` | `/v1/` |
+| `maas.opendatahub.io/extra-headers` | No | - | `anthropic-version=2023-06-01` |
+
+## Provider Examples
+
+### OpenAI
+
+```yaml
+annotations:
+  maas.opendatahub.io/provider: "openai"
+  maas.opendatahub.io/endpoint: "api.openai.com"
+```
+
+### Anthropic
+
+```yaml
+annotations:
+  maas.opendatahub.io/provider: "anthropic"
+  maas.opendatahub.io/endpoint: "api.anthropic.com"
+  maas.opendatahub.io/extra-headers: "anthropic-version=2023-06-01"
+```
+
+### Self-hosted vLLM (no TLS)
+
+```yaml
+annotations:
+  maas.opendatahub.io/provider: "vllm"
+  maas.opendatahub.io/endpoint: "vllm.example.com"
+  maas.opendatahub.io/port: "8000"
+  maas.opendatahub.io/tls: "false"
+```
+
+## Moving to MaaS
+
+This reconciler is designed to be portable to the MaaS controller repo. To
+integrate with the existing MaaS provider pattern:
+
+1. Implement `BackendHandler` interface in `providers_external.go`
+2. Call `BuildExternalNameService`, `BuildServiceEntry`, `BuildDestinationRule`,
+   `BuildHTTPRoute` from `ReconcileRoute`
+3. Set status endpoint and phase from `Status`
+4. Finalizer handles cleanup in `CleanupOnDelete`
+
+The resource builder functions in `resources.go` are stateless and can be
+copied directly into the MaaS controller.

--- a/pkg/reconciler/externalmodel/reconciler.go
+++ b/pkg/reconciler/externalmodel/reconciler.go
@@ -1,0 +1,480 @@
+package externalmodel
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const (
+	finalizerName = "maas.opendatahub.io/external-model-cleanup"
+
+	// Annotation keys for ExternalModel spec (until CRD is updated)
+	AnnProvider     = "maas.opendatahub.io/provider"
+	AnnEndpoint     = "maas.opendatahub.io/endpoint"
+	AnnExtraHeaders = "maas.opendatahub.io/extra-headers"
+	AnnPort         = "maas.opendatahub.io/port"
+	AnnTLS          = "maas.opendatahub.io/tls"
+	AnnPathPrefix   = "maas.opendatahub.io/path-prefix"
+
+	// MaaSModelRef GVK
+	maasGroup    = "maas.opendatahub.io"
+	maasVersion  = "v1alpha1"
+	maasResource = "maasmodelrefs"
+	maasKind     = "MaaSModelRef"
+
+	// Default gateway (matches MaaS controller defaults)
+	defaultGatewayName      = "maas-default-gateway"
+	defaultGatewayNamespace = "openshift-ingress"
+)
+
+// Reconciler watches MaaSModelRef CRs with kind=ExternalModel and creates
+// the Istio resources needed to route to the external provider.
+//
+// Resources are created in the gateway namespace (typically openshift-ingress),
+// which is a different namespace from the MaaSModelRef. Because Kubernetes
+// garbage collection does not work across namespaces, the reconciler uses a
+// finalizer to explicitly delete managed resources when the CR is removed.
+type Reconciler struct {
+	client.Client
+	Scheme           *runtime.Scheme
+	Log              logr.Logger
+	GatewayName      string
+	GatewayNamespace string
+}
+
+func (r *Reconciler) gatewayName() string {
+	if r.GatewayName != "" {
+		return r.GatewayName
+	}
+	return defaultGatewayName
+}
+
+func (r *Reconciler) gatewayNamespace() string {
+	if r.GatewayNamespace != "" {
+		return r.GatewayNamespace
+	}
+	return defaultGatewayNamespace
+}
+
+// Reconcile handles create/update/delete of MaaSModelRef CRs with kind=ExternalModel.
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("maasmodelref", req.NamespacedName)
+
+	// Fetch the MaaSModelRef (unstructured since we don't import the MaaS types)
+	model := &unstructured.Unstructured{}
+	model.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   maasGroup,
+		Version: maasVersion,
+		Kind:    maasKind,
+	})
+	if err := r.Get(ctx, req.NamespacedName, model); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Only handle ExternalModel kind
+	kind, _, _ := unstructured.NestedString(model.Object, "spec", "modelRef", "kind")
+	if kind != "ExternalModel" {
+		return ctrl.Result{}, nil
+	}
+
+	// Handle deletion — must explicitly delete cross-namespace resources
+	if !model.GetDeletionTimestamp().IsZero() {
+		return r.handleDeletion(ctx, log, model)
+	}
+
+	// Add finalizer if not present
+	if !controllerutil.ContainsFinalizer(model, finalizerName) {
+		controllerutil.AddFinalizer(model, finalizerName)
+		if err := r.Update(ctx, model); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Parse the ExternalModel spec from annotations (until CRD is enriched)
+	spec, err := specFromAnnotations(model)
+	if err != nil {
+		log.Error(err, "Failed to parse ExternalModel spec from annotations")
+		return r.setStatus(ctx, model, "Failed", fmt.Sprintf("invalid spec: %v", err))
+	}
+
+	log.Info("Reconciling ExternalModel",
+		"provider", spec.Provider,
+		"endpoint", spec.Endpoint,
+		"tls", spec.TLS,
+	)
+
+	gwNamespace := r.gatewayNamespace()
+	gwName := r.gatewayName()
+	labels := CommonLabels(model.GetName())
+	resourceKey := spec.Provider + "-" + sanitize(spec.Endpoint)
+
+	// NOTE: No OwnerReferences on these resources. The MaaSModelRef lives in a
+	// different namespace (e.g. opendatahub) than the gateway namespace (e.g.
+	// openshift-ingress). Kubernetes GC does not follow cross-namespace
+	// OwnerReferences. Instead, the finalizer on the MaaSModelRef triggers
+	// explicit deletion in handleDeletion().
+
+	// 1. ExternalName Service
+	svc := BuildExternalNameService(spec, gwNamespace, labels)
+	if err := r.applyService(ctx, log, svc); err != nil {
+		return r.setStatus(ctx, model, "Failed", fmt.Sprintf("failed to create Service: %v", err))
+	}
+
+	// 2. ServiceEntry
+	se := BuildServiceEntry(spec, gwNamespace, labels)
+	if err := r.applyUnstructured(ctx, log, se); err != nil {
+		return r.setStatus(ctx, model, "Failed", fmt.Sprintf("failed to create ServiceEntry: %v", err))
+	}
+
+	// 3. DestinationRule (only if TLS; delete stale DR when TLS is disabled)
+	if spec.TLS {
+		dr := BuildDestinationRule(spec, gwNamespace, labels)
+		if err := r.applyUnstructured(ctx, log, dr); err != nil {
+			return r.setStatus(ctx, model, "Failed", fmt.Sprintf("failed to create DestinationRule: %v", err))
+		}
+	} else {
+		// Clean up any stale DestinationRule from when TLS was previously enabled
+		_, _, drName, _ := ResourceNames(resourceKey)
+		if err := r.deleteIfExists(ctx, log, "DestinationRule", drName, gwNamespace, schema.GroupVersionKind{
+			Group: "networking.istio.io", Version: "v1", Kind: "DestinationRule",
+		}); err != nil {
+			log.Error(err, "Failed to delete stale DestinationRule", "name", drName)
+		}
+	}
+
+	// 4. HTTPRoute
+	hr := BuildHTTPRoute(spec, gwNamespace, gwName, gwNamespace, labels)
+	if err := r.applyHTTPRoute(ctx, log, hr); err != nil {
+		return r.setStatus(ctx, model, "Failed", fmt.Sprintf("failed to create HTTPRoute: %v", err))
+	}
+
+	log.Info("ExternalModel resources reconciled successfully",
+		"service", svc.Name,
+		"serviceEntry", se.GetName(),
+		"httpRoute", hr.Name,
+	)
+
+	// Build endpoint URL from the MaaS gateway (not the provider URL).
+	// MaaS clients discover models via status.endpoint which must point to
+	// the MaaS gateway, not directly to the external provider.
+	endpoint, err := r.resolveGatewayEndpoint(ctx, gwName, gwNamespace, spec.Provider)
+	if err != nil {
+		log.Error(err, "Failed to resolve gateway endpoint, using fallback")
+		endpoint = fmt.Sprintf("/external/%s/", spec.Provider)
+	}
+
+	return r.setStatusReady(ctx, model, endpoint, hr.Name, gwName, gwNamespace)
+}
+
+// resolveGatewayEndpoint reads the Gateway resource to get the listener hostname
+// and constructs the MaaS-facing endpoint URL.
+func (r *Reconciler) resolveGatewayEndpoint(ctx context.Context, gwName, gwNamespace, provider string) (string, error) {
+	gw := &gatewayapiv1.Gateway{}
+	if err := r.Get(ctx, types.NamespacedName{Name: gwName, Namespace: gwNamespace}, gw); err != nil {
+		return "", fmt.Errorf("failed to get Gateway %s/%s: %w", gwNamespace, gwName, err)
+	}
+
+	// Use the first listener hostname
+	for _, listener := range gw.Spec.Listeners {
+		if listener.Hostname != nil && *listener.Hostname != "" {
+			scheme := "https"
+			if listener.Protocol == gatewayapiv1.HTTPProtocolType {
+				scheme = "http"
+			}
+			return fmt.Sprintf("%s://%s/external/%s/", scheme, *listener.Hostname, provider), nil
+		}
+	}
+
+	// Fallback: check status addresses
+	for _, addr := range gw.Status.Addresses {
+		if addr.Value != "" {
+			return fmt.Sprintf("http://%s/external/%s/", addr.Value, provider), nil
+		}
+	}
+
+	return "", fmt.Errorf("no hostname or address found on Gateway %s/%s", gwNamespace, gwName)
+}
+
+// handleDeletion explicitly deletes all managed resources in the gateway
+// namespace, then removes the finalizer only if all deletions succeed.
+// This prevents orphaned resources when deletion fails (e.g., network
+// partition, RBAC issue). The controller will requeue and retry.
+func (r *Reconciler) handleDeletion(ctx context.Context, log logr.Logger, model *unstructured.Unstructured) (ctrl.Result, error) {
+	log.Info("Handling deletion of ExternalModel, cleaning up cross-namespace resources")
+
+	spec, err := specFromAnnotations(model)
+	if err != nil {
+		log.Error(err, "Failed to parse spec for cleanup, removing finalizer anyway")
+	} else {
+		gwNamespace := r.gatewayNamespace()
+		resourceKey := spec.Provider + "-" + sanitize(spec.Endpoint)
+		svcName, seName, drName, hrName := ResourceNames(resourceKey)
+
+		var cleanupErrs []error
+
+		// Delete in reverse creation order
+		if err := r.deleteIfExists(ctx, log, "HTTPRoute", hrName, gwNamespace, schema.GroupVersionKind{
+			Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute",
+		}); err != nil {
+			cleanupErrs = append(cleanupErrs, err)
+		}
+		if err := r.deleteIfExists(ctx, log, "DestinationRule", drName, gwNamespace, schema.GroupVersionKind{
+			Group: "networking.istio.io", Version: "v1", Kind: "DestinationRule",
+		}); err != nil {
+			cleanupErrs = append(cleanupErrs, err)
+		}
+		if err := r.deleteIfExists(ctx, log, "ServiceEntry", seName, gwNamespace, schema.GroupVersionKind{
+			Group: "networking.istio.io", Version: "v1", Kind: "ServiceEntry",
+		}); err != nil {
+			cleanupErrs = append(cleanupErrs, err)
+		}
+		// Delete ExternalName Service
+		svc := &corev1.Service{}
+		if err := r.Get(ctx, types.NamespacedName{Name: svcName, Namespace: gwNamespace}, svc); err == nil {
+			log.Info("Deleting Service", "name", svcName)
+			if err := r.Delete(ctx, svc); err != nil && !apierrors.IsNotFound(err) {
+				log.Error(err, "Failed to delete Service", "name", svcName)
+				cleanupErrs = append(cleanupErrs, fmt.Errorf("failed to delete Service %s/%s: %w", gwNamespace, svcName, err))
+			}
+		} else if !apierrors.IsNotFound(err) {
+			cleanupErrs = append(cleanupErrs, fmt.Errorf("failed to get Service %s/%s: %w", gwNamespace, svcName, err))
+		}
+
+		if len(cleanupErrs) > 0 {
+			// Requeue — do NOT remove finalizer so cleanup is retried
+			return ctrl.Result{}, fmt.Errorf("cleanup incomplete, will retry: %v", cleanupErrs)
+		}
+	}
+
+	if controllerutil.ContainsFinalizer(model, finalizerName) {
+		controllerutil.RemoveFinalizer(model, finalizerName)
+		if err := r.Update(ctx, model); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+// deleteIfExists deletes an unstructured resource if it exists.
+// Returns an error only for real failures; NotFound is treated as success.
+func (r *Reconciler) deleteIfExists(ctx context.Context, log logr.Logger, kind, name, namespace string, gvk schema.GroupVersionKind) error {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(gvk)
+	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get %s %s/%s: %w", kind, namespace, name, err)
+	}
+	log.Info("Deleting resource", "kind", kind, "name", name)
+	if err := r.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
+		log.Error(err, "Failed to delete resource", "kind", kind, "name", name)
+		return fmt.Errorf("failed to delete %s %s/%s: %w", kind, namespace, name, err)
+	}
+	return nil
+}
+
+// applyService creates or updates a Service.
+func (r *Reconciler) applyService(ctx context.Context, log logr.Logger, desired *corev1.Service) error {
+	existing := &corev1.Service{}
+	err := r.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing)
+	if apierrors.IsNotFound(err) {
+		log.Info("Creating Service", "name", desired.Name)
+		return r.Create(ctx, desired)
+	}
+	if err != nil {
+		return err
+	}
+	if !equality.Semantic.DeepEqual(existing.Spec, desired.Spec) {
+		existing.Spec = desired.Spec
+		existing.Labels = desired.Labels
+		log.Info("Updating Service", "name", desired.Name)
+		return r.Update(ctx, existing)
+	}
+	return nil
+}
+
+// applyUnstructured creates or updates an unstructured resource (ServiceEntry, DestinationRule).
+func (r *Reconciler) applyUnstructured(ctx context.Context, log logr.Logger, desired *unstructured.Unstructured) error {
+	existing := &unstructured.Unstructured{}
+	existing.SetGroupVersionKind(desired.GroupVersionKind())
+	err := r.Get(ctx, types.NamespacedName{Name: desired.GetName(), Namespace: desired.GetNamespace()}, existing)
+	if apierrors.IsNotFound(err) {
+		log.Info("Creating resource", "kind", desired.GetKind(), "name", desired.GetName())
+		return r.Create(ctx, desired)
+	}
+	if err != nil {
+		return err
+	}
+	desired.SetResourceVersion(existing.GetResourceVersion())
+	log.Info("Updating resource", "kind", desired.GetKind(), "name", desired.GetName())
+	return r.Update(ctx, desired)
+}
+
+// applyHTTPRoute creates or updates an HTTPRoute.
+func (r *Reconciler) applyHTTPRoute(ctx context.Context, log logr.Logger, desired *gatewayapiv1.HTTPRoute) error {
+	existing := &gatewayapiv1.HTTPRoute{}
+	err := r.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing)
+	if apierrors.IsNotFound(err) {
+		log.Info("Creating HTTPRoute", "name", desired.Name)
+		return r.Create(ctx, desired)
+	}
+	if err != nil {
+		return err
+	}
+	existing.Spec = desired.Spec
+	existing.Labels = desired.Labels
+	log.Info("Updating HTTPRoute", "name", desired.Name)
+	return r.Update(ctx, existing)
+}
+
+// setStatus updates the MaaSModelRef status phase and conditions.
+func (r *Reconciler) setStatus(ctx context.Context, model *unstructured.Unstructured, phase, message string) (ctrl.Result, error) {
+	status, _ := model.Object["status"].(map[string]interface{})
+	if status == nil {
+		status = map[string]interface{}{}
+	}
+	status["phase"] = phase
+	now := metav1.Now().Format("2006-01-02T15:04:05Z")
+	status["conditions"] = []interface{}{
+		map[string]interface{}{
+			"type":               "Ready",
+			"status":             "False",
+			"lastTransitionTime": now,
+			"reason":             phase,
+			"message":            message,
+		},
+	}
+	model.Object["status"] = status
+
+	if err := r.Status().Update(ctx, model); err != nil {
+		r.Log.Error(err, "Failed to update status", "phase", phase)
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// setStatusReady updates the MaaSModelRef status to Ready with the MaaS gateway endpoint.
+func (r *Reconciler) setStatusReady(ctx context.Context, model *unstructured.Unstructured, endpoint, httpRouteName, gwName, gwNamespace string) (ctrl.Result, error) {
+	status, _ := model.Object["status"].(map[string]interface{})
+	if status == nil {
+		status = map[string]interface{}{}
+	}
+	status["phase"] = "Ready"
+	status["endpoint"] = endpoint
+	status["httpRouteName"] = httpRouteName
+	status["httpRouteGatewayName"] = gwName
+	status["httpRouteGatewayNamespace"] = gwNamespace
+	now := metav1.Now().Format("2006-01-02T15:04:05Z")
+	status["conditions"] = []interface{}{
+		map[string]interface{}{
+			"type":               "Ready",
+			"status":             "True",
+			"lastTransitionTime": now,
+			"reason":             "Reconciled",
+			"message":            "Istio resources created successfully",
+		},
+	}
+	model.Object["status"] = status
+
+	if err := r.Status().Update(ctx, model); err != nil {
+		r.Log.Error(err, "Failed to update status to Ready")
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// specFromAnnotations parses ExternalModelSpec from MaaSModelRef annotations.
+// This is a bridge until the CRD is enriched with the required fields.
+func specFromAnnotations(model *unstructured.Unstructured) (ExternalModelSpec, error) {
+	ann := model.GetAnnotations()
+	if ann == nil {
+		ann = map[string]string{}
+	}
+
+	spec := ExternalModelSpec{
+		Provider:   ann[AnnProvider],
+		Endpoint:   ann[AnnEndpoint],
+		PathPrefix: ann[AnnPathPrefix],
+		TLS:        true,
+		Port:       443,
+	}
+
+	// Fall back to modelRef.name for provider if annotation not set
+	if spec.Provider == "" {
+		name, _, _ := unstructured.NestedString(model.Object, "spec", "modelRef", "name")
+		spec.Provider = name
+	}
+
+	if spec.Endpoint == "" {
+		return spec, fmt.Errorf("annotation %s is required", AnnEndpoint)
+	}
+
+	// Parse port with range validation
+	if portStr, ok := ann[AnnPort]; ok {
+		p, err := strconv.ParseInt(portStr, 10, 32)
+		if err != nil {
+			return spec, fmt.Errorf("invalid port %q: %v", portStr, err)
+		}
+		if p < 1 || p > 65535 {
+			return spec, fmt.Errorf("port %d out of range (1-65535)", p)
+		}
+		spec.Port = int32(p)
+	}
+
+	// Parse TLS
+	if tlsStr, ok := ann[AnnTLS]; ok {
+		parsed, err := strconv.ParseBool(tlsStr)
+		if err != nil {
+			return spec, fmt.Errorf("invalid tls value %q: %v", tlsStr, err)
+		}
+		spec.TLS = parsed
+	}
+
+	// Parse extra headers (format: "key1=value1,key2=value2")
+	if extraStr, ok := ann[AnnExtraHeaders]; ok && extraStr != "" {
+		spec.ExtraHeaders = map[string]string{}
+		for _, pair := range strings.Split(extraStr, ",") {
+			kv := strings.SplitN(pair, "=", 2)
+			if len(kv) == 2 {
+				spec.ExtraHeaders[strings.TrimSpace(kv[0])] = strings.TrimSpace(kv[1])
+			}
+		}
+	}
+
+	return spec, nil
+}
+
+// SetupWithManager registers the reconciler to watch MaaSModelRef CRs.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	modelRef := &unstructured.Unstructured{}
+	modelRef.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   maasGroup,
+		Version: maasVersion,
+		Kind:    maasKind,
+	})
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(modelRef).
+		Named("external-model-reconciler").
+		Complete(r)
+}

--- a/pkg/reconciler/externalmodel/resources.go
+++ b/pkg/reconciler/externalmodel/resources.go
@@ -1,0 +1,222 @@
+package externalmodel
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// BuildExternalNameService creates a Kubernetes ExternalName Service that maps
+// an in-cluster DNS name to the external FQDN. This allows HTTPRoute backendRefs
+// to reference external hosts via standard k8s Service names.
+//
+// No OwnerReferences are set because the MaaSModelRef lives in a different
+// namespace. Cleanup is handled by the finalizer in the reconciler.
+func BuildExternalNameService(spec ExternalModelSpec, namespace string, labels map[string]string) *corev1.Service {
+	svcName, _, _, _ := ResourceNames(spec.Provider + "-" + sanitize(spec.Endpoint))
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svcName,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:         corev1.ServiceTypeExternalName,
+			ExternalName: spec.Endpoint,
+			Ports: []corev1.ServicePort{
+				{
+					Port:       spec.Port,
+					TargetPort: intstr.FromInt32(spec.Port),
+				},
+			},
+		},
+	}
+}
+
+// BuildServiceEntry creates an Istio ServiceEntry that registers the external
+// FQDN in the mesh service registry. Required when outboundTrafficPolicy is
+// REGISTRY_ONLY.
+func BuildServiceEntry(spec ExternalModelSpec, namespace string, labels map[string]string) *unstructured.Unstructured {
+	_, seName, _, _ := ResourceNames(spec.Provider + "-" + sanitize(spec.Endpoint))
+
+	protocol := "HTTPS"
+	portName := "https"
+	if !spec.TLS {
+		protocol = "HTTP"
+		portName = "http"
+	}
+
+	se := &unstructured.Unstructured{}
+	se.SetAPIVersion("networking.istio.io/v1")
+	se.SetKind("ServiceEntry")
+	se.SetName(seName)
+	se.SetNamespace(namespace)
+	se.SetLabels(labels)
+
+	se.Object["spec"] = map[string]interface{}{
+		"hosts":      []interface{}{spec.Endpoint},
+		"location":   "MESH_EXTERNAL",
+		"resolution": "DNS",
+		"ports": []interface{}{
+			map[string]interface{}{
+				"number":   int64(spec.Port),
+				"name":     portName,
+				"protocol": protocol,
+			},
+		},
+	}
+	return se
+}
+
+// BuildDestinationRule creates an Istio DestinationRule that configures TLS
+// origination for the external host. Skipped when TLS is false.
+func BuildDestinationRule(spec ExternalModelSpec, namespace string, labels map[string]string) *unstructured.Unstructured {
+	_, _, drName, _ := ResourceNames(spec.Provider + "-" + sanitize(spec.Endpoint))
+
+	dr := &unstructured.Unstructured{}
+	dr.SetAPIVersion("networking.istio.io/v1")
+	dr.SetKind("DestinationRule")
+	dr.SetName(drName)
+	dr.SetNamespace(namespace)
+	dr.SetLabels(labels)
+
+	dr.Object["spec"] = map[string]interface{}{
+		"host": spec.Endpoint,
+		"trafficPolicy": map[string]interface{}{
+			"tls": map[string]interface{}{
+				"mode": "SIMPLE",
+			},
+		},
+	}
+	return dr
+}
+
+// BuildHTTPRoute creates a Gateway API HTTPRoute that routes requests matching
+// the path prefix to the ExternalName Service backend and sets the Host header.
+func BuildHTTPRoute(spec ExternalModelSpec, namespace, gatewayName, gatewayNamespace string, labels map[string]string) *gatewayapiv1.HTTPRoute {
+	svcName, _, _, hrName := ResourceNames(spec.Provider + "-" + sanitize(spec.Endpoint))
+
+	pathPrefix := spec.PathPrefix
+	if pathPrefix == "" {
+		// Sanitize provider for use in URL path to prevent path traversal
+		safeProvider := sanitize(spec.Provider)
+		pathPrefix = "/external/" + safeProvider + "/"
+	}
+
+	gwNamespace := gatewayapiv1.Namespace(gatewayNamespace)
+	pathType := gatewayapiv1.PathMatchPathPrefix
+	port := gatewayapiv1.PortNumber(spec.Port)
+
+	// Build header modifiers
+	headers := []gatewayapiv1.HTTPHeader{
+		{
+			Name:  "Host",
+			Value: spec.Endpoint,
+		},
+	}
+	for k, v := range spec.ExtraHeaders {
+		headers = append(headers, gatewayapiv1.HTTPHeader{
+			Name:  gatewayapiv1.HTTPHeaderName(k),
+			Value: v,
+		})
+	}
+
+	// Build filters
+	filters := []gatewayapiv1.HTTPRouteFilter{
+		{
+			Type: gatewayapiv1.HTTPRouteFilterURLRewrite,
+			URLRewrite: &gatewayapiv1.HTTPURLRewriteFilter{
+				Path: &gatewayapiv1.HTTPPathModifier{
+					Type:               gatewayapiv1.PrefixMatchHTTPPathModifier,
+					ReplacePrefixMatch: strPtr("/"),
+				},
+			},
+		},
+		{
+			Type: gatewayapiv1.HTTPRouteFilterRequestHeaderModifier,
+			RequestHeaderModifier: &gatewayapiv1.HTTPHeaderFilter{
+				Set: headers,
+			},
+		},
+	}
+
+	timeout := gatewayapiv1.Duration("300s")
+
+	return &gatewayapiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      hrName,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: gatewayapiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayapiv1.CommonRouteSpec{
+				ParentRefs: []gatewayapiv1.ParentReference{
+					{
+						Name:      gatewayapiv1.ObjectName(gatewayName),
+						Namespace: &gwNamespace,
+					},
+				},
+			},
+			Rules: []gatewayapiv1.HTTPRouteRule{
+				{
+					Matches: []gatewayapiv1.HTTPRouteMatch{
+						{
+							Path: &gatewayapiv1.HTTPPathMatch{
+								Type:  &pathType,
+								Value: &pathPrefix,
+							},
+						},
+					},
+					BackendRefs: []gatewayapiv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayapiv1.BackendRef{
+								BackendObjectReference: gatewayapiv1.BackendObjectReference{
+									Name: gatewayapiv1.ObjectName(svcName),
+									Port: &port,
+								},
+							},
+						},
+					},
+					Filters:  filters,
+					Timeouts: &gatewayapiv1.HTTPRouteTimeouts{Request: &timeout},
+				},
+			},
+		},
+	}
+}
+
+func sanitize(s string) string {
+	// Convert to lowercase and replace non-alphanumeric characters with dashes
+	// for RFC 1123 DNS label compatibility.
+	var result []byte
+	for _, c := range []byte(strings.ToLower(s)) {
+		if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') {
+			result = append(result, c)
+		} else {
+			result = append(result, '-')
+		}
+	}
+	// Trim leading/trailing dashes
+	return strings.Trim(string(result), "-")
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+// FormatResourceSummary returns a human-readable summary of resources that would be created.
+func FormatResourceSummary(spec ExternalModelSpec, namespace string) string {
+	svcName, seName, drName, hrName := ResourceNames(spec.Provider + "-" + sanitize(spec.Endpoint))
+	summary := fmt.Sprintf("ExternalName Service: %s/%s\n", namespace, svcName)
+	summary += fmt.Sprintf("ServiceEntry:         %s/%s\n", namespace, seName)
+	if spec.TLS {
+		summary += fmt.Sprintf("DestinationRule:      %s/%s\n", namespace, drName)
+	}
+	summary += fmt.Sprintf("HTTPRoute:            %s/%s\n", namespace, hrName)
+	return summary
+}

--- a/pkg/reconciler/externalmodel/resources_test.go
+++ b/pkg/reconciler/externalmodel/resources_test.go
@@ -1,0 +1,153 @@
+package externalmodel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResourceNames(t *testing.T) {
+	svc, se, dr, hr := ResourceNames("openai-api-openai-com")
+	assert.Equal(t, "openai-api-openai-com-external", svc)
+	assert.Equal(t, "openai-api-openai-com-serviceentry", se)
+	assert.Equal(t, "openai-api-openai-com-destinationrule", dr)
+	assert.Equal(t, "openai-api-openai-com-httproute", hr)
+}
+
+func TestSanitize(t *testing.T) {
+	assert.Equal(t, "api-openai-com", sanitize("api.openai.com"))
+	assert.Equal(t, "vllm-internal", sanitize("vllm.internal"))
+	assert.Equal(t, "simple", sanitize("simple"))
+	assert.Equal(t, "api-openai-com", sanitize("API.OpenAI.com"))  // uppercase
+	assert.Equal(t, "host-8000", sanitize("host:8000"))            // colon
+	assert.Equal(t, "my-host", sanitize("my_host"))                // underscore
+}
+
+func TestBuildExternalNameService(t *testing.T) {
+	spec := ExternalModelSpec{
+		Provider: "openai",
+		Endpoint: "api.openai.com",
+		Port:     443,
+		TLS:      true,
+	}
+	labels := CommonLabels("test-model")
+
+	svc := BuildExternalNameService(spec, "openshift-ingress", labels)
+
+	assert.Equal(t, "openai-api-openai-com-external", svc.Name)
+	assert.Equal(t, "openshift-ingress", svc.Namespace)
+	assert.Equal(t, "api.openai.com", svc.Spec.ExternalName)
+	assert.Equal(t, int32(443), svc.Spec.Ports[0].Port)
+	assert.Contains(t, svc.Labels, "maas.opendatahub.io/external-model")
+	assert.Empty(t, svc.OwnerReferences, "no OwnerReferences for cross-namespace resources")
+}
+
+func TestBuildServiceEntry(t *testing.T) {
+	spec := ExternalModelSpec{
+		Provider: "openai",
+		Endpoint: "api.openai.com",
+		Port:     443,
+		TLS:      true,
+	}
+	labels := CommonLabels("test-model")
+
+	se := BuildServiceEntry(spec, "openshift-ingress", labels)
+
+	assert.Equal(t, "ServiceEntry", se.GetKind())
+	assert.Equal(t, "networking.istio.io/v1", se.GetAPIVersion())
+	assert.Equal(t, "openai-api-openai-com-serviceentry", se.GetName())
+	assert.Empty(t, se.GetOwnerReferences(), "no OwnerReferences for cross-namespace resources")
+
+	hosts := se.Object["spec"].(map[string]interface{})["hosts"].([]interface{})
+	assert.Equal(t, "api.openai.com", hosts[0])
+
+	ports := se.Object["spec"].(map[string]interface{})["ports"].([]interface{})
+	port := ports[0].(map[string]interface{})
+	assert.Equal(t, "https", port["name"])
+	assert.Equal(t, "HTTPS", port["protocol"])
+}
+
+func TestBuildDestinationRule(t *testing.T) {
+	spec := ExternalModelSpec{
+		Provider: "openai",
+		Endpoint: "api.openai.com",
+		Port:     443,
+		TLS:      true,
+	}
+	labels := CommonLabels("test-model")
+
+	dr := BuildDestinationRule(spec, "openshift-ingress", labels)
+
+	assert.Equal(t, "DestinationRule", dr.GetKind())
+	assert.Equal(t, "networking.istio.io/v1", dr.GetAPIVersion())
+	assert.Empty(t, dr.GetOwnerReferences())
+
+	drSpec := dr.Object["spec"].(map[string]interface{})
+	assert.Equal(t, "api.openai.com", drSpec["host"])
+}
+
+func TestBuildHTTPRoute(t *testing.T) {
+	spec := ExternalModelSpec{
+		Provider:     "openai",
+		Endpoint:     "api.openai.com",
+		Port:         443,
+		TLS:          true,
+		ExtraHeaders: map[string]string{},
+	}
+	labels := CommonLabels("test-model")
+
+	hr := BuildHTTPRoute(spec, "openshift-ingress", "maas-default-gateway", "openshift-ingress", labels)
+
+	assert.Equal(t, "openai-api-openai-com-httproute", hr.Name)
+	assert.Equal(t, "openshift-ingress", hr.Namespace)
+	assert.Empty(t, hr.OwnerReferences, "no OwnerReferences for cross-namespace resources")
+	assert.Len(t, hr.Spec.ParentRefs, 1)
+	assert.Equal(t, "maas-default-gateway", string(hr.Spec.ParentRefs[0].Name))
+	assert.Len(t, hr.Spec.Rules, 1)
+	assert.Equal(t, "/external/openai/", *hr.Spec.Rules[0].Matches[0].Path.Value)
+}
+
+func TestBuildHTTPRouteAnthropic(t *testing.T) {
+	spec := ExternalModelSpec{
+		Provider: "anthropic",
+		Endpoint: "api.anthropic.com",
+		Port:     443,
+		TLS:      true,
+		ExtraHeaders: map[string]string{
+			"anthropic-version": "2023-06-01",
+		},
+	}
+	labels := CommonLabels("test-model")
+
+	hr := BuildHTTPRoute(spec, "openshift-ingress", "maas-default-gateway", "openshift-ingress", labels)
+
+	for _, filter := range hr.Spec.Rules[0].Filters {
+		if filter.RequestHeaderModifier != nil {
+			found := false
+			for _, h := range filter.RequestHeaderModifier.Set {
+				if string(h.Name) == "anthropic-version" {
+					found = true
+					assert.Equal(t, "2023-06-01", h.Value)
+				}
+			}
+			assert.True(t, found, "anthropic-version header should be present")
+		}
+	}
+}
+
+func TestBuildNoTLS(t *testing.T) {
+	spec := ExternalModelSpec{
+		Provider: "vllm",
+		Endpoint: "vllm.internal",
+		Port:     8000,
+		TLS:      false,
+	}
+	labels := CommonLabels("test-model")
+
+	se := BuildServiceEntry(spec, "default", labels)
+	seSpec := se.Object["spec"].(map[string]interface{})
+	ports := seSpec["ports"].([]interface{})
+	port := ports[0].(map[string]interface{})
+	assert.Equal(t, "HTTP", port["protocol"])
+	assert.Equal(t, "http", port["name"])
+}

--- a/pkg/reconciler/externalmodel/types.go
+++ b/pkg/reconciler/externalmodel/types.go
@@ -1,0 +1,77 @@
+// Package externalmodel implements a reconciler that watches MaaSModelRef CRs
+// with kind=ExternalModel and creates the Istio resources required to route
+// traffic to an external AI model provider:
+//
+//  1. ExternalName Service   - DNS bridge for HTTPRoute backendRef
+//  2. ServiceEntry           - Registers external host in Istio mesh
+//  3. DestinationRule        - TLS origination (HTTP -> HTTPS)
+//  4. HTTPRoute              - Routes requests and sets Host header
+//
+// Resources are created in the gateway namespace (cross-namespace from the CR).
+// A finalizer on the MaaSModelRef handles cleanup since cross-namespace
+// OwnerReferences are not supported by Kubernetes garbage collection.
+package externalmodel
+
+import "strings"
+
+// ExternalModelSpec holds the configuration for routing to an external model.
+// These fields are read from MaaSModelRef annotations until the CRD is enriched.
+//
+// Required annotations:
+//
+//	maas.opendatahub.io/endpoint: "api.openai.com"
+//
+// Optional annotations:
+//
+//	maas.opendatahub.io/provider: "openai"
+//	maas.opendatahub.io/extra-headers: "anthropic-version=2023-06-01"
+//	maas.opendatahub.io/port: "443"
+//	maas.opendatahub.io/tls: "true"
+//	maas.opendatahub.io/path-prefix: "/external/openai/"
+type ExternalModelSpec struct {
+	// Provider identifies the API format (e.g. "openai", "anthropic", "vllm")
+	Provider string
+	// Endpoint is the external FQDN (e.g. "api.openai.com")
+	Endpoint string
+	// ExtraHeaders are additional headers to set (e.g. "anthropic-version=2023-06-01")
+	ExtraHeaders map[string]string
+	// Port is the external service port (default 443)
+	Port int32
+	// TLS indicates whether TLS origination is needed (default true)
+	TLS bool
+	// PathPrefix is the path prefix to match (default "/external/<provider>/")
+	PathPrefix string
+}
+
+// ResourceNames returns consistent names for the resources created per external model.
+// Names are truncated to 63 characters (Kubernetes limit for DNS labels).
+func ResourceNames(modelName string) (svcName, seName, drName, hrName string) {
+	svcName = truncateName(modelName, "-external")
+	seName = truncateName(modelName, "-serviceentry")
+	drName = truncateName(modelName, "-destinationrule")
+	hrName = truncateName(modelName, "-httproute")
+	return
+}
+
+// truncateName ensures base + suffix fits within 63 characters.
+func truncateName(base, suffix string) string {
+	const maxLen = 63
+	max := maxLen - len(suffix)
+	if max < 1 {
+		max = 1
+	}
+	if len(base) > max {
+		base = base[:max]
+		// Trim trailing dashes from truncation
+		base = strings.TrimRight(base, "-")
+	}
+	return base + suffix
+}
+
+// CommonLabels returns labels applied to all managed resources.
+func CommonLabels(modelName string) map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/managed-by":       "maas-external-model-reconciler",
+		"maas.opendatahub.io/external-model": modelName,
+	}
+}


### PR DESCRIPTION
Implements the MaaS model reconciler that creates Istio resources (Service, ServiceEntry, DestinationRule, HTTPRoute) when a MaaSModelRef with kind=ExternalModel is created, updated, or deleted. Added some extra details and overview mostly for myself as it's been a while since I've done a reconciler and was rusty.

  ## Details

  Implements issue #5: when a platform admin creates a `MaaSModelRef` with `kind: ExternalModel`, the reconciler automatically creates the 4 Kubernetes/Istio resources needed to expose an external AI model through the MaaS gateway:

  | # | Resource | What It Does |
  |---|----------|-------------|
  | 1 | Service (ExternalName) | DNS bridge so HTTPRoute can reference the external host as a standard k8s Service |
  | 2 | ServiceEntry | Registers the external FQDN in the Istio mesh service registry |
  | 3 | DestinationRule | Originates TLS on the outbound connection (HTTP inside mesh → HTTPS to provider) |
  | 4 | HTTPRoute | Routes requests through the MaaS gateway to the external provider, sets Host header |

  Resources are created in the gateway namespace (`openshift-ingress`), which is cross-namespace from the MaaSModelRef. Since Kubernetes garbage collection does not follow cross-namespace OwnerReferences, the reconciler uses a **finalizer** to explicitly delete all managed resources when the CR is removed.

Current POC exposes an external model through MaaS requires manually creating 4 YAML files per provider. This reconciler reduces that to creating a single CR:

  ```yaml
  apiVersion: maas.opendatahub.io/v1alpha1
  kind: MaaSModelRef
  metadata:
    name: gpt-4o-mini
    annotations:
      maas.opendatahub.io/provider: "openai"
      maas.opendatahub.io/endpoint: "api.openai.com"
  spec:
    modelRef:
      kind: ExternalModel
      name: gpt-4o-mini

  The reconciler handles the rest. This is the foundation for MaaS to serve
  both local and external models through the same gateway, same auth, same
  rate limiting.
```

  **Reconciler behavior**

  | Event | What happens |
  |-------|-------------|
  | CR created | Parses spec from annotations, creates 4 Istio resources, sets status to Ready |
  | CR updated | Updates the 4 resources to match the new spec |
  | CR deleted | Finalizer explicitly deletes all 4 cross-namespace resources, then removes itself |
  | Invalid spec | Sets status to Failed with error message (e.g. missing endpoint annotation) |


  **Status endpoint**

  The reconciler reads the MaaS Gateway resource to resolve the listener hostname  and sets status.endpoint to the MaaS gateway URL (e.g. https://maas.apps.cluster.example.com/external/openai/), not the provider URL. This ensures MaaS API model discovery and clients see the correct MaaS-served endpoint. The HTTPRoute name and gateway references are also populated in status.

  **Annotation-based spec (bridge pattern)**

  Until the MaaSModelRef CRD is enriched with dedicated external model fields
  (tracked as a separate sub-task), the reconciler reads configuration from
  annotations:

| Annotation | Required | Default | Example |
|------------|----------|---------|---------|
| `maas.opendatahub.io/endpoint` | Yes | — | `api.openai.com` |
| `maas.opendatahub.io/provider` | No | `spec.modelRef.name` | `openai` |
| `maas.opendatahub.io/port` | No | `443` | `8000` |
| `maas.opendatahub.io/tls` | No | `true` | `false` |
| `maas.opendatahub.io/path-prefix` | No | `/external/<provider>/` | `/v1/` |
| `maas.opendatahub.io/extra-headers` | No | — | `anthropic-version=2023-06-01` |

  When the CRD is updated, the reconciler switches to reading from spec fields
  with no other changes needed.

  **Provider examples**

  OpenAI — just endpoint and provider:

```yaml
  annotations:
    maas.opendatahub.io/provider: "openai"
    maas.opendatahub.io/endpoint: "api.openai.com"
```

  Anthropic — different auth header, extra required header:

```yaml
  annotations:
    maas.opendatahub.io/provider: "anthropic"
    maas.opendatahub.io/endpoint: "api.anthropic.com"
    maas.opendatahub.io/extra-headers: "anthropic-version=2023-06-01"
```

  Self-hosted vLLM — no TLS, different port:

```yaml
  annotations:
    maas.opendatahub.io/provider: "vllm"
    maas.opendatahub.io/endpoint: "vllm.example.com"
    maas.opendatahub.io/port: "8000"
    maas.opendatahub.io/tls: "false"
```

  **Testing**

  - 8 unit tests for resource builders (naming, labels, Service, ServiceEntry, DestinationRule, HTTPRoute, Anthropic headers, no-TLS) — all passing
  - The reconciler is not yet wired into a running binary (`cmd/main.go` does not register it). It needs either a dedicated `cmd/reconciler/main.go` or to be ported into the MaaS controller to run against a cluster.
  - The Istio resource patterns this reconciler generates were validated E2E in the [maas-istio-only-external](https://github.com/nerdalert/egress-ai-gateway-poc/tree/main/demos/maas-istio-only-external) PoC (manually created resources, same structure). The reconciler automates that same creation.

  **Files**

  pkg/reconciler/externalmodel/
  ├── types.go             # ExternalModelSpec, naming, labels
  ├── resources.go         # Stateless builders for the 4 resources
  ├── reconciler.go        # Controller-runtime reconciler (watch, create, update, finalize)
  ├── resources_test.go    # Unit tests
  └── README.md            # Docs, annotation reference, provider examples

  **Related**

Issue tracked in #5 

  - Sub-task 1: Enrich MaaSModelRef CRD with provider, endpoint, credentialRef fields — @noyitz (pending)
  - Sub-task 2: Implement reconciler for ExternalModel → Istio resources — this PR
  - designed to be portable into the MaaS (if I remember correctly ) controller (providers_external.go) when ready


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for external models (OpenAI, Anthropic, self-hosted vLLM) via an External Model Reconciler
  * Automatic provisioning of routing and networking in the ingress/gateway namespace: ExternalName service, mesh service registration, optional TLS origination, and HTTP routing for /external/<provider>/* with host header rewriting and custom headers
  * Deterministic, sanitized resource naming for cross-namespace scenarios

* **Documentation**
  * Added comprehensive README describing configuration (annotations, defaults, examples) and operational behavior

* **Tests**
  * Unit tests validating resource builders and input sanitization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->