### PR TITLE
feat: add tool definitions, tool/function role, multimodal, and JSON mode to Vertex AI translator

### DIFF
--- a/pkg/plugins/api-translation/translator/vertex/vertex.go
+++ b/pkg/plugins/api-translation/translator/vertex/vertex.go
@@ -35,7 +35,7 @@ var _ translator.Translator = &VertexTranslator{}
 
 func NewVertexTranslator() *VertexTranslator {
 	return &VertexTranslator{
-		modelNamePattern: regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`), // modelNamePattern validates Gemini model names to prevent path injection.
+		modelNamePattern: regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`),
 	}
 }
 
@@ -86,6 +86,14 @@ func (t *VertexTranslator) TranslateRequest(body map[string]any) (map[string]any
 		translated["generationConfig"] = generationConfig
 	}
 
+	if tools := translateTools(body); len(tools) > 0 {
+		translated["tools"] = tools
+	}
+
+	if toolConfig := translateToolChoice(body); len(toolConfig) > 0 {
+		translated["toolConfig"] = toolConfig
+	}
+
 	// Use v1beta for systemInstruction support on the Generative Language API.
 	// The Vertex AI API (aiplatform.googleapis.com) supports systemInstruction in v1,
 	// but the Generative Language API (generativelanguage.googleapis.com) requires v1beta.
@@ -133,35 +141,134 @@ func (t *VertexTranslator) TranslateResponse(body map[string]any, model string) 
 
 // separateSystemMessages separates system/developer messages into systemInstruction
 // parts and converts the remaining messages into Vertex contents format.
+// It handles tool_calls in assistant messages and tool/function role messages.
 func separateSystemMessages(messages []map[string]any) ([]map[string]any, []map[string]any, error) {
 	var systemParts []map[string]any
 	var contents []map[string]any
 
+	// Maps tool_call_id to function name for correlating tool responses.
+	toolCallNames := map[string]string{}
+
 	for i, msg := range messages {
 		role, _ := msg["role"].(string)
-		content := extractContentString(msg)
 
 		switch role {
 		case "system", "developer":
+			content := extractContentString(msg)
 			systemParts = append(systemParts, map[string]any{"text": content})
+
 		case "user":
 			contents = append(contents, map[string]any{
 				"role":  "user",
-				"parts": []map[string]any{{"text": content}},
+				"parts": extractContentParts(msg),
 			})
+
 		case "assistant":
+			parts := buildAssistantParts(msg, toolCallNames)
 			contents = append(contents, map[string]any{
 				"role":  "model",
-				"parts": []map[string]any{{"text": content}},
+				"parts": parts,
 			})
-		case "tool", "function":
-			return nil, nil, fmt.Errorf("message at index %d has role '%s' which is not supported for Vertex translation", i, role)
+
+		case "tool":
+			toolCallID, _ := msg["tool_call_id"].(string)
+			fnName := toolCallNames[toolCallID]
+			if fnName == "" {
+				fnName = "unknown"
+			}
+
+			responseContent := extractContentString(msg)
+			var responseData any
+			if err := json.Unmarshal([]byte(responseContent), &responseData); err != nil {
+				responseData = map[string]any{"result": responseContent}
+			}
+
+			contents = append(contents, map[string]any{
+				"role": "user",
+				"parts": []map[string]any{{
+					"functionResponse": map[string]any{
+						"name":     fnName,
+						"response": responseData,
+					},
+				}},
+			})
+
+		case "function":
+			fnName, _ := msg["name"].(string)
+			if fnName == "" {
+				return nil, nil, fmt.Errorf("message at index %d has role \"function\" but missing name", i)
+			}
+
+			responseContent := extractContentString(msg)
+			var responseData any
+			if err := json.Unmarshal([]byte(responseContent), &responseData); err != nil {
+				responseData = map[string]any{"result": responseContent}
+			}
+
+			contents = append(contents, map[string]any{
+				"role": "user",
+				"parts": []map[string]any{{
+					"functionResponse": map[string]any{
+						"name":     fnName,
+						"response": responseData,
+					},
+				}},
+			})
+
 		default:
 			return nil, nil, fmt.Errorf("message at index %d has unknown role '%s'", i, role)
 		}
 	}
 
 	return systemParts, contents, nil
+}
+
+// buildAssistantParts builds Vertex parts for an assistant message, handling both
+// text content and tool_calls (converted to functionCall parts).
+func buildAssistantParts(msg map[string]any, toolCallNames map[string]string) []map[string]any {
+	var parts []map[string]any
+
+	content := extractContentString(msg)
+	if content != "" {
+		parts = append(parts, map[string]any{"text": content})
+	}
+
+	if toolCallsRaw, ok := msg["tool_calls"].([]any); ok {
+		for _, raw := range toolCallsRaw {
+			tc, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			fn, ok := tc["function"].(map[string]any)
+			if !ok {
+				continue
+			}
+			name, _ := fn["name"].(string)
+			argsStr, _ := fn["arguments"].(string)
+
+			if id, ok := tc["id"].(string); ok && id != "" {
+				toolCallNames[id] = name
+			}
+
+			var args any
+			if err := json.Unmarshal([]byte(argsStr), &args); err != nil {
+				args = map[string]any{}
+			}
+
+			parts = append(parts, map[string]any{
+				"functionCall": map[string]any{
+					"name": name,
+					"args": args,
+				},
+			})
+		}
+	}
+
+	if len(parts) == 0 {
+		parts = append(parts, map[string]any{"text": ""})
+	}
+
+	return parts
 }
 
 // buildGenerationConfig constructs the Vertex generationConfig from OpenAI parameters.
