### PR TITLE
feat: implement Vertex AI (Gemini) api-translation provider

### DIFF
--- a/pkg/external-model/provider/provider.go
+++ b/pkg/external-model/provider/provider.go
@@ -4,4 +4,5 @@ const (
 	OpenAI      = "openai"
 	Anthropic   = "anthropic"
 	AzureOpenAI = "azure-openai"
+	Vertex      = "vertex"
 )

--- a/pkg/plugins/api-translation/plugin.go
+++ b/pkg/plugins/api-translation/plugin.go
@@ -29,6 +29,7 @@ import (
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/providers"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/providers/anthropic"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/providers/azureopenai"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/providers/vertex"
 )
 
 const (
@@ -54,6 +55,7 @@ func NewAPITranslationPlugin() *APITranslationPlugin {
 		providers: map[string]providers.Provider{
 			provider.Anthropic:   anthropic.NewAnthropicProvider(),
 			provider.AzureOpenAI: azureopenai.NewAzureOpenAIProvider(),
+			provider.Vertex:      vertex.NewVertexProvider(),
 		},
 	}
 }

--- a/pkg/plugins/api-translation/plugin_test.go
+++ b/pkg/plugins/api-translation/plugin_test.go
@@ -293,6 +293,162 @@ func TestProcessResponse_AnthropicToolUse(t *testing.T) {
 	assert.Equal(t, 0, tc["index"])
 }
 
