### PR TITLE
feat(anthropic): add tool definitions and tool role translation

### DIFF
--- a/pkg/plugins/api-translation/translator/anthropic/anthropic.go
+++ b/pkg/plugins/api-translation/translator/anthropic/anthropic.go
@@ -85,6 +85,13 @@ func (t *AnthropicTranslator) TranslateRequest(body map[string]any) (map[string]
 		translated["stop_sequences"] = stop
 	}
 
+	if tools := translateToolDefinitions(body); len(tools) > 0 {
+		translated["tools"] = tools
+		if toolChoice := translateToolChoice(body); toolChoice != nil {
+			translated["tool_choice"] = toolChoice
+		}
+	}
+
 	headers := map[string]string{
 		"anthropic-version": anthropicAPIVersion,
 		"content-type":      "application/json",
@@ -166,36 +173,153 @@ func translateAnthropicError(body map[string]any) map[string]any {
 // separateSystemMessages extracts the system prompt and returns non-system messages
 // in Anthropic format (with role and content fields).
 // Maps OpenAI "developer" role to Anthropic system prompt (concatenated with "system").
-// Returns an error for unsupported roles like "tool" or "function".
+// Translates "tool" role messages to Anthropic "tool_result" content blocks in a "user" message.
+// Translates assistant messages with "tool_calls" to Anthropic "tool_use" content blocks.
 func separateSystemMessages(messages []map[string]any) (string, []map[string]any, error) {
 	var systemParts []string
 	var anthropicMessages []map[string]any
 
 	for i, msg := range messages {
 		role, _ := msg["role"].(string)
-		content := extractContentString(msg)
 
 		switch role {
 		case "system", "developer":
+			content := extractContentString(msg)
 			systemParts = append(systemParts, content)
 		case "user":
+			content := extractContentString(msg)
 			anthropicMessages = append(anthropicMessages, map[string]any{
 				"role":    "user",
 				"content": content,
 			})
 		case "assistant":
-			anthropicMessages = append(anthropicMessages, map[string]any{
-				"role":    "assistant",
-				"content": content,
-			})
-		case "tool", "function":
-			return "", nil, fmt.Errorf("message at index %d has role '%s' which is not supported for Anthropic translation", i, role)
+			anthropicMessages = append(anthropicMessages, buildAssistantMessage(msg))
+		case "tool":
+			toolResultMsg, err := buildToolResultMessage(msg)
+			if err != nil {
+				return "", nil, fmt.Errorf("message at index %d: %w", i, err)
+			}
+			anthropicMessages = appendToolResult(anthropicMessages, toolResultMsg)
 		default:
 			return "", nil, fmt.Errorf("message at index %d has unknown role '%s'", i, role)
 		}
 	}
 
 	return joinStrings(systemParts, "\n"), anthropicMessages, nil
+}
+
+// buildAssistantMessage converts an OpenAI assistant message to Anthropic format.
+// If the message has tool_calls, they are translated to Anthropic tool_use content blocks.
+func buildAssistantMessage(msg map[string]any) map[string]any {
+	toolCalls, hasToolCalls := msg["tool_calls"].([]any)
+	if !hasToolCalls || len(toolCalls) == 0 {
+		return map[string]any{
+			"role":    "assistant",
+			"content": extractContentString(msg),
+		}
+	}
+
+	var contentBlocks []any
+
+	// Add text content block if present
+	if text := extractContentString(msg); text != "" {
+		contentBlocks = append(contentBlocks, map[string]any{
+			"type": "text",
+			"text": text,
+		})
+	}
+
+	// Convert each OpenAI tool_call to an Anthropic tool_use block
+	for _, tc := range toolCalls {
+		tcMap, ok := tc.(map[string]any)
+		if !ok {
+			continue
+		}
+		toolUse := translateToolCallToToolUse(tcMap)
+		if toolUse != nil {
+			contentBlocks = append(contentBlocks, toolUse)
+		}
+	}
+
+	return map[string]any{
+		"role":    "assistant",
+		"content": contentBlocks,
+	}
+}
+
+// translateToolCallToToolUse converts an OpenAI tool_call object to an Anthropic tool_use content block.
+func translateToolCallToToolUse(toolCall map[string]any) map[string]any {
+	id, _ := toolCall["id"].(string)
+	fn, ok := toolCall["function"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	name, _ := fn["name"].(string)
+
+	// Parse arguments from JSON string to map
+	var input any
+	if argsStr, ok := fn["arguments"].(string); ok {
+		var parsed any
+		if err := json.Unmarshal([]byte(argsStr), &parsed); err == nil {
+			input = parsed
+		} else {
+			input = map[string]any{}
+		}
+	} else {
+		// Already a map (e.g., from in-memory representation)
+		input = fn["arguments"]
+		if input == nil {
+			input = map[string]any{}
+		}
+	}
+
+	return map[string]any{
+		"type":  "tool_use",
+		"id":    id,
+		"name":  name,
+		"input": input,
+	}
+}
+
+// buildToolResultMessage converts an OpenAI "tool" role message to an Anthropic
+// "tool_result" content block wrapped in a "user" message.
+func buildToolResultMessage(msg map[string]any) (map[string]any, error) {
+	toolCallID, _ := msg["tool_call_id"].(string)
+	if toolCallID == "" {
+		return nil, fmt.Errorf("tool message missing required 'tool_call_id' field")
+	}
+
+	content := extractContentString(msg)
+
+	toolResult := map[string]any{
+		"type":        "tool_result",
+		"tool_use_id": toolCallID,
+	}
+	if content != "" {
+		toolResult["content"] = content
+	}
+
+	return toolResult, nil
+}
+
+// appendToolResult appends a tool_result content block to the message list.
+// If the last message is already a "user" message with content blocks (from a previous
+// tool result), the new block is merged into it. This handles the common pattern of
+// multiple consecutive tool results that Anthropic expects in a single user message.
+func appendToolResult(messages []map[string]any, toolResult map[string]any) []map[string]any {
+	if len(messages) > 0 {
+		last := messages[len(messages)-1]
+		if role, _ := last["role"].(string); role == "user" {
+			if blocks, ok := last["content"].([]any); ok {
+				last["content"] = append(blocks, toolResult)
+				return messages
+			}
+		}
+	}
+	return append(messages, map[string]any{
+		"role":    "user",
+		"content": []any{toolResult},
+	})
 }
 
 // extractMessages extracts the messages array from the request body.
@@ -385,6 +509,79 @@ func mapAnthropicUsage(body map[string]any) map[string]any {
 		"completion_tokens": outputTokens,
 		"total_tokens":      inputTokens + outputTokens,
 	}
+}
+
+// translateToolDefinitions converts OpenAI tools[] to Anthropic tools[] format.
+// OpenAI: {"type":"function","function":{"name":"X","description":"Y","parameters":{...}}}
+// Anthropic: {"name":"X","description":"Y","input_schema":{...}}
+func translateToolDefinitions(body map[string]any) []any {
+	tools, ok := body["tools"].([]any)
+	if !ok || len(tools) == 0 {
+		return nil
+	}
+
+	var anthropicTools []any
+	for _, tool := range tools {
+		toolMap, ok := tool.(map[string]any)
+		if !ok {
+			continue
+		}
+		fn, ok := toolMap["function"].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		anthropicTool := map[string]any{
+			"name": fn["name"],
+		}
+		if desc, ok := fn["description"].(string); ok && desc != "" {
+			anthropicTool["description"] = desc
+		}
+		if params, ok := fn["parameters"]; ok && params != nil {
+			anthropicTool["input_schema"] = params
+		} else {
+			// Anthropic requires input_schema; default to empty object schema
+			anthropicTool["input_schema"] = map[string]any{"type": "object"}
+		}
+
+		anthropicTools = append(anthropicTools, anthropicTool)
+	}
+
+	return anthropicTools
+}
+
+// translateToolChoice converts OpenAI tool_choice to Anthropic tool_choice format.
+// OpenAI "auto" → Anthropic {"type":"auto"}
+// OpenAI "required" → Anthropic {"type":"any"}
+// OpenAI "none" → Anthropic: omitted (return nil)
+// OpenAI {"type":"function","function":{"name":"X"}} → Anthropic {"type":"tool","name":"X"}
+func translateToolChoice(body map[string]any) map[string]any {
+	toolChoice, ok := body["tool_choice"]
+	if !ok {
+		return nil
+	}
+
+	if s, ok := toolChoice.(string); ok {
+		switch s {
+		case "auto":
+			return map[string]any{"type": "auto"}
+		case "required":
+			return map[string]any{"type": "any"}
+		default:
+			// "none" or unknown — omit tool_choice, letting Anthropic use default behavior
+			return nil
+		}
+	}
+
+	if tcMap, ok := toolChoice.(map[string]any); ok {
+		if fn, ok := tcMap["function"].(map[string]any); ok {
+			if name, ok := fn["name"].(string); ok {
+				return map[string]any{"type": "tool", "name": name}
+			}
+		}
+	}
+
+	return nil
 }
 
 // Helper functions for type-safe extraction from map[string]any

--- a/pkg/plugins/api-translation/translator/anthropic/anthropic_test.go
+++ b/pkg/plugins/api-translation/translator/anthropic/anthropic_test.go
@@ -427,19 +427,280 @@ func TestTranslateRequest_SystemAndDeveloperConcatenated(t *testing.T) {
 	assert.Equal(t, "Be concise.\nUse markdown.", translated["system"])
 }
 
-func TestTranslateRequest_ToolRoleRejected(t *testing.T) {
+func TestTranslateRequest_ToolDefinitions(t *testing.T) {
+	body := map[string]any{
+		"model": "claude-sonnet-4-20250514",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "What's the weather in SF?"},
+		},
+		"tools": []any{
+			map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name":        "get_weather",
+					"description": "Get weather for a location",
+					"parameters": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"location": map[string]any{"type": "string"},
+						},
+						"required": []any{"location"},
+					},
+				},
+			},
+		},
+	}
+
+	translated, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	tools := translated["tools"].([]any)
+	require.Len(t, tools, 1)
+
+	tool := tools[0].(map[string]any)
+	assert.Equal(t, "get_weather", tool["name"])
+	assert.Equal(t, "Get weather for a location", tool["description"])
+
+	schema := tool["input_schema"].(map[string]any)
+	assert.Equal(t, "object", schema["type"])
+	props := schema["properties"].(map[string]any)
+	loc := props["location"].(map[string]any)
+	assert.Equal(t, "string", loc["type"])
+}
+
+func TestTranslateRequest_ToolDefinitionsNoParams(t *testing.T) {
 	body := map[string]any{
 		"model": "claude-sonnet-4-20250514",
 		"messages": []any{
 			map[string]any{"role": "user", "content": "Hi"},
-			map[string]any{"role": "tool", "content": "result", "tool_call_id": "abc"},
+		},
+		"tools": []any{
+			map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name":        "get_time",
+					"description": "Get current time",
+				},
+			},
+		},
+	}
+
+	translated, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	tools := translated["tools"].([]any)
+	tool := tools[0].(map[string]any)
+	assert.Equal(t, "get_time", tool["name"])
+	// Should default to empty object schema
+	schema := tool["input_schema"].(map[string]any)
+	assert.Equal(t, "object", schema["type"])
+}
+
+func TestTranslateRequest_ToolChoice(t *testing.T) {
+	tests := []struct {
+		name       string
+		toolChoice any
+		expected   map[string]any
+	}{
+		{"auto", "auto", map[string]any{"type": "auto"}},
+		{"required", "required", map[string]any{"type": "any"}},
+		{"none", "none", nil},
+		{"specific function", map[string]any{
+			"type":     "function",
+			"function": map[string]any{"name": "get_weather"},
+		}, map[string]any{"type": "tool", "name": "get_weather"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := map[string]any{
+				"model":    "claude-sonnet-4-20250514",
+				"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+				"tools": []any{
+					map[string]any{
+						"type":     "function",
+						"function": map[string]any{"name": "get_weather", "description": "Get weather"},
+					},
+				},
+				"tool_choice": tt.toolChoice,
+			}
+
+			translated, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+			require.NoError(t, err)
+
+			if tt.expected == nil {
+				assert.Nil(t, translated["tool_choice"])
+			} else {
+				tc := translated["tool_choice"].(map[string]any)
+				assert.Equal(t, tt.expected["type"], tc["type"])
+				if name, ok := tt.expected["name"]; ok {
+					assert.Equal(t, name, tc["name"])
+				}
+			}
+		})
+	}
+}
+
+func TestTranslateRequest_ToolRoleTranslated(t *testing.T) {
+	body := map[string]any{
+		"model": "claude-sonnet-4-20250514",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "What's the weather in SF?"},
+			map[string]any{
+				"role":    "assistant",
+				"content": "I'll check the weather.",
+				"tool_calls": []any{
+					map[string]any{
+						"id":   "call_123",
+						"type": "function",
+						"function": map[string]any{
+							"name":      "get_weather",
+							"arguments": `{"location":"San Francisco"}`,
+						},
+					},
+				},
+			},
+			map[string]any{
+				"role":         "tool",
+				"content":      "72°F and sunny",
+				"tool_call_id": "call_123",
+			},
+			map[string]any{"role": "user", "content": "Thanks!"},
+		},
+		"tools": []any{
+			map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name":        "get_weather",
+					"description": "Get weather",
+					"parameters":  map[string]any{"type": "object"},
+				},
+			},
+		},
+	}
+
+	translated, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	msgs := translated["messages"].([]map[string]any)
+	require.Len(t, msgs, 4)
+
+	// First message: user
+	assert.Equal(t, "user", msgs[0]["role"])
+	assert.Equal(t, "What's the weather in SF?", msgs[0]["content"])
+
+	// Second message: assistant with tool_use content blocks
+	assert.Equal(t, "assistant", msgs[1]["role"])
+	assistantContent := msgs[1]["content"].([]any)
+	require.Len(t, assistantContent, 2)
+
+	textBlock := assistantContent[0].(map[string]any)
+	assert.Equal(t, "text", textBlock["type"])
+	assert.Equal(t, "I'll check the weather.", textBlock["text"])
+
+	toolUseBlock := assistantContent[1].(map[string]any)
+	assert.Equal(t, "tool_use", toolUseBlock["type"])
+	assert.Equal(t, "call_123", toolUseBlock["id"])
+	assert.Equal(t, "get_weather", toolUseBlock["name"])
+	input := toolUseBlock["input"].(map[string]any)
+	assert.Equal(t, "San Francisco", input["location"])
+
+	// Third message: user with tool_result content block
+	assert.Equal(t, "user", msgs[2]["role"])
+	toolResultContent := msgs[2]["content"].([]any)
+	require.Len(t, toolResultContent, 1)
+
+	toolResult := toolResultContent[0].(map[string]any)
+	assert.Equal(t, "tool_result", toolResult["type"])
+	assert.Equal(t, "call_123", toolResult["tool_use_id"])
+	assert.Equal(t, "72°F and sunny", toolResult["content"])
+
+	// Fourth message: user
+	assert.Equal(t, "user", msgs[3]["role"])
+	assert.Equal(t, "Thanks!", msgs[3]["content"])
+}
+
+func TestTranslateRequest_MultipleToolResults(t *testing.T) {
+	body := map[string]any{
+		"model": "claude-sonnet-4-20250514",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Weather in SF and NYC?"},
+			map[string]any{
+				"role": "assistant",
+				"tool_calls": []any{
+					map[string]any{
+						"id":       "call_1",
+						"type":     "function",
+						"function": map[string]any{"name": "get_weather", "arguments": `{"location":"SF"}`},
+					},
+					map[string]any{
+						"id":       "call_2",
+						"type":     "function",
+						"function": map[string]any{"name": "get_weather", "arguments": `{"location":"NYC"}`},
+					},
+				},
+			},
+			map[string]any{"role": "tool", "content": "72°F", "tool_call_id": "call_1"},
+			map[string]any{"role": "tool", "content": "65°F", "tool_call_id": "call_2"},
+		},
+	}
+
+	translated, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	msgs := translated["messages"].([]map[string]any)
+	require.Len(t, msgs, 3) // user, assistant, user (merged tool results)
+
+	// The two consecutive tool results should merge into one user message
+	toolResultMsg := msgs[2]
+	assert.Equal(t, "user", toolResultMsg["role"])
+	blocks := toolResultMsg["content"].([]any)
+	require.Len(t, blocks, 2)
+
+	assert.Equal(t, "call_1", blocks[0].(map[string]any)["tool_use_id"])
+	assert.Equal(t, "call_2", blocks[1].(map[string]any)["tool_use_id"])
+}
+
+func TestTranslateRequest_ToolRoleMissingCallID(t *testing.T) {
+	body := map[string]any{
+		"model": "claude-sonnet-4-20250514",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Hi"},
+			map[string]any{"role": "tool", "content": "result"},
 		},
 	}
 
 	_, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "tool")
