### PR TITLE
fix(provider-resolver): extract ExternalModelKind constant, validate empty modelName

### DIFF
--- a/pkg/plugins/model-provider-resolver/plugin.go
+++ b/pkg/plugins/model-provider-resolver/plugin.go
@@ -34,6 +34,7 @@ import (
 
 const (
 	ModelProviderResolverPluginType = "model-provider-resolver"
+	ExternalModelKind              = "ExternalModel"
 )
 
 // maasModelRefGVK is the GroupVersionKind for MaaSModelRef CRD.

--- a/pkg/plugins/model-provider-resolver/reconciler.go
+++ b/pkg/plugins/model-provider-resolver/reconciler.go
@@ -59,11 +59,16 @@ func (r *maasModelRefReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Extract spec.modelRef fields
 	kind, _, _ := unstructured.NestedString(obj.Object, "spec", "modelRef", "kind")
-	if kind != "ExternalModel" {
+	if kind != ExternalModelKind {
 		return ctrl.Result{}, nil
 	}
 
 	modelName, _, _ := unstructured.NestedString(obj.Object, "spec", "modelRef", "name")
+	if modelName == "" {
+		logger.Info("MaaSModelRef ExternalModel missing modelRef.name, skipping", "name", req.Name)
+		return ctrl.Result{}, nil
+	}
+
 	provider, _, _ := unstructured.NestedString(obj.Object, "spec", "modelRef", "provider")
 	if provider == "" {
 		logger.Info("MaaSModelRef ExternalModel missing provider, skipping", "name", req.Name)


### PR DESCRIPTION
## Summary
Sync provider-resolver with review comments from models-as-a-service [PR #597](https://github.com/opendatahub-io/models-as-a-service/pull/597):

- Extract `ExternalModelKind = "ExternalModel"` as a constant instead of hardcoded string
- Add early return when `modelRef.name` is empty to prevent storing entries keyed by `""` in the model store

## Test plan
- [x] Existing unit tests pass — no behavioral change for valid inputs
- [x] Full repo test suite passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for external models by checking for missing name references and logging when they're absent.

* **Refactor**
  * Enhanced code consistency by replacing hardcoded string literals with standardized model kind constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->