+func TestProcessRequest_VertexProvider(t *testing.T) {
+	p := NewAPITranslationPlugin()
+
+	cs := newCycleStateWithProvider("vertex")
+	req := framework.NewInferenceRequest()
+	req.Headers["authorization"] = "Bearer sk-test"
+	req.Headers["content-length"] = "200"
+	req.Body["model"] = "gemini-2.5-flash"
+	req.Body["messages"] = []any{
+		map[string]any{"role": "system", "content": "Be concise"},
+		map[string]any{"role": "user", "content": "What is Kubernetes?"},
+	}
+	req.Body["max_tokens"] = float64(100)
+	req.Body["temperature"] = 0.7
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err)
+
+	assert.True(t, req.BodyMutated())
+
+	contents, ok := req.Body["contents"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, contents, 1)
+	assert.Equal(t, "user", contents[0]["role"])
+
+	sysInstruction, ok := req.Body["systemInstruction"].(map[string]any)
+	require.True(t, ok)
+	sysParts := sysInstruction["parts"].([]map[string]any)
+	assert.Equal(t, "Be concise", sysParts[0]["text"])
+
+	genConfig, ok := req.Body["generationConfig"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, 100, genConfig["maxOutputTokens"])
+	assert.Equal(t, 0.7, genConfig["temperature"])
+
+	mutated := req.MutatedHeaders()
+	assert.Equal(t, "/v1beta/models/gemini-2.5-flash:generateContent", mutated[":path"])
+	assert.Equal(t, "application/json", mutated["content-type"])
+
+	removed := req.RemovedHeaders()
+	assert.Contains(t, removed, "authorization")
+	assert.NotContains(t, removed, "content-length")
+}
+
+func TestProcessResponse_Vertex(t *testing.T) {
+	p := NewAPITranslationPlugin()
+
+	cs := newCycleStateWithProvider("vertex")
+	cs.Write(state.ModelKey, "gemini-2.5-flash")
+
+	resp := framework.NewInferenceResponse()
+	resp.Body["candidates"] = []any{
+		map[string]any{
+			"content": map[string]any{
+				"parts": []any{map[string]any{"text": "Kubernetes is a container orchestration platform."}},
+				"role":  "model",
+			},
+			"finishReason": "STOP",
+		},
+	}
+	resp.Body["usageMetadata"] = map[string]any{
+		"promptTokenCount":     float64(12),
+		"candidatesTokenCount": float64(8),
+		"totalTokenCount":      float64(20),
+	}
+	resp.Body["responseId"] = "resp-abc123"
+
+	err := p.ProcessResponse(context.Background(), cs, resp)
+	require.NoError(t, err)
+
+	assert.True(t, resp.BodyMutated())
+	assert.Equal(t, "chat.completion", resp.Body["object"])
+	assert.Equal(t, "gemini-2.5-flash", resp.Body["model"])
+	assert.Equal(t, "resp-abc123", resp.Body["id"])
+
+	choices := resp.Body["choices"].([]any)
+	choice := choices[0].(map[string]any)
+	msg := choice["message"].(map[string]any)
+	assert.Equal(t, "assistant", msg["role"])
+	assert.Equal(t, "Kubernetes is a container orchestration platform.", msg["content"])
+	assert.Equal(t, "stop", choice["finish_reason"])
+
+	usage := resp.Body["usage"].(map[string]any)
+	assert.Equal(t, 12, usage["prompt_tokens"])
+	assert.Equal(t, 8, usage["completion_tokens"])
+	assert.Equal(t, 20, usage["total_tokens"])
+}
+
+func TestProcessResponse_VertexError(t *testing.T) {
+	p := NewAPITranslationPlugin()
+
+	cs := newCycleStateWithProvider("vertex")
+
+	resp := framework.NewInferenceResponse()
+	resp.Body["error"] = map[string]any{
+		"code":    float64(400),
+		"message": "Invalid value at 'contents'",
+		"status":  "INVALID_ARGUMENT",
+	}
+
+	err := p.ProcessResponse(context.Background(), cs, resp)
+	require.NoError(t, err)
+
+	assert.True(t, resp.BodyMutated())
+	errObj := resp.Body["error"].(map[string]any)
+	assert.Equal(t, "INVALID_ARGUMENT", errObj["type"])
+	assert.Equal(t, "Invalid value at 'contents'", errObj["message"])
+}
+
+func TestProcessResponse_VertexToolCall(t *testing.T) {
+	p := NewAPITranslationPlugin()
+
+	cs := newCycleStateWithProvider("vertex")
+	cs.Write(state.ModelKey, "gemini-2.5-flash")
+
+	resp := framework.NewInferenceResponse()
+	resp.Body["candidates"] = []any{
+		map[string]any{
+			"content": map[string]any{
+				"parts": []any{
+					map[string]any{
+						"functionCall": map[string]any{
+							"name": "get_weather",
+							"args": map[string]any{"location": "Paris"},
+						},
+					},
+				},
+				"role": "model",
+			},
+			"finishReason": "STOP",
+		},
+	}
+	resp.Body["usageMetadata"] = map[string]any{
+		"promptTokenCount":     float64(20),
+		"candidatesTokenCount": float64(10),
+		"totalTokenCount":      float64(30),
+	}
+
+	err := p.ProcessResponse(context.Background(), cs, resp)
+	require.NoError(t, err)
+
+	assert.True(t, resp.BodyMutated())
+
+	choices := resp.Body["choices"].([]any)
+	choice := choices[0].(map[string]any)
+	msg := choice["message"].(map[string]any)
+	toolCalls := msg["tool_calls"].([]any)
+	require.Len(t, toolCalls, 1)
+
+	tc := toolCalls[0].(map[string]any)
+	assert.Equal(t, "call_0", tc["id"])
+	assert.Equal(t, 0, tc["index"])
+	fn := tc["function"].(map[string]any)
+	assert.Equal(t, "get_weather", fn["name"])
+}
+
 func TestProcessResponse_NoProviderPassthrough(t *testing.T) {
 	p := NewAPITranslationPlugin()
 

--- a/pkg/plugins/api-translation/providers/vertex/vertex.go
+++ b/pkg/plugins/api-translation/providers/vertex/vertex.go
@@ -1,0 +1,476 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vertex
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const (
+	vertexV1BetaPathTemplate = "/v1beta/models/%s:generateContent"
+)
+
+// modelNamePattern validates Gemini model names to prevent path injection.
+var modelNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+
+// VertexProvider translates between OpenAI Chat Completions format and
+// Google Vertex AI (Gemini) GenerateContent API format.
+type VertexProvider struct{}
+
+func NewVertexProvider() *VertexProvider {
+	return &VertexProvider{}
+}
+
+// TranslateRequest translates an OpenAI Chat Completions request body to
+// Vertex AI GenerateContent API format.
+func (p *VertexProvider) TranslateRequest(body map[string]any) (map[string]any, map[string]string, []string, error) {
+	model, _ := body["model"].(string)
+	if model == "" {
+		return nil, nil, nil, fmt.Errorf("model field is required")
+	}
+
+	if !modelNamePattern.MatchString(model) {
+		return nil, nil, nil, fmt.Errorf("model '%s' contains invalid characters for Vertex AI model name", model)
+	}
+
+	messages, err := extractMessages(body)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to extract messages: %w", err)
+	}
+
+	systemParts, contents, err := separateSystemMessages(messages)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	if len(contents) == 0 {
+		return nil, nil, nil, fmt.Errorf("at least one non-system message is required")
+	}
+
+	translated := map[string]any{
+		"contents": contents,
+	}
+
+	if len(systemParts) > 0 {
+		translated["systemInstruction"] = map[string]any{
+			"parts": systemParts,
+		}
+	}
+
+	generationConfig := buildGenerationConfig(body)
+	if len(generationConfig) > 0 {
+		translated["generationConfig"] = generationConfig
+	}
+
+	// Use v1beta for systemInstruction support on the Generative Language API.
+	// The Vertex AI API (aiplatform.googleapis.com) supports systemInstruction in v1,
+	// but the Generative Language API (generativelanguage.googleapis.com) requires v1beta.
+	// Using v1beta is compatible with both endpoints.
+	path := fmt.Sprintf(vertexV1BetaPathTemplate, model)
+
+	headers := map[string]string{
+		"content-type": "application/json",
+		":path":        path,
+	}
+
+	return translated, headers, nil, nil
+}
+
+// TranslateResponse translates a Vertex AI GenerateContent response to
+// OpenAI Chat Completions format. Handles both success and error responses.
+func (p *VertexProvider) TranslateResponse(body map[string]any, model string) (map[string]any, error) {
+	if errObj, ok := body["error"].(map[string]any); ok {
+		return translateVertexError(errObj), nil
+	}
+
+	choices := translateCandidates(body)
+
+	usage := mapVertexUsage(body)
+
+	if model == "" {
+		if mv, ok := body["modelVersion"].(string); ok && mv != "" {
+			model = mv
+		}
+	}
+
+	responseID, _ := body["responseId"].(string)
+
+	translated := map[string]any{
+		"id":      responseID,
+		"object":  "chat.completion",
+		"created": time.Now().Unix(),
+		"model":   model,
+		"choices": choices,
+		"usage":   usage,
+	}
+
+	return translated, nil
+}
+
+// separateSystemMessages separates system/developer messages into systemInstruction
+// parts and converts the remaining messages into Vertex contents format.
+func separateSystemMessages(messages []map[string]any) ([]map[string]any, []map[string]any, error) {
+	var systemParts []map[string]any
+	var contents []map[string]any
+
+	for i, msg := range messages {
+		role, _ := msg["role"].(string)
+		content := extractContentString(msg)
+
+		switch role {
+		case "system", "developer":
+			systemParts = append(systemParts, map[string]any{"text": content})
+		case "user":
+			contents = append(contents, map[string]any{
+				"role":  "user",
+				"parts": []map[string]any{{"text": content}},
+			})
+		case "assistant":
+			contents = append(contents, map[string]any{
+				"role":  "model",
+				"parts": []map[string]any{{"text": content}},
+			})
+		case "tool", "function":
+			return nil, nil, fmt.Errorf("message at index %d has role %q which is not supported for Vertex translation", i, role)
+		default:
+			return nil, nil, fmt.Errorf("message at index %d has unknown role %q", i, role)
+		}
+	}
+
+	return systemParts, contents, nil
+}
+
+// buildGenerationConfig constructs the Vertex generationConfig from OpenAI parameters.
+func buildGenerationConfig(body map[string]any) map[string]any {
+	config := map[string]any{}
+
+	maxTokens := resolveMaxTokens(body)
+	if maxTokens > 0 {
+		config["maxOutputTokens"] = maxTokens
+	}
+
+	if temp, ok := getFloat(body, "temperature"); ok {
+		config["temperature"] = temp
+	}
+	if topP, ok := getFloat(body, "top_p"); ok {
+		config["topP"] = topP
+	}
+	if stop := extractStopSequences(body); len(stop) > 0 {
+		config["stopSequences"] = stop
+	}
+
+	return config
+}
+
+// translateCandidates converts Vertex candidates to OpenAI choices.
+func translateCandidates(body map[string]any) []any {
+	candidatesRaw, ok := body["candidates"].([]any)
+	if !ok || len(candidatesRaw) == 0 {
+		return []any{}
+	}
+
+	var choices []any
+	for i, raw := range candidatesRaw {
+		candidate, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		text, toolCalls := extractCandidateContent(candidate)
+		finishReason := mapFinishReason(candidate)
+
+		message := map[string]any{
+			"role":    "assistant",
+			"content": text,
+		}
+
+		if len(toolCalls) > 0 {
+			message["tool_calls"] = toolCalls
+		}
+
+		choice := map[string]any{
+			"index":         i,
+			"message":       message,
+			"finish_reason": finishReason,
+		}
+
+		choices = append(choices, choice)
+	}
+
+	return choices
+}
+
+// extractCandidateContent extracts text content and tool calls from a Vertex candidate.
+func extractCandidateContent(candidate map[string]any) (string, []any) {
+	content, ok := candidate["content"].(map[string]any)
+	if !ok {
+		return "", nil
+	}
+
+	partsRaw, ok := content["parts"].([]any)
+	if !ok {
+		return "", nil
+	}
+
+	var texts []string
+	var toolCalls []any
+	toolIndex := 0
+
+	for _, raw := range partsRaw {
+		part, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if text, ok := part["text"].(string); ok {
+			texts = append(texts, text)
+		}
+
+		if fc, ok := part["functionCall"].(map[string]any); ok {
+			name, _ := fc["name"].(string)
+			args := fc["args"]
+
+			argsStr, err := toJSONString(args)
+			if err != nil {
+				continue
+			}
+
+			toolCall := map[string]any{
+				"id":    fmt.Sprintf("call_%d", toolIndex),
+				"index": toolIndex,
+				"type":  "function",
+				"function": map[string]any{
+					"name":      name,
+					"arguments": argsStr,
+				},
+			}
+			toolCalls = append(toolCalls, toolCall)
+			toolIndex++
+		}
+	}
+
+	return strings.Join(texts, ""), toolCalls
+}
+
+// mapFinishReason maps Vertex finishReason to OpenAI finish_reason.
+func mapFinishReason(candidate map[string]any) string {
+	reason, _ := candidate["finishReason"].(string)
+	switch reason {
+	case "STOP":
+		return "stop"
+	case "MAX_TOKENS":
+		return "length"
+	case "SAFETY", "RECITATION", "BLOCKLIST", "PROHIBITED_CONTENT", "SPII",
+		"MODEL_ARMOR", "IMAGE_SAFETY", "IMAGE_PROHIBITED_CONTENT", "IMAGE_RECITATION":
+		return "content_filter"
+	case "MALFORMED_FUNCTION_CALL", "UNEXPECTED_TOOL_CALL":
+		return "tool_calls"
+	default:
+		return "stop"
+	}
+}
+
+// mapVertexUsage maps Vertex usageMetadata to OpenAI usage format.
+func mapVertexUsage(body map[string]any) map[string]any {
+	usage, ok := body["usageMetadata"].(map[string]any)
+	if !ok {
+		return map[string]any{
+			"prompt_tokens":     0,
+			"completion_tokens": 0,
+			"total_tokens":      0,
+		}
+	}
+
+	promptTokens := toInt(usage["promptTokenCount"])
+	completionTokens := toInt(usage["candidatesTokenCount"])
+	totalTokens := toInt(usage["totalTokenCount"])
+
+	return map[string]any{
+		"prompt_tokens":     promptTokens,
+		"completion_tokens": completionTokens,
+		"total_tokens":      totalTokens,
+	}
+}
+
+// translateVertexError converts a Vertex error object to OpenAI error format.
+func translateVertexError(errObj map[string]any) map[string]any {
+	message, _ := errObj["message"].(string)
+	status, _ := errObj["status"].(string)
+	code := errObj["code"]
+
+	codeStr := ""
+	if code != nil {
+		codeStr = fmt.Sprintf("%v", code)
+	}
+
+	return map[string]any{
+		"error": map[string]any{
+			"message": message,
+			"type":    status,
+			"param":   nil,
+			"code":    codeStr,
+		},
+	}
+}
+
+// --- Helper functions ---
+
+func extractMessages(body map[string]any) ([]map[string]any, error) {
+	rawMessages, ok := body["messages"]
+	if !ok {
+		return nil, fmt.Errorf("messages field is required")
+	}
+
+	messagesSlice, ok := rawMessages.([]any)
+	if !ok {
+		return nil, fmt.Errorf("messages must be an array")
+	}
+
+	var messages []map[string]any
+	for i, raw := range messagesSlice {
+		msg, ok := raw.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("message at index %d is not an object", i)
+		}
+		messages = append(messages, msg)
+	}
+
+	return messages, nil
+}
+
+func extractContentString(msg map[string]any) string {
+	content, ok := msg["content"]
+	if !ok {
+		return ""
+	}
+
+	if s, ok := content.(string); ok {
+		return s
+	}
+
+	if parts, ok := content.([]any); ok {
+		var texts []string
+		for _, part := range parts {
+			if partMap, ok := part.(map[string]any); ok {
+				if text, ok := partMap["text"].(string); ok {
+					texts = append(texts, text)
+				}
+			}
+		}
+		return strings.Join(texts, " ")
+	}
+
+	return ""
+}
+
+func resolveMaxTokens(body map[string]any) int {
+	if v, ok := getInt(body, "max_completion_tokens"); ok && v > 0 {
+		return v
+	}
+	if v, ok := getInt(body, "max_tokens"); ok && v > 0 {
+		return v
+	}
+	return 0
+}
+
+func extractStopSequences(body map[string]any) []string {
+	stop, ok := body["stop"]
+	if !ok {
+		return nil
+	}
+
+	if s, ok := stop.(string); ok && s != "" {
+		return []string{s}
+	}
+
+	if arr, ok := stop.([]any); ok {
+		var sequences []string
+		for _, v := range arr {
+			if s, ok := v.(string); ok {
+				sequences = append(sequences, s)
+			}
+		}
+		return sequences
+	}
+
+	return nil
+}
+
+func getFloat(body map[string]any, key string) (float64, bool) {
+	v, ok := body[key]
+	if !ok {
+		return 0, false
+	}
+	switch f := v.(type) {
+	case float64:
+		return f, true
+	case int:
+		return float64(f), true
+	case int64:
+		return float64(f), true
+	default:
+		return 0, false
+	}
+}
+
+func getInt(body map[string]any, key string) (int, bool) {
+	v, ok := body[key]
+	if !ok {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case float64:
+		return int(n), true
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	default:
+		return 0, false
+	}
+}
+
+func toInt(v any) int {
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	case int64:
+		return int(n)
+	default:
+		return 0
+	}
+}
+
+func toJSONString(v any) (string, error) {
+	if v == nil {
+		return "{}", nil
+	}
+	if s, ok := v.(string); ok {
+		return s, nil
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal to JSON: %w", err)
+	}
+	return string(b), nil
+}