@@ -181,6 +288,12 @@ func buildGenerationConfig(body map[string]any) map[string]any {
 	}
 	if stop := extractStopSequences(body); len(stop) > 0 {
 		config["stopSequences"] = stop
+	}
+
+	if rf, ok := body["response_format"].(map[string]any); ok {
+		if rfType, _ := rf["type"].(string); rfType == "json_object" || rfType == "json_schema" {
+			config["responseMimeType"] = "application/json"
+		}
 	}
 
 	return config
@@ -337,6 +450,85 @@ func translateVertexError(errObj map[string]any) map[string]any {
 	}
 }
 
+// translateTools converts OpenAI tools[] to Vertex tools[].function_declarations.
+func translateTools(body map[string]any) []map[string]any {
+	toolsRaw, ok := body["tools"].([]any)
+	if !ok || len(toolsRaw) == 0 {
+		return nil
+	}
+
+	var declarations []map[string]any
+	for _, raw := range toolsRaw {
+		tool, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		toolType, _ := tool["type"].(string)
+		if toolType != "function" {
+			continue
+		}
+		fn, ok := tool["function"].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		decl := map[string]any{}
+		if name, ok := fn["name"].(string); ok {
+			decl["name"] = name
+		}
+		if desc, ok := fn["description"].(string); ok {
+			decl["description"] = desc
+		}
+		if params, ok := fn["parameters"]; ok && params != nil {
+			decl["parameters"] = params
+		}
+		declarations = append(declarations, decl)
+	}
+
+	if len(declarations) == 0 {
+		return nil
+	}
+
+	return []map[string]any{
+		{"functionDeclarations": declarations},
+	}
+}
+
+// translateToolChoice converts OpenAI tool_choice to Vertex toolConfig.functionCallingConfig.
+func translateToolChoice(body map[string]any) map[string]any {
+	tc, ok := body["tool_choice"]
+	if !ok {
+		return nil
+	}
+
+	if s, ok := tc.(string); ok {
+		switch s {
+		case "auto":
+			return map[string]any{"functionCallingConfig": map[string]any{"mode": "AUTO"}}
+		case "none":
+			return map[string]any{"functionCallingConfig": map[string]any{"mode": "NONE"}}
+		case "required":
+			return map[string]any{"functionCallingConfig": map[string]any{"mode": "ANY"}}
+		}
+		return nil
+	}
+
+	if obj, ok := tc.(map[string]any); ok {
+		if fn, ok := obj["function"].(map[string]any); ok {
+			if name, ok := fn["name"].(string); ok && name != "" {
+				return map[string]any{
+					"functionCallingConfig": map[string]any{
+						"mode":                  "ANY",
+						"allowedFunctionNames": []string{name},
+					},
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
 // --- Helper functions ---
 
 func extractMessages(body map[string]any) ([]map[string]any, error) {
@@ -362,6 +554,7 @@ func extractMessages(body map[string]any) ([]map[string]any, error) {
 	return messages, nil
 }
 
+// extractContentString extracts only text content from a message (used for system instructions).
 func extractContentString(msg map[string]any) string {
 	content, ok := msg["content"]
 	if !ok {
@@ -385,6 +578,82 @@ func extractContentString(msg map[string]any) string {
 	}
 
 	return ""
+}
+
+// extractContentParts converts OpenAI message content (string or array of parts)
+// into Vertex AI parts, supporting both text and image_url (data URI) content.
+func extractContentParts(msg map[string]any) []map[string]any {
+	content, ok := msg["content"]
+	if !ok {
+		return []map[string]any{{"text": ""}}
+	}
+
+	if s, ok := content.(string); ok {
+		return []map[string]any{{"text": s}}
+	}
+
+	if parts, ok := content.([]any); ok {
+		var vertexParts []map[string]any
+		for _, part := range parts {
+			partMap, ok := part.(map[string]any)
+			if !ok {
+				continue
+			}
+			partType, _ := partMap["type"].(string)
+
+			switch partType {
+			case "text":
+				if text, ok := partMap["text"].(string); ok {
+					vertexParts = append(vertexParts, map[string]any{"text": text})
+				}
+			case "image_url":
+				if imgObj, ok := partMap["image_url"].(map[string]any); ok {
+					if url, ok := imgObj["url"].(string); ok {
+						if mimeType, data, ok := parseDataURI(url); ok {
+							vertexParts = append(vertexParts, map[string]any{
+								"inlineData": map[string]any{
+									"mimeType": mimeType,
+									"data":     data,
+								},
+							})
+						}
+					}
+				}
+			}
+		}
+		if len(vertexParts) == 0 {
+			return []map[string]any{{"text": ""}}
+		}
+		return vertexParts
+	}
+
+	return []map[string]any{{"text": ""}}
+}
+
+// parseDataURI parses a data URI (e.g., "data:image/png;base64,iVBOR...") and returns
+// the MIME type, base64 data, and whether parsing succeeded.
+func parseDataURI(url string) (mimeType string, data string, ok bool) {
+	if !strings.HasPrefix(url, "data:") {
+		return "", "", false
+	}
+
+	rest := url[len("data:"):]
+	semicolonIdx := strings.Index(rest, ";")
+	if semicolonIdx < 0 {
+		return "", "", false
+	}
+	mimeType = rest[:semicolonIdx]
+
+	rest = rest[semicolonIdx+1:]
+	if !strings.HasPrefix(rest, "base64,") {
+		return "", "", false
+	}
+	data = rest[len("base64,"):]
+
+	if mimeType == "" || data == "" {
+		return "", "", false
+	}
+	return mimeType, data, true
 }
 
 func resolveMaxTokens(body map[string]any) int {

--- a/pkg/plugins/api-translation/translator/vertex/vertex_test.go
+++ b/pkg/plugins/api-translation/translator/vertex/vertex_test.go
@@ -324,22 +324,76 @@ func TestTranslateRequest_OnlySystemMessage(t *testing.T) {
 	assert.Contains(t, err.Error(), "non-system message")
 }
 
-func TestTranslateRequest_ToolRoleRejected(t *testing.T) {
+func TestTranslateRequest_ToolRoleTranslated(t *testing.T) {
 	body := map[string]any{
 		"model": "gemini-2.5-flash",
 		"messages": []any{
-			map[string]any{"role": "user", "content": "Hi"},
-			map[string]any{"role": "tool", "content": "result", "tool_call_id": "abc"},
+			map[string]any{"role": "user", "content": "What's the weather?"},
+			map[string]any{
+				"role":    "assistant",
+				"content": "",
+				"tool_calls": []any{
+					map[string]any{
+						"id":   "call_abc",
+						"type": "function",
+						"function": map[string]any{
+							"name":      "get_weather",
+							"arguments": `{"location":"NYC"}`,
+						},
+					},
+				},
+			},
+			map[string]any{"role": "tool", "content": `{"temp": 72}`, "tool_call_id": "call_abc"},
 		},
 	}
 
-	_, _, _, err := NewVertexTranslator().TranslateRequest(body)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "tool")
-	assert.Contains(t, err.Error(), "not supported")
+	translated, _, _, err := NewVertexTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	contents := translated["contents"].([]map[string]any)
+	require.Len(t, contents, 3)
+
+	// Assistant message with functionCall
+	assistantParts := contents[1]["parts"].([]map[string]any)
+	assert.Equal(t, "model", contents[1]["role"])
+	fc := assistantParts[0]["functionCall"].(map[string]any)
+	assert.Equal(t, "get_weather", fc["name"])
+	args := fc["args"].(map[string]any)
+	assert.Equal(t, "NYC", args["location"])
+
+	// Tool response as functionResponse
+	toolParts := contents[2]["parts"].([]map[string]any)
+	assert.Equal(t, "user", contents[2]["role"])
+	fr := toolParts[0]["functionResponse"].(map[string]any)
+	assert.Equal(t, "get_weather", fr["name"])
+	response := fr["response"].(map[string]any)
+	assert.Equal(t, float64(72), response["temp"])
 }
 
-func TestTranslateRequest_FunctionRoleRejected(t *testing.T) {
+func TestTranslateRequest_FunctionRoleTranslated(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-2.5-flash",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Hello"},
+			map[string]any{"role": "function", "name": "get_time", "content": `{"time":"12:00"}`},
+		},
+	}
+
+	translated, _, _, err := NewVertexTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	contents := translated["contents"].([]map[string]any)
+	require.Len(t, contents, 2)
+
+	fnParts := contents[1]["parts"].([]map[string]any)
+	assert.Equal(t, "user", contents[1]["role"])
+	fr := fnParts[0]["functionResponse"].(map[string]any)
+	assert.Equal(t, "get_time", fr["name"])
+	response := fr["response"].(map[string]any)
+	assert.Equal(t, "12:00", response["time"])
+}
+
+func TestTranslateRequest_FunctionRoleMissingName(t *testing.T) {
 	body := map[string]any{
 		"model": "gemini-2.5-flash",
 		"messages": []any{
@@ -349,8 +403,7 @@ func TestTranslateRequest_FunctionRoleRejected(t *testing.T) {
 
 	_, _, _, err := NewVertexTranslator().TranslateRequest(body)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "function")
-	assert.Contains(t, err.Error(), "not supported")
+	assert.Contains(t, err.Error(), "missing name")
 }
 
 func TestTranslateRequest_UnknownRoleRejected(t *testing.T) {
@@ -385,7 +438,9 @@ func TestTranslateRequest_ContentParts(t *testing.T) {
 
 	contents := translated["contents"].([]map[string]any)
 	parts := contents[0]["parts"].([]map[string]any)
-	assert.Equal(t, "Hello World", parts[0]["text"])
+	require.Len(t, parts, 2)
+	assert.Equal(t, "Hello", parts[0]["text"])
+	assert.Equal(t, "World", parts[1]["text"])
 }
 
 func TestTranslateRequest_EmptyContentString(t *testing.T) {
@@ -428,7 +483,36 @@ func TestTranslateRequest_NoGenerationConfigWhenNoParams(t *testing.T) {
 	assert.False(t, hasConfig)
 }
 
-func TestTranslateRequest_NonTextContentSkipped(t *testing.T) {
+func TestTranslateRequest_ImageDataURI(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-2.5-flash",
+		"messages": []any{
+			map[string]any{
+				"role": "user",
+				"content": []any{
+					map[string]any{"type": "text", "text": "Describe this image"},
+					map[string]any{"type": "image_url", "image_url": map[string]any{
+						"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==",
+					}},
+				},
+			},
+		},
+	}
+
+	translated, _, _, err := NewVertexTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	contents := translated["contents"].([]map[string]any)
+	parts := contents[0]["parts"].([]map[string]any)
+	require.Len(t, parts, 2)
+	assert.Equal(t, "Describe this image", parts[0]["text"])
+
+	inlineData := parts[1]["inlineData"].(map[string]any)
+	assert.Equal(t, "image/png", inlineData["mimeType"])
+	assert.Equal(t, "iVBORw0KGgoAAAANSUhEUg==", inlineData["data"])
+}
+
+func TestTranslateRequest_ImageHTTPURLSkipped(t *testing.T) {
 	body := map[string]any{
 		"model": "gemini-2.5-flash",
 		"messages": []any{
@@ -447,6 +531,7 @@ func TestTranslateRequest_NonTextContentSkipped(t *testing.T) {
 
 	contents := translated["contents"].([]map[string]any)
 	parts := contents[0]["parts"].([]map[string]any)
+	require.Len(t, parts, 1)
 	assert.Equal(t, "Describe this", parts[0]["text"])
 }
 
@@ -511,6 +596,420 @@ func TestTranslateRequest_StopNonStringNonArray(t *testing.T) {
 
 	_, hasConfig := translated["generationConfig"]
 	assert.False(t, hasConfig)
+}
+
+// --- Tool definitions tests ---
+
+func TestTranslateRequest_ToolDefinitions(t *testing.T) {
+	body := map[string]any{
+		"model":    "gemini-2.5-flash",
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+		"tools": []any{
+			map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name":        "get_weather",
+					"description": "Get weather for a location",
+					"parameters": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"location": map[string]any{"type": "string"},
+						},
+						"required": []any{"location"},
+					},
+				},
+			},
+		},
+	}
+
+	translated, _, _, err := NewVertexTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	tools := translated["tools"].([]map[string]any)
+	require.Len(t, tools, 1)
+
+	declarations := tools[0]["functionDeclarations"].([]map[string]any)
+	require.Len(t, declarations, 1)
+	assert.Equal(t, "get_weather", declarations[0]["name"])
+	assert.Equal(t, "Get weather for a location", declarations[0]["description"])
+	assert.NotNil(t, declarations[0]["parameters"])
+}
+
+func TestTranslateRequest_MultipleToolDefinitions(t *testing.T) {
+	body := map[string]any{
+		"model":    "gemini-2.5-flash",
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+		"tools": []any{
+			map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name": "get_weather",
+				},
+			},
+			map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name": "get_time",
+				},
+			},
+		},
+	}
+
+	translated, _, _, err := NewVertexTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	tools := translated["tools"].([]map[string]any)
+	declarations := tools[0]["functionDeclarations"].([]map[string]any)
+	require.Len(t, declarations, 2)
+	assert.Equal(t, "get_weather", declarations[0]["name"])
+	assert.Equal(t, "get_time", declarations[1]["name"])
+}
+
+func TestTranslateRequest_NoToolsOmitted(t *testing.T) {
+	body := map[string]any{
+		"model":    "gemini-2.5-flash",
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+	}
+
+	translated, _, _, err := NewVertexTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	_, hasTools := translated["tools"]
+	assert.False(t, hasTools)
+}
+
+func TestTranslateRequest_NonFunctionToolSkipped(t *testing.T) {
+	body := map[string]any{
+		"model":    "gemini-2.5-flash",
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+		"tools": []any{
+			map[string]any{
+				"type": "code_interpreter",
+			},
+		},
+	}
+
+	translated, _, _, err := NewVertexTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	_, hasTools := translated["tools"]
+	assert.False(t, hasTools)
+}
+
+// --- tool_choice tests ---
+
+func TestTranslateRequest_ToolChoiceAuto(t *testing.T) {
+	body := map[string]any{
+		"model":       "gemini-2.5-flash",
+		"messages":    []any{map[string]any{"role": "user", "content": "Hi"}},
+		"tools":       []any{map[string]any{"type": "function", "function": map[string]any{"name": "fn"}}},
+		"tool_choice": "auto",
+	}
+
+	translated, _, _, err := NewVertexTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	toolConfig := translated["toolConfig"].(map[string]any)
+	fcc := toolConfig["functionCallingConfig"].(map[string]any)
+	assert.Equal(t, "AUTO", fcc["mode"])
+}
+
+func TestTranslateRequest_ToolChoiceNone(t *testing.T) {
+	body := map[string]any{
+		"model":       "gemini-2.5-flash",
+		"messages":    []any{map[string]any{"role": "user", "content": "Hi"}},
+		"tool_choice": "none",
+	}
+
+	translated, _, _, err := NewVertexTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	toolConfig := translated["toolConfig"].(map[string]any)
+	fcc := toolConfig["functionCallingConfig"].(map[string]any)
+	assert.Equal(t, "NONE", fcc["mode"])
+}
+
+func TestTranslateRequest_ToolChoiceRequired(t *testing.T) {
+	body := map[string]any{
+		"model":       "gemini-2.5-flash",
+		"messages":    []any{map[string]any{"role": "user", "content": "Hi"}},
+		"tools":       []any{map[string]any{"type": "function", "function": map[string]any{"name": "fn"}}},
+		"tool_choice": "required",
+	}
+
+	translated, _, _, err := NewVertexTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	toolConfig := translated["toolConfig"].(map[string]any)
+	fcc := toolConfig["functionCallingConfig"].(map[string]any)
+	assert.Equal(t, "ANY", fcc["mode"])
+}
+
+func TestTranslateRequest_ToolChoiceSpecificFunction(t *testing.T) {
+	body := map[string]any{
+		"model":    "gemini-2.5-flash",
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+		"tools":    []any{map[string]any{"type": "function", "function": map[string]any{"name": "get_weather"}}},
+		"tool_choice": map[string]any{
+			"type":     "function",
+			"function": map[string]any{"name": "get_weather"},
+		},
+	}
+
+	translated, _, _, err := NewVertexTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	toolConfig := translated["toolConfig"].(map[string]any)
+	fcc := toolConfig["functionCallingConfig"].(map[string]any)
+	assert.Equal(t, "ANY", fcc["mode"])
+	assert.Equal(t, []string{"get_weather"}, fcc["allowedFunctionNames"])
+}
+
+func TestTranslateRequest_NoToolChoiceOmitted(t *testing.T) {
+	body := map[string]any{
+		"model":    "gemini-2.5-flash",
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+	}
+
+	translated, _, _, err := NewVertexTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	_, hasToolConfig := translated["toolConfig"]
+	assert.False(t, hasToolConfig)
+}
+
+// --- response_format tests ---
+
+func TestTranslateRequest_ResponseFormatJSON(t *testing.T) {
+	body := map[string]any{
+		"model":           "gemini-2.5-flash",
+		"messages":        []any{map[string]any{"role": "user", "content": "Hi"}},
+		"response_format": map[string]any{"type": "json_object"},
+	}
+
+	translated, _, _, err := NewVertexTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	config := translated["generationConfig"].(map[string]any)
+	assert.Equal(t, "application/json", config["responseMimeType"])
+}
+
+func TestTranslateRequest_ResponseFormatJSONSchema(t *testing.T) {
+	body := map[string]any{
+		"model":           "gemini-2.5-flash",
+		"messages":        []any{map[string]any{"role": "user", "content": "Hi"}},
+		"response_format": map[string]any{"type": "json_schema"},
+	}
+
+	translated, _, _, err := NewVertexTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	config := translated["generationConfig"].(map[string]any)
+	assert.Equal(t, "application/json", config["responseMimeType"])
+}
+
+func TestTranslateRequest_ResponseFormatText(t *testing.T) {
+	body := map[string]any{
+		"model":           "gemini-2.5-flash",
+		"messages":        []any{map[string]any{"role": "user", "content": "Hi"}},
+		"response_format": map[string]any{"type": "text"},
+	}
+
+	translated, _, _, err := NewVertexTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	_, hasConfig := translated["generationConfig"]
+	assert.False(t, hasConfig)
+}
+
+// --- Tool/function role message tests ---
+
+func TestTranslateRequest_ToolRoleNonJSONContent(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-2.5-flash",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Hi"},
+			map[string]any{
+				"role":    "assistant",
+				"content": "",
+				"tool_calls": []any{
+					map[string]any{
+						"id":       "call_1",
+						"type":     "function",
+						"function": map[string]any{"name": "search", "arguments": `{}`},
+					},
+				},
+			},
+			map[string]any{"role": "tool", "content": "plain text result", "tool_call_id": "call_1"},
+		},
+	}
+
+	translated, _, _, err := NewVertexTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	contents := translated["contents"].([]map[string]any)
+	toolParts := contents[2]["parts"].([]map[string]any)
+	fr := toolParts[0]["functionResponse"].(map[string]any)
+	assert.Equal(t, "search", fr["name"])
+	response := fr["response"].(map[string]any)
+	assert.Equal(t, "plain text result", response["result"])
+}
+
+func TestTranslateRequest_ToolRoleUnknownCallID(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-2.5-flash",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Hi"},
+			map[string]any{"role": "tool", "content": `{"data": 1}`, "tool_call_id": "unknown_id"},
+		},
+	}
+
+	translated, _, _, err := NewVertexTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	contents := translated["contents"].([]map[string]any)
+	toolParts := contents[1]["parts"].([]map[string]any)
+	fr := toolParts[0]["functionResponse"].(map[string]any)
+	assert.Equal(t, "unknown", fr["name"])
+}
+
+func TestTranslateRequest_MultipleToolCalls(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-2.5-flash",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Get weather and time"},
+			map[string]any{
+				"role": "assistant",
+				"tool_calls": []any{
+					map[string]any{
+						"id":       "call_w",
+						"type":     "function",
+						"function": map[string]any{"name": "get_weather", "arguments": `{"city":"NYC"}`},
+					},
+					map[string]any{
+						"id":       "call_t",
+						"type":     "function",
+						"function": map[string]any{"name": "get_time", "arguments": `{"tz":"EST"}`},
+					},
+				},
+			},
+			map[string]any{"role": "tool", "content": `{"temp": 72}`, "tool_call_id": "call_w"},
+			map[string]any{"role": "tool", "content": `{"time": "12:00"}`, "tool_call_id": "call_t"},
+		},
+	}
+
+	translated, _, _, err := NewVertexTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	contents := translated["contents"].([]map[string]any)
+	require.Len(t, contents, 4)
+
+	// Assistant should have two functionCall parts
+	assistantParts := contents[1]["parts"].([]map[string]any)
+	require.Len(t, assistantParts, 2)
+	assert.NotNil(t, assistantParts[0]["functionCall"])
+	assert.NotNil(t, assistantParts[1]["functionCall"])
+
+	// Each tool response maps to the correct function name
+	fr1 := contents[2]["parts"].([]map[string]any)[0]["functionResponse"].(map[string]any)
+	assert.Equal(t, "get_weather", fr1["name"])
+
+	fr2 := contents[3]["parts"].([]map[string]any)[0]["functionResponse"].(map[string]any)
+	assert.Equal(t, "get_time", fr2["name"])
+}
+
+func TestTranslateRequest_AssistantWithTextAndToolCalls(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-2.5-flash",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "What's the weather?"},
+			map[string]any{
+				"role":    "assistant",
+				"content": "Let me check that for you.",
+				"tool_calls": []any{
+					map[string]any{
+						"id":       "call_1",
+						"type":     "function",
+						"function": map[string]any{"name": "get_weather", "arguments": `{}`},
+					},
+				},
+			},
+		},
+	}
+
+	translated, _, _, err := NewVertexTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	contents := translated["contents"].([]map[string]any)
+	assistantParts := contents[1]["parts"].([]map[string]any)
+	require.Len(t, assistantParts, 2)
+	assert.Equal(t, "Let me check that for you.", assistantParts[0]["text"])
+	assert.NotNil(t, assistantParts[1]["functionCall"])
+}
+
+// --- Multimodal tests ---
+
+func TestTranslateRequest_MultipleImageDataURIs(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-2.5-flash",
+		"messages": []any{
+			map[string]any{
+				"role": "user",
+				"content": []any{
+					map[string]any{"type": "text", "text": "Compare these images"},
+					map[string]any{"type": "image_url", "image_url": map[string]any{
+						"url": "data:image/jpeg;base64,/9j/4AAQ==",
+					}},
+					map[string]any{"type": "image_url", "image_url": map[string]any{
+						"url": "data:image/webp;base64,UklGR==",
+					}},
+				},
+			},
+		},
+	}
+
+	translated, _, _, err := NewVertexTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	contents := translated["contents"].([]map[string]any)
+	parts := contents[0]["parts"].([]map[string]any)
+	require.Len(t, parts, 3)
+	assert.Equal(t, "Compare these images", parts[0]["text"])
+
+	img1 := parts[1]["inlineData"].(map[string]any)
+	assert.Equal(t, "image/jpeg", img1["mimeType"])
+
+	img2 := parts[2]["inlineData"].(map[string]any)
+	assert.Equal(t, "image/webp", img2["mimeType"])
+}
+
+func TestParseDataURI(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		wantMime string
+		wantData string
+		wantOK   bool
+	}{
+		{"valid png", "data:image/png;base64,abc123", "image/png", "abc123", true},
+		{"valid jpeg", "data:image/jpeg;base64,/9j/4A==", "image/jpeg", "/9j/4A==", true},
+		{"http url", "https://example.com/img.png", "", "", false},
+		{"no base64 prefix", "data:image/png;abc123", "", "", false},
+		{"empty mime", "data:;base64,abc123", "", "", false},
+		{"empty data", "data:image/png;base64,", "", "", false},
+		{"no semicolon", "data:image/pngbase64,abc", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mime, data, ok := parseDataURI(tt.url)
+			assert.Equal(t, tt.wantOK, ok)
+			if ok {
+				assert.Equal(t, tt.wantMime, mime)
+				assert.Equal(t, tt.wantData, data)
+			}
+		})
+	}
 }
 
 // --- Response translation tests ---
