### PR TITLE
feat: support ExternalModel CRD in model-provider-resolver

### DIFF
--- a/pkg/plugins/model-provider-resolver/plugin.go
+++ b/pkg/plugins/model-provider-resolver/plugin.go
@@ -36,11 +36,11 @@ const (
 	ModelProviderResolverPluginType = "model-provider-resolver"
 )
 
-// maasModelRefGVK is the GroupVersionKind for MaaSModelRef CRD.
-var maasModelRefGVK = schema.GroupVersionKind{
+// externalModelGVK is the GroupVersionKind for ExternalModel CRD.
+var externalModelGVK = schema.GroupVersionKind{
 	Group:   "maas.opendatahub.io",
 	Version: "v1alpha1",
-	Kind:    "MaaSModelRef",
+	Kind:    "ExternalModel",
 }
 
 // compile-time type validation
@@ -58,17 +58,17 @@ func ModelProviderResolverFactory(name string, _ json.RawMessage, handle framewo
 
 func NewModelProviderResolver(reconcilerBuilder func() *builder.Builder, clientReader client.Reader) (*ModelProviderResolverPlugin, error) {
 	modelInfoStore := newModelInfoStore()
-	reconciler := &maasModelRefReconciler{
+	reconciler := &externalModelReconciler{
 		Reader: clientReader,
 		store:  modelInfoStore,
 	}
 
-	// Watch MaaSModelRef CRDs using unstructured client (no MaaS type dependency)
+	// Watch ExternalModel CRDs directly (no MaaSModelRef dependency)
 	obj := &unstructured.Unstructured{}
-	obj.SetGroupVersionKind(maasModelRefGVK)
+	obj.SetGroupVersionKind(externalModelGVK)
 
 	if err := reconcilerBuilder().For(obj).Complete(reconciler); err != nil {
-		return nil, fmt.Errorf("failed to register MaaSModelRef reconciler for plugin '%s' - %w", ModelProviderResolverPluginType, err)
+		return nil, fmt.Errorf("failed to register ExternalModel reconciler for plugin '%s' - %w", ModelProviderResolverPluginType, err)
 	}
 
 	return &ModelProviderResolverPlugin{
@@ -77,7 +77,7 @@ func NewModelProviderResolver(reconcilerBuilder func() *builder.Builder, clientR
 	}, nil
 }
 
-// ModelProviderResolverPlugin resolves model names to provider info by watching MaaSModelRef CRDs.
+// ModelProviderResolverPlugin resolves model names to provider info by watching ExternalModel CRDs.
 // It writes the model, provider and credential reference to CycleState for downstream plugins
 // (api-translation, api-key-injection).
 type ModelProviderResolverPlugin struct {
@@ -97,7 +97,7 @@ func (p *ModelProviderResolverPlugin) WithName(name string) *ModelProviderResolv
 }
 
 // ProcessRequest reads the model name from the request body, resolves the provider
-// from the modelInfoStore (populated by MaaSModelRef reconciler), and writes model, provider
+// from the modelInfoStore (populated by ExternalModel reconciler), and writes model, provider
 // and credential reference info to CycleState.
 func (p *ModelProviderResolverPlugin) ProcessRequest(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceRequest) error {
 	if request == nil || request.Headers == nil || request.Body == nil {

--- a/pkg/plugins/model-provider-resolver/reconciler.go
+++ b/pkg/plugins/model-provider-resolver/reconciler.go
@@ -27,29 +27,31 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// maasModelRefReconciler watches MaaSModelRef CRDs (via unstructured client)
+// externalModelReconciler watches ExternalModel CRDs (via unstructured client)
 // and updates the model store with provider and credential information.
-type maasModelRefReconciler struct {
+type externalModelReconciler struct {
 	client.Reader
 	store *modelInfoStore
 }
 
-// Reconcile handles create/update/delete events for MaaSModelRef resources.
-func (r *maasModelRefReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+// Reconcile handles create/update/delete events for ExternalModel resources.
+// The ExternalModel CR name is used as the model key in the store, matching
+// the model name in inference request bodies.
+func (r *externalModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
-	logger.Info("Reconciling MaaSModelRef", "name", req.Name, "namespace", req.Namespace)
+	logger.Info("Reconciling ExternalModel", "name", req.Name, "namespace", req.Namespace)
 
 	obj := &unstructured.Unstructured{}
-	obj.SetGroupVersionKind(maasModelRefGVK)
+	obj.SetGroupVersionKind(externalModelGVK)
 
 	err := r.Get(ctx, req.NamespacedName, obj)
 	if errors.IsNotFound(err) {
 		r.store.deleteByResource(req.NamespacedName)
-		logger.Info("MaaSModelRef deleted, cleaned store", "name", req.Name)
+		logger.Info("ExternalModel deleted, cleaned store", "name", req.Name)
 		return ctrl.Result{}, nil
 	}
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("unable to get MaaSModelRef: %w", err)
+		return ctrl.Result{}, fmt.Errorf("unable to get ExternalModel: %w", err)
 	}
 
 	if !obj.GetDeletionTimestamp().IsZero() {
@@ -57,16 +59,10 @@ func (r *maasModelRefReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
-	// Extract spec.modelRef fields
-	kind, _, _ := unstructured.NestedString(obj.Object, "spec", "modelRef", "kind")
-	if kind != "ExternalModel" {
-		return ctrl.Result{}, nil
-	}
-
-	modelName, _, _ := unstructured.NestedString(obj.Object, "spec", "modelRef", "name")
-	provider, _, _ := unstructured.NestedString(obj.Object, "spec", "modelRef", "provider")
+	provider, _, _ := unstructured.NestedString(obj.Object, "spec", "provider")
 	if provider == "" {
-		logger.Info("MaaSModelRef ExternalModel missing provider, skipping", "name", req.Name)
+		logger.Info("ExternalModel missing provider, skipping", "name", req.Name)
+		r.store.deleteByResource(req.NamespacedName)
 		return ctrl.Result{}, nil
 	}
 
@@ -74,7 +70,7 @@ func (r *maasModelRefReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		provider: provider,
 	}
 
-	// Extract spec.credentialRef if present
+	// Extract credentialRef
 	credName, _, _ := unstructured.NestedString(obj.Object, "spec", "credentialRef", "name")
 	credNS, _, _ := unstructured.NestedString(obj.Object, "spec", "credentialRef", "namespace")
 	if credName != "" {
@@ -85,8 +81,9 @@ func (r *maasModelRefReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 	}
 
-	r.store.setModelInfo(modelName, info, req.NamespacedName)
-	logger.Info("Updated model store", "model", modelName, "provider", provider)
+	// ExternalModel name = model key (matches the model name in request body)
+	r.store.setModelInfo(req.Name, info, req.NamespacedName)
+	logger.Info("Updated model store", "model", req.Name, "provider", provider)
 
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
## Summary

Updates the `model-provider-resolver` plugin to work with the new `ExternalModel` CRD introduced in [MaaS PR #586](https://github.com/opendatahub-io/models-as-a-service/pull/586).

The reconciler now:
- Reads `spec.modelRef.name` as the ExternalModel CR name (not the model name directly)
- Fetches the `ExternalModel` CR via unstructured client from the same namespace
- Reads `provider` and `credentialRef` from the ExternalModel spec
- Stores using the MaaSModelRef name as the model key (matching request body model name)

No changes to the store, ProcessRequest, or downstream plugins (api-translation, apikey-injection).

## RBAC

BBR ClusterRole needs:
```yaml
- apiGroups: ["maas.opendatahub.io"]
  resources: ["externalmodels"]
  verbs: ["get", "list", "watch"]
```

## Test plan
- [x] Build passes
- [x] Unit tests pass
- [ ] Deploy to cluster with ExternalModel CRDs and verify end-to-end

Fixes #51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Model provider resolution now uses ExternalModel resources for provider configuration and storage.
  * Improved lookup and storage logic: model entries are keyed by the ExternalModel resource name and credential references are preserved.
* **Bug Fixes**
  * Stale store entries are removed when an ExternalModel no longer specifies a provider, ensuring cleaner state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->