--- a/pkg/plugins/api-translation/providers/vertex/vertex_test.go
+++ b/pkg/plugins/api-translation/providers/vertex/vertex_test.go
@@ -1,0 +1,1122 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vertex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVertexV1BetaPathTemplate(t *testing.T) {
+	assert.Equal(t, "/v1beta/models/%s:generateContent", vertexV1BetaPathTemplate)
+}
+
+func TestTranslateRequest_BasicChat(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-2.5-flash",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "What is 2+2?"},
+		},
+	}
+
+	translated, headers, headersToRemove, err := NewVertexProvider().TranslateRequest(body)
+	require.NoError(t, err)
+
+	contents := translated["contents"].([]map[string]any)
+	require.Len(t, contents, 1)
+	assert.Equal(t, "user", contents[0]["role"])
+
+	parts := contents[0]["parts"].([]map[string]any)
+	assert.Equal(t, "What is 2+2?", parts[0]["text"])
+
+	assert.Nil(t, translated["systemInstruction"])
+	assert.Nil(t, translated["model"])
+
+	assert.Equal(t, "application/json", headers["content-type"])
+	assert.Equal(t, "/v1beta/models/gemini-2.5-flash:generateContent", headers[":path"])
+
+	assert.Nil(t, headersToRemove)
+}
+
+func TestTranslateRequest_SystemMessage(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-2.5-flash",
+		"messages": []any{
+			map[string]any{"role": "system", "content": "You are a helpful assistant."},
+			map[string]any{"role": "user", "content": "Hello"},
+		},
+	}
+
+	translated, _, _, err := NewVertexProvider().TranslateRequest(body)
+	require.NoError(t, err)
+
+	sysInstruction := translated["systemInstruction"].(map[string]any)
+	sysParts := sysInstruction["parts"].([]map[string]any)
+	require.Len(t, sysParts, 1)
+	assert.Equal(t, "You are a helpful assistant.", sysParts[0]["text"])
+
+	contents := translated["contents"].([]map[string]any)
+	require.Len(t, contents, 1)
+	assert.Equal(t, "user", contents[0]["role"])
+}
+
+func TestTranslateRequest_MultipleMessages(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-2.5-flash",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Hi"},
+			map[string]any{"role": "assistant", "content": "Hello!"},
+			map[string]any{"role": "user", "content": "How are you?"},
+		},
+	}
+
+	translated, _, _, err := NewVertexProvider().TranslateRequest(body)
+	require.NoError(t, err)
+
+	contents := translated["contents"].([]map[string]any)
+	require.Len(t, contents, 3)
+	assert.Equal(t, "user", contents[0]["role"])
+	assert.Equal(t, "model", contents[1]["role"])
+	assert.Equal(t, "user", contents[2]["role"])
+
+	parts1 := contents[1]["parts"].([]map[string]any)
+	assert.Equal(t, "Hello!", parts1[0]["text"])
+}
+
+func TestTranslateRequest_DeveloperRole(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-2.5-flash",
+		"messages": []any{
+			map[string]any{"role": "developer", "content": "You are a coding assistant."},
+			map[string]any{"role": "user", "content": "Hello"},
+		},
+	}
+
+	translated, _, _, err := NewVertexProvider().TranslateRequest(body)
+	require.NoError(t, err)
+
+	sysInstruction := translated["systemInstruction"].(map[string]any)
+	sysParts := sysInstruction["parts"].([]map[string]any)
+	require.Len(t, sysParts, 1)
+	assert.Equal(t, "You are a coding assistant.", sysParts[0]["text"])
+}
+
+func TestTranslateRequest_SystemAndDeveloperConcatenated(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-2.5-flash",
+		"messages": []any{
+			map[string]any{"role": "system", "content": "Be concise."},
+			map[string]any{"role": "developer", "content": "Use markdown."},
+			map[string]any{"role": "user", "content": "Hello"},
+		},
+	}
+
+	translated, _, _, err := NewVertexProvider().TranslateRequest(body)
+	require.NoError(t, err)
+
+	sysInstruction := translated["systemInstruction"].(map[string]any)
+	sysParts := sysInstruction["parts"].([]map[string]any)
+	require.Len(t, sysParts, 2)
+	assert.Equal(t, "Be concise.", sysParts[0]["text"])
+	assert.Equal(t, "Use markdown.", sysParts[1]["text"])
+}
+
+func TestTranslateRequest_OptionalParams(t *testing.T) {
+	body := map[string]any{
+		"model":       "gemini-2.5-flash",
+		"messages":    []any{map[string]any{"role": "user", "content": "Hi"}},
+		"temperature": 0.7,
+		"top_p":       0.9,
+		"stop":        []any{"END", "STOP"},
+		"max_tokens":  float64(500),
+	}
+
+	translated, _, _, err := NewVertexProvider().TranslateRequest(body)
+	require.NoError(t, err)
+
+	config := translated["generationConfig"].(map[string]any)
+	assert.Equal(t, 0.7, config["temperature"])
+	assert.Equal(t, 0.9, config["topP"])
+	assert.Equal(t, []string{"END", "STOP"}, config["stopSequences"])
+	assert.Equal(t, 500, config["maxOutputTokens"])
+}
+
+func TestTranslateRequest_MaxTokens(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     map[string]any
+		expected int
+	}{
+		{
+			name: "max_completion_tokens takes priority",
+			body: map[string]any{
+				"model":                 "gemini-2.5-flash",
+				"messages":              []any{map[string]any{"role": "user", "content": "Hi"}},
+				"max_completion_tokens": float64(200),
+				"max_tokens":            float64(100),
+			},
+			expected: 200,
+		},
+		{
+			name: "max_tokens fallback",
+			body: map[string]any{
+				"model":      "gemini-2.5-flash",
+				"messages":   []any{map[string]any{"role": "user", "content": "Hi"}},
+				"max_tokens": float64(500),
+			},
+			expected: 500,
+		},
+		{
+			name: "no max tokens omits field",
+			body: map[string]any{
+				"model":    "gemini-2.5-flash",
+				"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+			},
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			translated, _, _, err := NewVertexProvider().TranslateRequest(tt.body)
+			require.NoError(t, err)
+
+			config, hasConfig := translated["generationConfig"].(map[string]any)
+			if tt.expected > 0 {
+				require.True(t, hasConfig)
+				assert.Equal(t, tt.expected, config["maxOutputTokens"])
+			} else {
+				if hasConfig {
+					_, hasMaxTokens := config["maxOutputTokens"]
+					assert.False(t, hasMaxTokens)
+				}
+			}
+		})
+	}
+}
+
+func TestTranslateRequest_StopString(t *testing.T) {
+	body := map[string]any{
+		"model":    "gemini-2.5-flash",
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+		"stop":     "END",
+	}
+
+	translated, _, _, err := NewVertexProvider().TranslateRequest(body)
+	require.NoError(t, err)
+
+	config := translated["generationConfig"].(map[string]any)
+	assert.Equal(t, []string{"END"}, config["stopSequences"])
+}
+
+func TestTranslateRequest_InvalidModelCharacters(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+	}{
+		{"path traversal", "../../admin"},
+		{"encoded traversal", "%2e%2e%2fadmin"},
+		{"encoded slash", "gemini%2fadmin"},
+		{"query injection", "model?key=val"},
+		{"crlf injection", "gemini%0d%0aX-Injected:1"},
+		{"backslash traversal", `..\\admin`},
+		{"null byte", "gemini\x00admin"},
+		{"slash in model", "models/gemini"},
+		{"space in model", "gemini pro"},
+		{"starts with hyphen", "-gemini"},
+		{"starts with dot", ".gemini"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := map[string]any{
+				"model":    tt.model,
+				"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+			}
+			_, _, _, err := NewVertexProvider().TranslateRequest(body)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid characters")
+		})
+	}
+}
+
+func TestTranslateRequest_ValidModelNames(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+	}{
+		{"simple", "gemini-pro"},
+		{"with version", "gemini-2.5-flash"},
+		{"with dots", "gemini-2.0-flash-001"},
+		{"with underscore", "gemini_pro"},
+		{"alphanumeric", "model123"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := map[string]any{
+				"model":    tt.model,
+				"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+			}
+			_, _, _, err := NewVertexProvider().TranslateRequest(body)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestTranslateRequest_MissingModel(t *testing.T) {
+	body := map[string]any{
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+	}
+
+	_, _, _, err := NewVertexProvider().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "model")
+}
+
+func TestTranslateRequest_MissingMessages(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-2.5-flash",
+	}
+
+	_, _, _, err := NewVertexProvider().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "messages")
+}
+
+func TestTranslateRequest_EmptyMessagesArray(t *testing.T) {
+	body := map[string]any{
+		"model":    "gemini-2.5-flash",
+		"messages": []any{},
+	}
+
+	_, _, _, err := NewVertexProvider().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "non-system message")
+}
+
+func TestTranslateRequest_OnlySystemMessage(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-2.5-flash",
+		"messages": []any{
+			map[string]any{"role": "system", "content": "You are helpful"},
+		},
+	}
+
+	_, _, _, err := NewVertexProvider().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "non-system message")
+}
+
+func TestTranslateRequest_ToolRoleRejected(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-2.5-flash",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Hi"},
+			map[string]any{"role": "tool", "content": "result", "tool_call_id": "abc"},
+		},
+	}
+
+	_, _, _, err := NewVertexProvider().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "tool")
+	assert.Contains(t, err.Error(), "not supported")
+}
+
+func TestTranslateRequest_FunctionRoleRejected(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-2.5-flash",
+		"messages": []any{
+			map[string]any{"role": "function", "content": "result"},
+		},
+	}
+
+	_, _, _, err := NewVertexProvider().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "function")
+	assert.Contains(t, err.Error(), "not supported")
+}
+
+func TestTranslateRequest_UnknownRoleRejected(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-2.5-flash",
+		"messages": []any{
+			map[string]any{"role": "narrator", "content": "Once upon a time"},
+		},
+	}
+
+	_, _, _, err := NewVertexProvider().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown role")
+}
+
+func TestTranslateRequest_ContentParts(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-2.5-flash",
+		"messages": []any{
+			map[string]any{
+				"role": "user",
+				"content": []any{
+					map[string]any{"type": "text", "text": "Hello"},
+					map[string]any{"type": "text", "text": "World"},
+				},
+			},
+		},
+	}
+
+	translated, _, _, err := NewVertexProvider().TranslateRequest(body)
+	require.NoError(t, err)
+
+	contents := translated["contents"].([]map[string]any)
+	parts := contents[0]["parts"].([]map[string]any)
+	assert.Equal(t, "Hello World", parts[0]["text"])
+}
+
+func TestTranslateRequest_EmptyContentString(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-2.5-flash",
+		"messages": []any{
+			map[string]any{"role": "user", "content": ""},
+		},
+	}
+
+	translated, _, _, err := NewVertexProvider().TranslateRequest(body)
+	require.NoError(t, err)
+
+	contents := translated["contents"].([]map[string]any)
+	parts := contents[0]["parts"].([]map[string]any)
+	assert.Equal(t, "", parts[0]["text"])
+}
+
+func TestTranslateRequest_PathIncludesModel(t *testing.T) {
+	body := map[string]any{
+		"model":    "gemini-2.0-flash-001",
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+	}
+
+	_, headers, _, err := NewVertexProvider().TranslateRequest(body)
+	require.NoError(t, err)
+	assert.Equal(t, "/v1beta/models/gemini-2.0-flash-001:generateContent", headers[":path"])
+}
+
+func TestTranslateRequest_NoGenerationConfigWhenNoParams(t *testing.T) {
+	body := map[string]any{
+		"model":    "gemini-2.5-flash",
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+	}
+
+	translated, _, _, err := NewVertexProvider().TranslateRequest(body)
+	require.NoError(t, err)
+
+	_, hasConfig := translated["generationConfig"]
+	assert.False(t, hasConfig)
+}
+
+func TestTranslateRequest_NonTextContentSkipped(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-2.5-flash",
+		"messages": []any{
+			map[string]any{
+				"role": "user",
+				"content": []any{
+					map[string]any{"type": "text", "text": "Describe this"},
+					map[string]any{"type": "image_url", "image_url": map[string]any{"url": "https://example.com/img.png"}},
+				},
+			},
+		},
+	}
+
+	translated, _, _, err := NewVertexProvider().TranslateRequest(body)
+	require.NoError(t, err)
+
+	contents := translated["contents"].([]map[string]any)
+	parts := contents[0]["parts"].([]map[string]any)
+	assert.Equal(t, "Describe this", parts[0]["text"])
+}
+
+func TestTranslateRequest_MessagesNotArray(t *testing.T) {
+	body := map[string]any{
+		"model":    "gemini-2.5-flash",
+		"messages": "not-an-array",
+	}
+	_, _, _, err := NewVertexProvider().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "messages must be an array")
+}
+
+func TestTranslateRequest_MessageNotObject(t *testing.T) {
+	body := map[string]any{
+		"model":    "gemini-2.5-flash",
+		"messages": []any{"not-a-map"},
+	}
+	_, _, _, err := NewVertexProvider().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not an object")
+}
+
+func TestTranslateRequest_ContentNonStringNonArray(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-2.5-flash",
+		"messages": []any{
+			map[string]any{"role": "user", "content": 42},
+		},
+	}
+	translated, _, _, err := NewVertexProvider().TranslateRequest(body)
+	require.NoError(t, err)
+
+	contents := translated["contents"].([]map[string]any)
+	parts := contents[0]["parts"].([]map[string]any)
+	assert.Equal(t, "", parts[0]["text"])
+}
+
+func TestTranslateRequest_ContentKeyMissing(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-2.5-flash",
+		"messages": []any{
+			map[string]any{"role": "user"},
+		},
+	}
+	translated, _, _, err := NewVertexProvider().TranslateRequest(body)
+	require.NoError(t, err)
+
+	contents := translated["contents"].([]map[string]any)
+	parts := contents[0]["parts"].([]map[string]any)
+	assert.Equal(t, "", parts[0]["text"])
+}
+
+func TestTranslateRequest_StopNonStringNonArray(t *testing.T) {
+	body := map[string]any{
+		"model":    "gemini-2.5-flash",
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+		"stop":     12345,
+	}
+	translated, _, _, err := NewVertexProvider().TranslateRequest(body)
+	require.NoError(t, err)
+
+	_, hasConfig := translated["generationConfig"]
+	assert.False(t, hasConfig)
+}
+
+// --- Response translation tests ---
+
+func TestTranslateResponse_BasicCompletion(t *testing.T) {
+	body := map[string]any{
+		"responseId":   "resp_123",
+		"modelVersion": "gemini-2.5-flash",
+		"candidates": []any{
+			map[string]any{
+				"content": map[string]any{
+					"parts": []any{
+						map[string]any{"text": "The answer is 4."},
+					},
+					"role": "model",
+				},
+				"finishReason": "STOP",
+				"index":        float64(0),
+			},
+		},
+		"usageMetadata": map[string]any{
+			"promptTokenCount":     float64(10),
+			"candidatesTokenCount": float64(5),
+			"totalTokenCount":      float64(15),
+		},
+	}
+
+	translated, err := NewVertexProvider().TranslateResponse(body, "gemini-2.5-flash")
+	require.NoError(t, err)
+
+	assert.Equal(t, "resp_123", translated["id"])
+	assert.Equal(t, "chat.completion", translated["object"])
+	assert.Equal(t, "gemini-2.5-flash", translated["model"])
+
+	choices := translated["choices"].([]any)
+	require.Len(t, choices, 1)
+
+	choice := choices[0].(map[string]any)
+	assert.Equal(t, 0, choice["index"])
+	assert.Equal(t, "stop", choice["finish_reason"])
+
+	msg := choice["message"].(map[string]any)
+	assert.Equal(t, "assistant", msg["role"])
+	assert.Equal(t, "The answer is 4.", msg["content"])
+
+	usage := translated["usage"].(map[string]any)
+	assert.Equal(t, 10, usage["prompt_tokens"])
+	assert.Equal(t, 5, usage["completion_tokens"])
+	assert.Equal(t, 15, usage["total_tokens"])
+}
+
+func TestTranslateResponse_FinishReasons(t *testing.T) {
+	tests := []struct {
+		vertexReason string
+		openaiReason string
+	}{
+		{"STOP", "stop"},
+		{"MAX_TOKENS", "length"},
+		{"SAFETY", "content_filter"},
+		{"RECITATION", "content_filter"},
+		{"BLOCKLIST", "content_filter"},
+		{"PROHIBITED_CONTENT", "content_filter"},
+		{"SPII", "content_filter"},
+		{"MALFORMED_FUNCTION_CALL", "tool_calls"},
+		{"UNEXPECTED_TOOL_CALL", "tool_calls"},
+		{"MODEL_ARMOR", "content_filter"},
+		{"IMAGE_SAFETY", "content_filter"},
+		{"IMAGE_PROHIBITED_CONTENT", "content_filter"},
+		{"IMAGE_RECITATION", "content_filter"},
+		{"OTHER", "stop"},
+		{"", "stop"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.vertexReason, func(t *testing.T) {
+			body := map[string]any{
+				"candidates": []any{
+					map[string]any{
+						"content": map[string]any{
+							"parts": []any{map[string]any{"text": "hi"}},
+							"role":  "model",
+						},
+						"finishReason": tt.vertexReason,
+					},
+				},
+				"usageMetadata": map[string]any{
+					"promptTokenCount":     float64(1),
+					"candidatesTokenCount": float64(1),
+					"totalTokenCount":      float64(2),
+				},
+			}
+
+			translated, err := NewVertexProvider().TranslateResponse(body, "test")
+			require.NoError(t, err)
+
+			choices := translated["choices"].([]any)
+			choice := choices[0].(map[string]any)
+			assert.Equal(t, tt.openaiReason, choice["finish_reason"])
+		})
+	}
+}
+
+func TestTranslateResponse_MultipleCandidates(t *testing.T) {
+	body := map[string]any{
+		"candidates": []any{
+			map[string]any{
+				"content":      map[string]any{"parts": []any{map[string]any{"text": "Response A"}}, "role": "model"},
+				"finishReason": "STOP",
+			},
+			map[string]any{
+				"content":      map[string]any{"parts": []any{map[string]any{"text": "Response B"}}, "role": "model"},
+				"finishReason": "STOP",
+			},
+		},
+		"usageMetadata": map[string]any{"promptTokenCount": float64(5), "candidatesTokenCount": float64(10), "totalTokenCount": float64(15)},
+	}
+
+	translated, err := NewVertexProvider().TranslateResponse(body, "gemini-2.5-flash")
+	require.NoError(t, err)
+
+	choices := translated["choices"].([]any)
+	require.Len(t, choices, 2)
+	assert.Equal(t, 0, choices[0].(map[string]any)["index"])
+	assert.Equal(t, 1, choices[1].(map[string]any)["index"])
+	assert.Equal(t, "Response A", choices[0].(map[string]any)["message"].(map[string]any)["content"])
+	assert.Equal(t, "Response B", choices[1].(map[string]any)["message"].(map[string]any)["content"])
+}
+
+func TestTranslateResponse_MultipleContentParts(t *testing.T) {
+	body := map[string]any{
+		"candidates": []any{
+			map[string]any{
+				"content":      map[string]any{"parts": []any{map[string]any{"text": "Hello "}, map[string]any{"text": "World"}}, "role": "model"},
+				"finishReason": "STOP",
+			},
+		},
+		"usageMetadata": map[string]any{"promptTokenCount": float64(1), "candidatesTokenCount": float64(2), "totalTokenCount": float64(3)},
+	}
+
+	translated, err := NewVertexProvider().TranslateResponse(body, "test")
+	require.NoError(t, err)
+
+	msg := translated["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)
+	assert.Equal(t, "Hello World", msg["content"])
+}
+
+func TestTranslateResponse_ModelFromBody(t *testing.T) {
+	body := map[string]any{
+		"modelVersion": "gemini-2.5-flash",
+		"candidates": []any{
+			map[string]any{
+				"content":      map[string]any{"parts": []any{map[string]any{"text": "hi"}}, "role": "model"},
+				"finishReason": "STOP",
+			},
+		},
+		"usageMetadata": map[string]any{"promptTokenCount": float64(1), "candidatesTokenCount": float64(1), "totalTokenCount": float64(2)},
+	}
+
+	translated, err := NewVertexProvider().TranslateResponse(body, "")
+	require.NoError(t, err)
+	assert.Equal(t, "gemini-2.5-flash", translated["model"])
+}
+
+func TestTranslateResponse_ModelFromParam(t *testing.T) {
+	body := map[string]any{
+		"modelVersion": "gemini-2.5-flash",
+		"candidates": []any{
+			map[string]any{
+				"content":      map[string]any{"parts": []any{map[string]any{"text": "hi"}}, "role": "model"},
+				"finishReason": "STOP",
+			},
+		},
+		"usageMetadata": map[string]any{"promptTokenCount": float64(1), "candidatesTokenCount": float64(1), "totalTokenCount": float64(2)},
+	}
+
+	translated, err := NewVertexProvider().TranslateResponse(body, "my-model")
+	require.NoError(t, err)
+	assert.Equal(t, "my-model", translated["model"])
+}
+
+func TestTranslateResponse_MissingUsage(t *testing.T) {
+	body := map[string]any{
+		"candidates": []any{
+			map[string]any{
+				"content":      map[string]any{"parts": []any{map[string]any{"text": "hi"}}, "role": "model"},
+				"finishReason": "STOP",
+			},
+		},
+	}
+
+	translated, err := NewVertexProvider().TranslateResponse(body, "test")
+	require.NoError(t, err)
+
+	usage := translated["usage"].(map[string]any)
+	assert.Equal(t, 0, usage["prompt_tokens"])
+	assert.Equal(t, 0, usage["completion_tokens"])
+	assert.Equal(t, 0, usage["total_tokens"])
+}
+
+func TestTranslateResponse_NoCandidates(t *testing.T) {
+	body := map[string]any{
+		"usageMetadata": map[string]any{"promptTokenCount": float64(5), "totalTokenCount": float64(5)},
+	}
+
+	translated, err := NewVertexProvider().TranslateResponse(body, "test")
+	require.NoError(t, err)
+
+	choices := translated["choices"].([]any)
+	assert.Empty(t, choices)
+}
+
+func TestTranslateResponse_EmptyCandidatesArray(t *testing.T) {
+	body := map[string]any{
+		"candidates":    []any{},
+		"usageMetadata": map[string]any{"promptTokenCount": float64(5), "totalTokenCount": float64(5)},
+	}
+
+	translated, err := NewVertexProvider().TranslateResponse(body, "test")
+	require.NoError(t, err)
+
+	choices := translated["choices"].([]any)
+	assert.Empty(t, choices)
+}
+
+func TestTranslateResponse_VertexError(t *testing.T) {
+	body := map[string]any{
+		"error": map[string]any{
+			"code":    float64(400),
+			"message": "Invalid argument: model not found",
+			"status":  "INVALID_ARGUMENT",
+		},
+	}
+
+	translated, err := NewVertexProvider().TranslateResponse(body, "gemini-2.5-flash")
+	require.NoError(t, err)
+
+	errObj := translated["error"].(map[string]any)
+	assert.Equal(t, "INVALID_ARGUMENT", errObj["type"])
+	assert.Equal(t, "Invalid argument: model not found", errObj["message"])
+	assert.Equal(t, "400", errObj["code"])
+}
+
+func TestTranslateResponse_VertexError_NilCode(t *testing.T) {
+	body := map[string]any{
+		"error": map[string]any{
+			"message": "Something went wrong",
+			"status":  "INTERNAL",
+		},
+	}
+	translated, err := NewVertexProvider().TranslateResponse(body, "test")
+	require.NoError(t, err)
+
+	errObj := translated["error"].(map[string]any)
+	assert.Equal(t, "", errObj["code"])
+	assert.Equal(t, "INTERNAL", errObj["type"])
+}
+
+func TestTranslateResponse_VertexError_404(t *testing.T) {
+	body := map[string]any{
+		"error": map[string]any{
+			"code":    float64(404),
+			"message": "models/nonexistent-model is not found",
+			"status":  "NOT_FOUND",
+		},
+	}
+
+	translated, err := NewVertexProvider().TranslateResponse(body, "test")
+	require.NoError(t, err)
+
+	errObj := translated["error"].(map[string]any)
+	assert.Equal(t, "NOT_FOUND", errObj["type"])
+	assert.Equal(t, "404", errObj["code"])
+	assert.Nil(t, errObj["param"])
+}
+
+func TestTranslateResponse_VertexError_429(t *testing.T) {
+	body := map[string]any{
+		"error": map[string]any{
+			"code":    float64(429),
+			"message": "Resource has been exhausted",
+			"status":  "RESOURCE_EXHAUSTED",
+		},
+	}
+
+	translated, err := NewVertexProvider().TranslateResponse(body, "test")
+	require.NoError(t, err)
+
+	errObj := translated["error"].(map[string]any)
+	assert.Equal(t, "RESOURCE_EXHAUSTED", errObj["type"])
+	assert.Equal(t, "429", errObj["code"])
+}
+
+func TestTranslateResponse_FunctionCall(t *testing.T) {
+	body := map[string]any{
+		"candidates": []any{
+			map[string]any{
+				"content": map[string]any{
+					"parts": []any{
+						map[string]any{"text": "I'll check the weather."},
+						map[string]any{
+							"functionCall": map[string]any{
+								"name": "get_weather",
+								"args": map[string]any{"location": "San Francisco"},
+							},
+						},
+					},
+					"role": "model",
+				},
+				"finishReason": "STOP",
+			},
+		},
+		"usageMetadata": map[string]any{"promptTokenCount": float64(20), "candidatesTokenCount": float64(15), "totalTokenCount": float64(35)},
+	}
+
+	translated, err := NewVertexProvider().TranslateResponse(body, "gemini-2.5-flash")
+	require.NoError(t, err)
+
+	choices := translated["choices"].([]any)
+	choice := choices[0].(map[string]any)
+	msg := choice["message"].(map[string]any)
+
+	assert.Equal(t, "I'll check the weather.", msg["content"])
+
+	toolCalls := msg["tool_calls"].([]any)
+	require.Len(t, toolCalls, 1)
+
+	tc := toolCalls[0].(map[string]any)
+	assert.Equal(t, "call_0", tc["id"])
+	assert.Equal(t, "function", tc["type"])
+	assert.Equal(t, 0, tc["index"])
+
+	fn := tc["function"].(map[string]any)
+	assert.Equal(t, "get_weather", fn["name"])
+	assert.JSONEq(t, `{"location":"San Francisco"}`, fn["arguments"].(string))
+}
+
+func TestTranslateResponse_MultipleFunctionCalls(t *testing.T) {
+	body := map[string]any{
+		"candidates": []any{
+			map[string]any{
+				"content": map[string]any{
+					"parts": []any{
+						map[string]any{"functionCall": map[string]any{"name": "get_weather", "args": map[string]any{"location": "NYC"}}},
+						map[string]any{"functionCall": map[string]any{"name": "get_time", "args": map[string]any{"timezone": "EST"}}},
+					},
+					"role": "model",
+				},
+				"finishReason": "STOP",
+			},
+		},
+		"usageMetadata": map[string]any{"promptTokenCount": float64(10), "candidatesTokenCount": float64(20), "totalTokenCount": float64(30)},
+	}
+
+	translated, err := NewVertexProvider().TranslateResponse(body, "gemini-2.5-flash")
+	require.NoError(t, err)
+
+	msg := translated["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)
+	toolCalls := msg["tool_calls"].([]any)
+	require.Len(t, toolCalls, 2)
+
+	assert.Equal(t, "call_0", toolCalls[0].(map[string]any)["id"])
+	assert.Equal(t, 0, toolCalls[0].(map[string]any)["index"])
+	assert.Equal(t, "call_1", toolCalls[1].(map[string]any)["id"])
+	assert.Equal(t, 1, toolCalls[1].(map[string]any)["index"])
+}
+
+func TestTranslateResponse_FunctionCallStringArgs(t *testing.T) {
+	body := map[string]any{
+		"candidates": []any{map[string]any{
+			"content": map[string]any{
+				"parts": []any{map[string]any{"functionCall": map[string]any{"name": "fn", "args": `{"key":"value"}`}}},
+				"role":  "model",
+			},
+			"finishReason": "STOP",
+		}},
+		"usageMetadata": map[string]any{"promptTokenCount": float64(1), "candidatesTokenCount": float64(1), "totalTokenCount": float64(2)},
+	}
+	translated, err := NewVertexProvider().TranslateResponse(body, "test")
+	require.NoError(t, err)
+
+	tc := translated["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)["tool_calls"].([]any)[0].(map[string]any)
+	assert.Equal(t, `{"key":"value"}`, tc["function"].(map[string]any)["arguments"])
+}
+
+func TestTranslateResponse_FunctionCallNilArgs(t *testing.T) {
+	body := map[string]any{
+		"candidates": []any{map[string]any{
+			"content": map[string]any{
+				"parts": []any{map[string]any{"functionCall": map[string]any{"name": "fn", "args": nil}}},
+				"role":  "model",
+			},
+			"finishReason": "STOP",
+		}},
+		"usageMetadata": map[string]any{"promptTokenCount": float64(1), "candidatesTokenCount": float64(1), "totalTokenCount": float64(2)},
+	}
+	translated, err := NewVertexProvider().TranslateResponse(body, "test")
+	require.NoError(t, err)
+
+	tc := translated["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)["tool_calls"].([]any)[0].(map[string]any)
+	assert.Equal(t, "{}", tc["function"].(map[string]any)["arguments"])
+}
+
+func TestTranslateResponse_FunctionCallUnmarshalableArgs(t *testing.T) {
+	body := map[string]any{
+		"candidates": []any{map[string]any{
+			"content": map[string]any{
+				"parts": []any{map[string]any{"functionCall": map[string]any{"name": "fn", "args": make(chan int)}}},
+				"role":  "model",
+			},
+			"finishReason": "STOP",
+		}},
+		"usageMetadata": map[string]any{"promptTokenCount": float64(1), "candidatesTokenCount": float64(1), "totalTokenCount": float64(2)},
+	}
+	translated, err := NewVertexProvider().TranslateResponse(body, "test")
+	require.NoError(t, err)
+
+	msg := translated["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)
+	assert.Nil(t, msg["tool_calls"])
+}
+
+func TestTranslateResponse_CandidateNotMap(t *testing.T) {
+	body := map[string]any{
+		"candidates":    []any{"not-a-map"},
+		"usageMetadata": map[string]any{"promptTokenCount": float64(1), "candidatesTokenCount": float64(1), "totalTokenCount": float64(2)},
+	}
+	translated, err := NewVertexProvider().TranslateResponse(body, "test")
+	require.NoError(t, err)
+
+	choices := translated["choices"].([]any)
+	assert.Empty(t, choices)
+}
+
+func TestTranslateResponse_CandidateNoContent(t *testing.T) {
+	body := map[string]any{
+		"candidates":    []any{map[string]any{"finishReason": "STOP"}},
+		"usageMetadata": map[string]any{"promptTokenCount": float64(1), "candidatesTokenCount": float64(1), "totalTokenCount": float64(2)},
+	}
+	translated, err := NewVertexProvider().TranslateResponse(body, "test")
+	require.NoError(t, err)
+
+	msg := translated["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)
+	assert.Equal(t, "", msg["content"])
+	assert.Nil(t, msg["tool_calls"])
+}
+
+func TestTranslateResponse_PartsNotArray(t *testing.T) {
+	body := map[string]any{
+		"candidates": []any{map[string]any{
+			"content":      map[string]any{"parts": "not-an-array", "role": "model"},
+			"finishReason": "STOP",
+		}},
+		"usageMetadata": map[string]any{"promptTokenCount": float64(1), "candidatesTokenCount": float64(1), "totalTokenCount": float64(2)},
+	}
+	translated, err := NewVertexProvider().TranslateResponse(body, "test")
+	require.NoError(t, err)
+
+	msg := translated["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)
+	assert.Equal(t, "", msg["content"])
+}
+
+func TestTranslateResponse_PartNotMap(t *testing.T) {
+	body := map[string]any{
+		"candidates": []any{map[string]any{
+			"content":      map[string]any{"parts": []any{"not-a-map", map[string]any{"text": "hello"}}, "role": "model"},
+			"finishReason": "STOP",
+		}},
+		"usageMetadata": map[string]any{"promptTokenCount": float64(1), "candidatesTokenCount": float64(1), "totalTokenCount": float64(2)},
+	}
+	translated, err := NewVertexProvider().TranslateResponse(body, "test")
+	require.NoError(t, err)
+
+	msg := translated["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)
+	assert.Equal(t, "hello", msg["content"])
+}
+
+func TestTranslateResponse_UnknownFieldsIgnored(t *testing.T) {
+	body := map[string]any{
+		"candidates": []any{
+			map[string]any{
+				"content":      map[string]any{"parts": []any{map[string]any{"text": "hi"}}, "role": "model"},
+				"finishReason": "STOP",
+				"safetyRatings": []any{map[string]any{"category": "HARM_CATEGORY_HARASSMENT", "probability": "NEGLIGIBLE"}},
+				"citationMetadata": map[string]any{},
+			},
+		},
+		"usageMetadata": map[string]any{
+			"promptTokenCount":     float64(1),
+			"candidatesTokenCount": float64(1),
+			"totalTokenCount":      float64(2),
+			"promptTokensDetails":  []any{map[string]any{"modality": "TEXT", "tokenCount": float64(1)}},
+			"thoughtsTokenCount":   float64(50),
+		},
+		"modelVersion": "gemini-2.5-flash",
+		"responseId":   "abc123",
+	}
+
+	translated, err := NewVertexProvider().TranslateResponse(body, "test")
+	require.NoError(t, err)
+
+	assert.Equal(t, "chat.completion", translated["object"])
+	assert.Nil(t, translated["safetyRatings"])
+	assert.Nil(t, translated["citationMetadata"])
+	assert.Nil(t, translated["promptTokensDetails"])
+
+	usage := translated["usage"].(map[string]any)
+	assert.Equal(t, 1, usage["prompt_tokens"])
+	assert.Equal(t, 1, usage["completion_tokens"])
+	assert.Equal(t, 2, usage["total_tokens"])
+}
+
+func TestTranslateResponse_EmptyBody(t *testing.T) {
+	body := map[string]any{}
+
+	translated, err := NewVertexProvider().TranslateResponse(body, "test")
+	require.NoError(t, err)
+
+	assert.Equal(t, "chat.completion", translated["object"])
+	choices := translated["choices"].([]any)
+	assert.Empty(t, choices)
+	usage := translated["usage"].(map[string]any)
+	assert.Equal(t, 0, usage["prompt_tokens"])
+}
+
+// --- Helper function edge case tests ---
+
+func TestGetFloat_IntTypes(t *testing.T) {
+	body := map[string]any{
+		"model":       "gemini-2.5-flash",
+		"messages":    []any{map[string]any{"role": "user", "content": "Hi"}},
+		"temperature": int(1),
+		"top_p":       int64(1),
+	}
+	translated, _, _, err := NewVertexProvider().TranslateRequest(body)
+	require.NoError(t, err)
+
+	config := translated["generationConfig"].(map[string]any)
+	assert.Equal(t, float64(1), config["temperature"])
+	assert.Equal(t, float64(1), config["topP"])
+}
+
+func TestGetFloat_UnsupportedType(t *testing.T) {
+	body := map[string]any{
+		"model":       "gemini-2.5-flash",
+		"messages":    []any{map[string]any{"role": "user", "content": "Hi"}},
+		"temperature": "not-a-number",
+	}
+	translated, _, _, err := NewVertexProvider().TranslateRequest(body)
+	require.NoError(t, err)
+
+	_, hasConfig := translated["generationConfig"]
+	assert.False(t, hasConfig)
+}
+
+func TestGetInt_IntTypes(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{"int", int(300)},
+		{"int64", int64(300)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := map[string]any{
+				"model":      "gemini-2.5-flash",
+				"messages":   []any{map[string]any{"role": "user", "content": "Hi"}},
+				"max_tokens": tt.value,
+			}
+			translated, _, _, err := NewVertexProvider().TranslateRequest(body)
+			require.NoError(t, err)
+			config := translated["generationConfig"].(map[string]any)
+			assert.Equal(t, 300, config["maxOutputTokens"])
+		})
+	}
+}
+
+func TestGetInt_UnsupportedType(t *testing.T) {
+	body := map[string]any{
+		"model":      "gemini-2.5-flash",
+		"messages":   []any{map[string]any{"role": "user", "content": "Hi"}},
+		"max_tokens": "not-a-number",
+	}
+	translated, _, _, err := NewVertexProvider().TranslateRequest(body)
+	require.NoError(t, err)
+
+	_, hasConfig := translated["generationConfig"]
+	assert.False(t, hasConfig)
+}
+
+func TestToInt_IntTypes(t *testing.T) {
+	body := map[string]any{
+		"candidates": []any{map[string]any{
+			"content":      map[string]any{"parts": []any{map[string]any{"text": "hi"}}, "role": "model"},
+			"finishReason": "STOP",
+		}},
+		"usageMetadata": map[string]any{
+			"promptTokenCount":     int(10),
+			"candidatesTokenCount": int64(5),
+			"totalTokenCount":      "not-a-number",
+		},
+	}
+	translated, err := NewVertexProvider().TranslateResponse(body, "test")
+	require.NoError(t, err)
+
+	usage := translated["usage"].(map[string]any)
+	assert.Equal(t, 10, usage["prompt_tokens"])
+	assert.Equal(t, 5, usage["completion_tokens"])
+	assert.Equal(t, 0, usage["total_tokens"])
+}

--- a/pkg/plugins/apikey_injection/plugin.go
+++ b/pkg/plugins/apikey_injection/plugin.go
@@ -63,6 +63,7 @@ func defaultInjectors() map[string]*apiKeyInjector {
 		provider.OpenAI:      {headerName: "Authorization", headerValuePrefix: "Bearer "},
 		provider.Anthropic:   {headerName: "x-api-key"},
 		provider.AzureOpenAI: {headerName: "api-key"},
+		provider.Vertex:      {headerName: "Authorization", headerValuePrefix: "Bearer "},
 	}
 }
 

--- a/pkg/plugins/apikey_injection/plugin_test.go
+++ b/pkg/plugins/apikey_injection/plugin_test.go
@@ -84,6 +84,14 @@ func TestProcessRequest(t *testing.T) {
 			},
 		},
 		{
+			name:       "Vertex provider — injects Authorization: Bearer (same as OpenAI)",
+			secrets:    []*corev1.Secret{testSecret("default", "vertex-key", "vtx-key-456")},
+			cycleState: newCycleState("default", "vertex-key", provider.Vertex),
+			wantHeaders: map[string]string{
+				"Authorization": "Bearer vtx-key-456",
+			},
+		},
+		{
 			name:       "default provider when CycleState has no provider — uses OpenAI Bearer",
 			secrets:    []*corev1.Secret{testSecret("default", "no-provider", "sk-key")},
 			cycleState: newCycleState("default", "no-provider", ""),
@@ -185,7 +193,11 @@ func TestDefaultInjectors(t *testing.T) {
 	assert.Equal(t, "api-key", injectors[provider.AzureOpenAI].headerName)
 	assert.Empty(t, injectors[provider.AzureOpenAI].headerValuePrefix)
 
-	assert.Len(t, injectors, 3)
+	require.Contains(t, injectors, provider.Vertex)
+	assert.Equal(t, "Authorization", injectors[provider.Vertex].headerName)
+	assert.Equal(t, "Bearer ", injectors[provider.Vertex].headerValuePrefix)
+
+	assert.Len(t, injectors, 4)
 }
 
 func TestAPIKeyInjector(t *testing.T) {


### PR DESCRIPTION
Add Vertex AI provider to the api-translation plugin, translating OpenAI Chat Completions requests to Google Gemini GenerateContent API format and responses back to OpenAI schema.

## Description

Implements the Vertex AI (Gemini) api-translation provider (#11), following the same Provider interface pattern used by the Anthropic and Azure OpenAI translators.

**Request translation (TranslateRequest):**
- Converts OpenAI messages array to Gemini `contents` format
- Maps `system`/`developer` role messages to `systemInstruction`
- Maps `assistant` role to `model` role
- Translates generation parameters (`max_tokens`/`max_completion_tokens` → `maxOutputTokens`, `temperature`, `top_p` → `topP`, `stop` → `stopSequences`)
- Rewrites `:path` to `/v1beta/models/{model}:generateContent`
- Validates model name to prevent path injection
- Sets `content-type: application/json` header

**Response translation (TranslateResponse):**
- Converts Gemini `candidates` to OpenAI `choices`
- Maps Vertex `finishReason` to OpenAI `finish_reason` (STOP→stop, MAX_TOKENS→length, SAFETY/RECITATION/BLOCKLIST/PROHIBITED_CONTENT/SPII/MODEL_ARMOR/IMAGE_SAFETY/IMAGE_PROHIBITED_CONTENT/IMAGE_RECITATION→content_filter, MALFORMED_FUNCTION_CALL/UNEXPECTED_TOOL_CALL→tool_calls)
- Translates `usageMetadata` to OpenAI `usage` format
- Converts `functionCall` parts to OpenAI `tool_calls` with generated IDs
- Translates Vertex error responses to OpenAI error format
- Gracefully handles missing `usageMetadata`, empty `candidates`, missing `content.parts`

**Registration and integration:**
- Adds `Vertex = "vertex"` constant to `pkg/external-model/provider/provider.go`
- Registers the Vertex provider in the api-translation plugin alongside Anthropic and Azure OpenAI
- Adds Vertex to the apikey-injection plugin's `defaultInjectors` with `Authorization: Bearer` format (same as OpenAI)

**API target — v1beta:**
The translator targets `/v1beta/models/{model}:generateContent` because `systemInstruction` requires `v1beta` on the Generative Language API (`generativelanguage.googleapis.com`). The Vertex AI API (`aiplatform.googleapis.com`) supports `systemInstruction` in `v1`, but `v1beta` is compatible with both endpoints. If the project moves to the enterprise Vertex AI API, the path format would change entirely — that path transformation would likely be handled by Envoy path rewriting, not by this plugin.

## How Has This Been Tested?

- **Unit tests** (`vertex_test.go` — 60+ tests): basic translation, system messages, multi-turn conversations, all generation parameters, all finish reason mappings, function calling, error responses, model name validation, edge cases (missing fields, empty content, malformed structures, unknown fields), helper function coverage
- **Unit test coverage**: 100% statement coverage on the Vertex provider
- **Plugin integration tests** (`plugin_test.go` — 4 new tests): `TestProcessRequest_VertexProvider`, `TestProcessResponse_Vertex`, `TestProcessResponse_VertexError`, `TestProcessResponse_VertexToolCall`
- **apikey-injection tests**: Vertex injector test added (`TestProcessRequest` Vertex case, `TestDefaultInjectors` updated)
- **Full test suite**: all existing tests (Anthropic, Azure OpenAI, model-provider-resolver, apikey-injection) continue to pass
- **Real Vertex AI API validation**: tested against Google's Generative Language API with multiple models (gemini-2.5-flash, gemini-2.0-flash-lite, gemini-2.5-pro), including system instruction, multi-turn, function calling, MAX_TOKENS truncation, and error scenarios
- **Simulator validation**: tested against the team's llm-katan mock server — full pipeline (OpenAI request → TranslateRequest → simulator → TranslateResponse → OpenAI response) verified
- **E2E validation**: BBR server deployed in kind cluster with MaaSModelRef CRD, model-provider-resolver, api-translation, and apikey-injection plugins — full gRPC ext_proc pipeline confirmed working with Vertex translation (request body mutation, header mutations, response body mutation, API key injection)
- **Lint**: `golangci-lint run ./...` — 0 issues

**Test evidence (real API round-trip):**
```
# OpenAI request → our TranslateRequest → translated Gemini body
{"contents":[{"parts":[{"text":"What is Kubernetes?"}],"role":"user"}],
 "generationConfig":{"maxOutputTokens":100,"temperature":0.1},
 "systemInstruction":{"parts":[{"text":"Be concise. One sentence max."}]}}

# Real Gemini API response:
{"candidates":[{"content":{"parts":[{"text":"Kubernetes is an open-source
 platform for automating the"}],"role":"model"},"finishReason":"MAX_TOKENS"}],
 "usageMetadata":{"promptTokenCount":12,"candidatesTokenCount":11,
 "totalTokenCount":108}}

# Our TranslateResponse → OpenAI format:
{"choices":[{"finish_reason":"length","index":0,"message":{"content":
 "Kubernetes is an open-source platform for automating the",
 "role":"assistant"}}],"model":"gemini-2.5-flash",
 "object":"chat.completion","usage":{"completion_tokens":11,
 "prompt_tokens":12,"total_tokens":108}}
```

**E2E evidence (kind cluster, full gRPC pipeline):**
```
# Request body mutation — OpenAI → Gemini format:
Body mutation: {"contents":[{"parts":[{"text":"What is Go?"}],"role":"user"}],
 "generationConfig":{"maxOutputTokens":50,"temperature":0.5},
 "systemInstruction":{"parts":[{"text":"Be concise."}]}}
Header mutations: SET :path /v1beta/models/gemini-2.5-flash:generateContent
                  SET Authorization: Bearer <key>
                  REMOVE authorization
Server log: "API key injected","provider":"vertex"

# Response body mutation — Gemini → OpenAI format:
{"choices":[{"finish_reason":"stop","index":0,"message":{"content":
 "Go is a statically typed compiled language.","role":"assistant"}}],
 "model":"gemini-2.5-flash","object":"chat.completion",
 "usage":{"completion_tokens":8,"prompt_tokens":10,"total_tokens":18}}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Vertex AI as a supported provider ("vertex") with automatic translation between OpenAI and Vertex request/response formats (system instructions, tool calls, generation params, error mapping) and built-in API key injection using Authorization: Bearer.

* **Tests**
  * Added comprehensive tests covering Vertex request/response translation, validation, error scenarios, parameter mapping, and API key injection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->