@@ -990,9 +1489,9 @@ func TestTranslateResponse_UnknownFieldsIgnored(t *testing.T) {
 	body := map[string]any{
 		"candidates": []any{
 			map[string]any{
-				"content":          map[string]any{"parts": []any{map[string]any{"text": "hi"}}, "role": "model"},
-				"finishReason":     "STOP",
-				"safetyRatings":    []any{map[string]any{"category": "HARM_CATEGORY_HARASSMENT", "probability": "NEGLIGIBLE"}},
+				"content":      map[string]any{"parts": []any{map[string]any{"text": "hi"}}, "role": "model"},
+				"finishReason": "STOP",
+				"safetyRatings": []any{map[string]any{"category": "HARM_CATEGORY_HARASSMENT", "probability": "NEGLIGIBLE"}},
 				"citationMetadata": map[string]any{},
 			},
 		},


### PR DESCRIPTION
## Description

Fills four translation gaps in the Vertex AI (Gemini) translator that were documented limitations from the initial implementation (#32, #11). After this PR, the translator supports tool definitions, tool/function role messages, multimodal images (data URIs), and JSON mode.

**Gap 1 — Tool definitions + tool_choice:**
- Translates OpenAI `tools[]` to Vertex `tools[].functionDeclarations`
- Maps `tool_choice` to `toolConfig.functionCallingConfig` (`auto`→AUTO, `none`→NONE, `required`→ANY, specific function→ANY+allowedFunctionNames)
- Non-function tools (e.g. `type: "code_interpreter"`) are gracefully skipped

**Gap 2 — Tool/function role messages:**
- Assistant `tool_calls` → Vertex `functionCall` parts, with ID→name tracking
- `role: "tool"` messages → `functionResponse` parts (correlated via `tool_call_id`)
- `role: "function"` messages (legacy) → `functionResponse` parts (using `msg.name`)
- Non-JSON tool response content wrapped as `{"result": "..."}`

**Gap 3 — Multimodal image content:**
- Data URI images (`data:image/png;base64,...`) → Vertex `inlineData` parts
- HTTP/HTTPS image URLs gracefully skipped (stateless translator cannot download)
- Mixed text + image content arrays fully supported

**Gap 4 — JSON mode (response_format):**
- `response_format.type: "json_object"` or `"json_schema"` → `generationConfig.responseMimeType: "application/json"`

Closes #38

## How Has This Been Tested?

- **Unit tests** (`vertex_test.go` — 78 tests): All existing tests pass plus 18 new tests covering tool definitions (single, multiple, non-function skipped), tool_choice (auto, none, required, specific function), tool/function role messages (JSON and non-JSON content, unknown tool_call_id, missing function name), multimodal (data URI, HTTP URL skipped, multiple images), JSON mode (json_object, json_schema, text passthrough), assistant messages with mixed text and tool_calls, and parseDataURI edge cases
- **Integration tests** (`plugin_test.go`): All 4 existing Vertex integration tests pass
- **Full test suite**: `go test ./... -count=1` — all packages pass (api-translation, anthropic, azureopenai, vertex, apikey-injection, model-provider-resolver)
- **Static analysis**: `go vet ./...` clean, `golangci-lint run ./...` — 0 issues

**Real Gemini API validation** (generativelanguage.googleapis.com/v1beta):

| Test | Model | Result |
|------|-------|--------|
| Tool calling (`functionDeclarations` + `mode: ANY`) | gemini-2.5-flash-lite | PASS — returned `functionCall` with correct args |
| Tool round-trip (`functionCall` → `functionResponse`) | gemini-2.5-flash-lite | PASS — model used function result in response |
| JSON mode (`responseMimeType: application/json`) | gemini-flash-lite-latest | PASS — returned valid JSON |
| Multimodal (`inlineData` with base64 PNG) | gemini-flash-lite-latest | PASS — parsed and described image content |

**llm-katan simulator validation** (full Go pipeline: OpenAI request → `TranslateRequest()` → HTTP to simulator → `TranslateResponse()` → OpenAI response):

| Test | What it validates |
|------|-------------------|
| `TestE2E_BasicChat` | Baseline translation round-trip |
| `TestE2E_ToolDefinitions` | `tools[]` + `tool_choice: "auto"` translated and accepted |
| `TestE2E_ToolRoundTrip` | Assistant `tool_calls` → `functionCall`, then `role: "tool"` → `functionResponse` |
| `TestE2E_FunctionRole` | Legacy `role: "function"` → `functionResponse` |
| `TestE2E_JSONMode` | `response_format: json_object` → `responseMimeType` |
| `TestE2E_Multimodal` | Data URI image → `inlineData` parts |
| `TestE2E_SystemInstruction` | System message → `systemInstruction` |
| `TestE2E_ToolChoiceRequired` | `tool_choice: "required"` → `mode: ANY` |

All 8 E2E tests pass against llm-katan v0.7.3 at `3.150.113.9:8000`.


## Architecture Notes

- Vertex API requires `functionResponse` parts to use `role: "user"`, not a dedicated tool role
- HTTP image URLs are skipped because the translator is stateless and cannot download external resources
- Uses `v1beta` endpoint for `systemInstruction` compatibility (same as PR #32)
- Aligned with upstream refactor (PR #33): `providers/` → `translator/`, `*Provider` → `*Translator`