### PR TITLE
Support for AWS Bedrock, OpenAI endpoint and chat completions only

### DIFF
--- a/pkg/plugins/api-translation/plugin.go
+++ b/pkg/plugins/api-translation/plugin.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator/anthropic"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator/awsbedrock"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator/azureopenai"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator/vertex"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/provider"
@@ -53,9 +54,10 @@ func NewAPITranslationPlugin() *APITranslationPlugin {
 			Name: APITranslationPluginType,
 		},
 		providers: map[string]translator.Translator{
-			provider.Anthropic:   anthropic.NewAnthropicTranslator(),
-			provider.AzureOpenAI: azureopenai.NewAzureOpenAITranslator(),
-			provider.Vertex:      vertex.NewVertexTranslator(),
+			provider.Anthropic:        anthropic.NewAnthropicTranslator(),
+			provider.AzureOpenAI:      azureopenai.NewAzureOpenAITranslator(),
+			provider.Vertex:           vertex.NewVertexTranslator(),
+			provider.AWSBedrockOpenAI: awsbedrock.NewBedrockTranslator(),
 		},
 	}
 }

--- a/pkg/plugins/api-translation/translator/awsbedrock/awsbedrock.go
+++ b/pkg/plugins/api-translation/translator/awsbedrock/awsbedrock.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsbedrock
+
+import (
+	"fmt"
+)
+
+const (
+	// Bedrock OpenAI-compatible endpoint path
+	bedrockOpenAIPath = "/v1/chat/completions"
+)
+
+// BedrockApiType represents the type of Bedrock API to use
+type BedrockApiType string
+
+const (
+	ConverseApi BedrockApiType = "ConverseApi"
+	InvokeApi   BedrockApiType = "InvokeApi"
+	OpenAiApi   BedrockApiType = "OpenAiApi"
+)
+
+// BedrockTranslator translates OpenAI Chat Completions to AWS Bedrock's OpenAI-compatible API
+// This is a simple path rewriter since Bedrock's OpenAI-compatible endpoint uses the same format
+type BedrockTranslator struct {
+	apiType BedrockApiType
+}
+
+// NewBedrockTranslator creates a new AWS Bedrock translator instance
+func NewBedrockTranslator() *BedrockTranslator {
+	return &BedrockTranslator{
+		// Makes it clear that only Bedrock's OpenAi api endpoint is supported currently.
+		// Placeholder to set other Bedrock api types if supported in future.
+		apiType: OpenAiApi,
+	}
+}
+
+// TranslateRequest rewrites the path to target Bedrock's OpenAI-compatible endpoint.
+// The request body is not mutated since Bedrock's OpenAI-compatible API accepts the same schema as OpenAI.
+func (t *BedrockTranslator) TranslateRequest(body map[string]any) (
+	translatedBody map[string]any,
+	headersToMutate map[string]string,
+	headersToRemove []string,
+	err error,
+) {
+	// Validate required fields
+	model, ok := body["model"].(string)
+	if !ok || model == "" {
+		return nil, nil, nil, fmt.Errorf("model field is required")
+	}
+
+	// Validate that this is a chat completions request with proper messages
+	messagesRaw, hasMessages := body["messages"]
+	if !hasMessages {
+		return nil, nil, nil, fmt.Errorf("messages field is required for chat completions")
+	}
+
+	messages, ok := messagesRaw.([]interface{})
+	if !ok {
+		return nil, nil, nil, fmt.Errorf("messages field must be an array")
+	}
+
+	if len(messages) == 0 {
+		return nil, nil, nil, fmt.Errorf("messages array cannot be empty")
+	}
+
+	// Build headers for Bedrock OpenAI-compatible endpoint
+	headersToMutate = map[string]string{
+		":path":        bedrockOpenAIPath,
+		"content-type": "application/json",
+	}
+
+	// Return nil body — no body mutation needed, Bedrock accepts OpenAI request format as-is
+	return nil, headersToMutate, nil, nil
+}
+
+// TranslateResponse is a no-op since Bedrock's OpenAI-compatible API returns responses in OpenAI format
+func (t *BedrockTranslator) TranslateResponse(body map[string]any, model string) (
+	translatedBody map[string]any,
+	err error,
+) {
+	// No translation needed - Bedrock's OpenAI-compatible endpoint returns OpenAI format
+	return nil, nil
+}