-	assert.Contains(t, err.Error(), "not supported")
+	assert.Contains(t, err.Error(), "tool_call_id")
+}
+
+func TestTranslateRequest_AssistantToolCallsNoText(t *testing.T) {
+	body := map[string]any{
+		"model": "claude-sonnet-4-20250514",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Hi"},
+			map[string]any{
+				"role": "assistant",
+				"tool_calls": []any{
+					map[string]any{
+						"id":       "call_1",
+						"type":     "function",
+						"function": map[string]any{"name": "greet", "arguments": `{}`},
+					},
+				},
+			},
+		},
+	}
+
+	translated, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	msgs := translated["messages"].([]map[string]any)
+	assistantContent := msgs[1]["content"].([]any)
+	// Should only have tool_use block, no empty text block
+	require.Len(t, assistantContent, 1)
+	assert.Equal(t, "tool_use", assistantContent[0].(map[string]any)["type"])
 }
 
 func TestTranslateRequest_UnknownRoleRejected(t *testing.T) {
@@ -456,6 +717,8 @@ func TestTranslateRequest_UnknownRoleRejected(t *testing.T) {
 }
 
 func TestTranslateRequest_NonTextContentSkipped(t *testing.T) {
+	// Non-text content (images) is currently extracted as text-only.
+	// Full multimodal support is tracked in a separate issue.
 	body := map[string]any{
 		"model": "claude-sonnet-4-20250514",
 		"messages": []any{


### PR DESCRIPTION
## Summary
- Translate OpenAI `tools[]` to Anthropic `tools[]` format (`function.parameters` → `input_schema`)
- Translate `tool_choice` (`auto` → `{"type":"auto"}`, `required` → `{"type":"any"}`, specific function → `{"type":"tool","name":"X"}`)
- Handle `tool` role messages → Anthropic `tool_result` content blocks in `user` messages
- Merge consecutive tool results into a single `user` message (Anthropic API requirement)
- Translate assistant `tool_calls` in conversation history → Anthropic `tool_use` content blocks

Addresses the two biggest gaps from #37:
1. ~~Tool definitions in REQUEST are silently dropped~~
2. ~~"tool" and "function" role messages explicitly rejected~~

Remaining gaps (multimodal, JSON mode) tracked separately in #37.

## Test plan
- [x] Tool definitions with parameters translate correctly
- [x] Tool definitions without parameters default to `{"type":"object"}` schema
- [x] All `tool_choice` variants (auto, required, none, specific) translate correctly
- [x] Full tool-calling conversation loop (user → assistant+tool_calls → tool results → user)
- [x] Multiple consecutive tool results merge into one user message
- [x] Missing `tool_call_id` returns error
- [x] Assistant tool_calls without text content handled correctly
- [x] All existing tests continue to pass
- [x] Full repo test suite passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added comprehensive support for translating OpenAI tools and tool_choice specifications to Anthropic API format with proper parameter mapping
- Enhanced translation of assistant tool calls and tool result messages for more complex interaction patterns
- Improved overall compatibility for tool-based workflows between APIs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->