### PR TITLE
refactor(apikey-injection): use custom predicate for managed-label filtering

### DIFF
--- a/pkg/plugins/apikey-injection/plugin.go
+++ b/pkg/plugins/apikey-injection/plugin.go
@@ -22,11 +22,9 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 
@@ -89,14 +87,7 @@ func NewAPIKeyInjectionPlugin(reconcilerBuilder func() *builder.Builder, clientR
 		store:  store,
 	}
 
-	labelPredicate, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{
-		MatchLabels: map[string]string{managedLabel: "true"},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to build label predicate for plugin '%s' - %w", APIKeyInjectionPluginType, err)
-	}
-
-	if err := reconcilerBuilder().For(&corev1.Secret{}).WithEventFilter(labelPredicate).Complete(reconciler); err != nil {
+	if err := reconcilerBuilder().For(&corev1.Secret{}).WithEventFilter(managedLabelPredicate()).Complete(reconciler); err != nil {
 		return nil, fmt.Errorf("failed to register Secret reconciler for plugin '%s' - %w", APIKeyInjectionPluginType, err)
 	}
 

--- a/pkg/plugins/apikey-injection/reconciler.go
+++ b/pkg/plugins/apikey-injection/reconciler.go
@@ -24,8 +24,27 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
+
+func hasManagedLabel(object client.Object) bool {
+	return object.GetLabels()[managedLabel] == "true"
+}
+
+// managedLabelPredicate filters events to only Secrets labeled with
+// "inference.networking.k8s.io/bbr-managed" = "true".
+// For updates, it accepts the event when either the old or new object carries
+// the label so that label-removal is visible to the reconciler.
+func managedLabelPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return hasManagedLabel(e.Object) },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return hasManagedLabel(e.ObjectOld) || hasManagedLabel(e.ObjectNew) },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return hasManagedLabel(e.Object) },
+		GenericFunc: func(e event.GenericEvent) bool { return hasManagedLabel(e.Object) },
+	}
+}
 
 // secretReconciler watches Secrets and updates the secretStore.
 type secretReconciler struct {
@@ -45,7 +64,7 @@ func (r *secretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, fmt.Errorf("unable to get Secret: %w", err)
 	}
 
-	if errors.IsNotFound(err) || !secret.DeletionTimestamp.IsZero() {
+	if errors.IsNotFound(err) || !secret.DeletionTimestamp.IsZero() || !hasManagedLabel(secret) {
 		r.store.delete(key)
 		return ctrl.Result{}, nil
 	}

--- a/pkg/plugins/apikey-injection/reconciler_test.go
+++ b/pkg/plugins/apikey-injection/reconciler_test.go
@@ -70,6 +70,7 @@ func TestReconcile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "no-data",
 					Namespace: "default",
+					Labels:    map[string]string{managedLabel: "true"},
 				},
 				Data: map[string][]byte{},
 			},
@@ -85,6 +86,7 @@ func TestReconcile(t *testing.T) {
 					Namespace:         "default",
 					DeletionTimestamp: &metav1.Time{Time: time.Now()},
 					Finalizers:        []string{"test-finalizer"},
+					Labels:            map[string]string{managedLabel: "true"},
 				},
 				Data: map[string][]byte{
 					secretDataKey: []byte("sk-key"),
@@ -92,6 +94,21 @@ func TestReconcile(t *testing.T) {
 			},
 			preSeed:   []*corev1.Secret{testSecret("default", "deleting", "sk-key")},
 			wantKey:   "default/deleting",
+			wantFound: false,
+		},
+		{
+			name: "Secret with managed label removed — removes from store",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "unlabeled",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					secretDataKey: []byte("sk-key"),
+				},
+			},
+			preSeed:   []*corev1.Secret{testSecret("default", "unlabeled", "sk-key")},
+			wantKey:   "default/unlabeled",
 			wantFound: false,
 		},
 	}

--- a/pkg/plugins/apikey-injection/store_test.go
+++ b/pkg/plugins/apikey-injection/store_test.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// testSecret builds a corev1.Secret for test seeding.
+// testSecret builds a labeled corev1.Secret for use in reconciler and store tests.
 func testSecret(namespace, name, apiKey string) *corev1.Secret {
 	if namespace == "" {
 		namespace = "default"
@@ -36,6 +36,7 @@ func testSecret(namespace, name, apiKey string) *corev1.Secret {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Labels:    map[string]string{managedLabel: "true"},
 		},
 		Data: map[string][]byte{
 			secretDataKey: []byte(apiKey),


### PR DESCRIPTION
## Description

Replace `predicate.LabelSelectorPredicate` with a custom `predicate.Funcs` in the apikey-injection plugin.


## How Has This Been Tested?

- All existing tests pass (`go test ./...`)
- Added new test case: "Secret with managed label removed — removes from store"
- Updated existing test Secrets to include the managed label where needed

Fixes #35 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * The API key injection plugin now uses a streamlined label-based approach to identify and manage secrets, improving reconciliation efficiency and ensuring proper cleanup when secret status changes.

* **Tests**
  * Test suite updated to validate label-based secret filtering and lifecycle handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->