--- a/pkg/plugins/api-translation/translator/awsbedrock/awsbedrock_test.go
+++ b/pkg/plugins/api-translation/translator/awsbedrock/awsbedrock_test.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsbedrock
+
+import (
+	"testing"
+
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTranslateRequest_BasicChat(t *testing.T) {
+	body := map[string]any{
+		"model": "nvidia.nemotron-nano-12b-v2",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "What is 2+2?"},
+		},
+	}
+
+	translatedBody, headers, headersToRemove, err := NewBedrockTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	assert.Nil(t, translatedBody, "body should not be mutated for Bedrock OpenAI-compatible API")
+	assert.Equal(t, "/v1/chat/completions", headers[":path"])
+	assert.Equal(t, "application/json", headers["content-type"])
+	assert.Empty(t, headersToRemove)
+}
+
+func TestTranslateRequest_PassthroughAllChatParams(t *testing.T) {
+	body := map[string]any{
+		"model": "nvidia.nemotron-nano-12b-v2",
+		"messages": []any{
+			map[string]any{"role": "system", "content": "You are helpful."},
+			map[string]any{"role": "user", "content": "Hello"},
+		},
+		"temperature":       0.7,
+		"top_p":             0.9,
+		"max_tokens":        1000,
+		"stream":            true,
+		"stop":              []any{"END"},
+		"n":                 1,
+		"presence_penalty":  0.5,
+		"frequency_penalty": 0.3,
+	}
+
+	translatedBody, _, _, err := NewBedrockTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	assert.Nil(t, translatedBody, "Bedrock OpenAI-compatible API should not mutate the request body")
+}
+
+func TestTranslateRequest_MissingModel(t *testing.T) {
+	body := map[string]any{
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+	}
+
+	_, _, _, err := NewBedrockTranslator().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "model field is required")
+}
+
+func TestTranslateRequest_EmptyModel(t *testing.T) {
+	body := map[string]any{
+		"model":    "",
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+	}
+
+	_, _, _, err := NewBedrockTranslator().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "model field is required")
+}
+
+func TestTranslateRequest_MissingMessages(t *testing.T) {
+	body := map[string]any{
+		"model": "nvidia.nemotron-nano-12b-v2",
+		// missing "messages" field
+	}
+
+	_, _, _, err := NewBedrockTranslator().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "messages field is required for chat completions")
+}
+
+func TestTranslateRequest_MessagesNotArray(t *testing.T) {
+	body := map[string]any{
+		"model":    "nvidia.nemotron-nano-12b-v2",
+		"messages": "not an array", // wrong type
+	}
+
+	_, _, _, err := NewBedrockTranslator().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "messages field must be an array")
+}
+
+func TestTranslateRequest_EmptyMessagesArray(t *testing.T) {
+	body := map[string]any{
+		"model":    "nvidia.nemotron-nano-12b-v2",
+		"messages": []any{}, // empty array
+	}
+
+	_, _, _, err := NewBedrockTranslator().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "messages array cannot be empty")
+}
+
+func TestTranslateRequest_HeadersSet(t *testing.T) {
+	body := map[string]any{
+		"model":    "nvidia.nemotron-nano-12b-v2",
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+	}
+
+	_, headers, _, err := NewBedrockTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	assert.Len(t, headers, 2)
+	assert.Contains(t, headers, ":path")
+	assert.Contains(t, headers, "content-type")
+}
+
+func TestTranslateResponse_Passthrough(t *testing.T) {
+	body := map[string]any{
+		"id":      "chatcmpl-abc123",
+		"object":  "chat.completion",
+		"created": 1700000000,
+		"model":   "nvidia.nemotron-nano-12b-v2",
+		"choices": []any{
+			map[string]any{
+				"index": 0,
+				"message": map[string]any{
+					"role":    "assistant",
+					"content": "The answer is 4.",
+				},
+				"finish_reason": "stop",
+			},
+		},
+		"usage": map[string]any{
+			"prompt_tokens":     10,
+			"completion_tokens": 5,
+			"total_tokens":      15,
+		},
+	}
+
+	translatedBody, err := NewBedrockTranslator().TranslateResponse(body, "nvidia.nemotron-nano-12b-v2")
+	require.NoError(t, err)
+	assert.Nil(t, translatedBody, "Bedrock OpenAI-compatible response should not be mutated")
+}
+
+func TestTranslateResponse_StreamingChunk(t *testing.T) {
+	body := map[string]any{
+		"id":      "chatcmpl-abc123",
+		"object":  "chat.completion.chunk",
+		"created": 1700000000,
+		"model":   "nvidia.nemotron-nano-12b-v2",
+		"choices": []any{
+			map[string]any{
+				"index": 0,
+				"delta": map[string]any{
+					"content": "Hello",
+				},
+				"finish_reason": nil,
+			},
+		},
+	}
+
+	translatedBody, err := NewBedrockTranslator().TranslateResponse(body, "nvidia.nemotron-nano-12b-v2")
+	require.NoError(t, err)
+	assert.Nil(t, translatedBody)
+}
+
+func TestTranslateResponse_Error(t *testing.T) {
+	body := map[string]any{
+		"error": map[string]any{
+			"message": "Model not found",
+			"type":    "invalid_request_error",
+			"code":    "model_not_found",
+		},
+	}
+
+	translatedBody, err := NewBedrockTranslator().TranslateResponse(body, "invalid-model")
+	require.NoError(t, err)
+	assert.Nil(t, translatedBody, "Error responses should pass through unchanged")
+}
+
+func TestProviderName(t *testing.T) {
+	assert.Equal(t, "awsbedrock-openai", provider.AWSBedrockOpenAI)
+}
+
+func TestNewBedrockTranslator(t *testing.T) {
+	translator := NewBedrockTranslator()
+	assert.NotNil(t, translator)
+	assert.Equal(t, OpenAiApi, translator.apiType)
+}

--- a/pkg/plugins/apikey-injection/plugin.go
+++ b/pkg/plugins/apikey-injection/plugin.go
@@ -62,10 +62,11 @@ func (inj *apiKeyGenerator) generateHeader(apiKey string) (string, string) {
 // defaultApiKeyGenerators returns the built-in provider-to-generator registry.
 func defaultApiKeyGenerators() map[string]*apiKeyGenerator {
 	return map[string]*apiKeyGenerator{
-		provider.OpenAI:      {headerName: "Authorization", headerValuePrefix: "Bearer "},
-		provider.Anthropic:   {headerName: "x-api-key"},
-		provider.AzureOpenAI: {headerName: "api-key"},
-		provider.Vertex:      {headerName: "Authorization", headerValuePrefix: "Bearer "},
+		provider.OpenAI:            {headerName: "Authorization", headerValuePrefix: "Bearer "},
+		provider.Anthropic:         {headerName: "x-api-key"},
+		provider.AzureOpenAI:       {headerName: "api-key"},
+		provider.Vertex:            {headerName: "Authorization", headerValuePrefix: "Bearer "},
+		provider.AWSBedrockOpenAI:  {headerName: "Authorization", headerValuePrefix: "Bearer "},
 	}
 }
 

--- a/pkg/plugins/apikey-injection/plugin_test.go
+++ b/pkg/plugins/apikey-injection/plugin_test.go
@@ -197,7 +197,7 @@ func TestDefaultInjectors(t *testing.T) {
 	assert.Equal(t, "Authorization", injectors[provider.Vertex].headerName)
 	assert.Equal(t, "Bearer ", injectors[provider.Vertex].headerValuePrefix)
 
-	assert.Len(t, injectors, 4)
+	assert.Len(t, injectors, 5)
 }
 
 func TestAPIKeyInjector(t *testing.T) {

--- a/pkg/plugins/common/provider/provider.go
+++ b/pkg/plugins/common/provider/provider.go
@@ -17,8 +17,9 @@ limitations under the License.
 package provider
 
 const (
-	OpenAI      = "openai"
-	Anthropic   = "anthropic"
-	AzureOpenAI = "azure-openai"
-	Vertex      = "vertex"
+	OpenAI            = "openai"
+	Anthropic         = "anthropic"
+	AzureOpenAI       = "azure-openai"
+	Vertex            = "vertex"
+	AWSBedrockOpenAI  = "awsbedrock-openai"
 )


### PR DESCRIPTION
## Description
  - Adds AWS Bedrock support
  - Targets the OpenAI-compatible endpoint (not Converse or Invoke APIs)
  - Supports chat completions only (not legacy completions API)

## How Has This Been Tested?
Unit tested. Will be tested manually e2e after this.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AWS Bedrock (OpenAI-compatible) provider support for chat completions, including request translation and required header handling.
  * Enabled API key injection for AWS Bedrock using the Authorization Bearer header.
* **Tests**
  * Added tests covering Bedrock request validation, header behavior, passthrough response handling, and provider integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->