### PR TITLE
feat: add deploy/rbac.yaml with required RBAC for BBR plugins

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,30 @@
+# Deploy
+
+RBAC manifests required by the AI Gateway Payload Processing BBR plugins.
+
+These are applied **in addition to** the upstream
+[body-based-routing Helm chart](https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/config/charts/body-based-routing)
+which provides the BBR Deployment and Service.
+
+## Prerequisites
+
+- A Kubernetes cluster with `kubectl` configured
+- `envsubst` (part of `gettext`, usually pre-installed on Linux/macOS)
+
+## Apply RBAC
+
+1. Set the `NAMESPACE` environment variable to the namespace where the BBR pod will run:
+    ```
+    export NAMESPACE=<your-namespace>
+    ```
+
+2. Deploy the RBAC resources:
+    ```
+    envsubst < deploy/rbac.yaml | kubectl apply -f -
+    ```
+
+## Cleanup
+
+```
+envsubst < deploy/rbac.yaml | kubectl delete -f -
+```

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -1,0 +1,45 @@
+# RBAC for AI Gateway Payload Processing (BBR with custom plugins).
+# Required permissions: Secrets (apikey-injection), ExternalModel CRDs
+# (model-provider-resolver), ConfigMaps (upstream BBR framework).
+#
+# Usage:
+#   export NAMESPACE=<your-namespace>
+#   envsubst < deploy/rbac.yaml | kubectl apply -f -
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ai-gateway-bbr
+  namespace: $NAMESPACE
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ai-gateway-bbr
+rules:
+  # apikey-injection plugin: watches labeled Secrets
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  # model-provider-resolver plugin: watches ExternalModel CRDs
+  - apiGroups: ["maas.opendatahub.io"]
+    resources: ["externalmodels"]
+    verbs: ["get", "list", "watch"]
+  # upstream BBR framework: cache tracks labeled ConfigMaps
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ai-gateway-bbr
+subjects:
+  - kind: ServiceAccount
+    name: ai-gateway-bbr
+    namespace: $NAMESPACE
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ai-gateway-bbr


### PR DESCRIPTION
## Description

Add `deploy/rbac.yaml` with the minimum RBAC manifests required to run the
ai-gateway-payload-processing BBR pod on a Kubernetes cluster.

The namespace is configurable via `$NAMESPACE` environment variable using `envsubst`,

The file contains three resources:

- **ServiceAccount** (`ai-gateway-bbr`) — identity for the BBR pod
- **ClusterRole** (`ai-gateway-bbr`) — read-only permissions for:
  - `secrets` (get/list/watch) — required by the `apikey-injection` plugin which watches labeled Secrets via a controller-runtime reconciler
  - `maasmodelrefs` in `maas.opendatahub.io` (get/list/watch) — required by the `model-provider-resolver` plugin which watches MaaSModelRef CRDs
  - `configmaps` (get/list/watch) — required by the upstream BBR framework cache setup
- **ClusterRoleBinding** — connects the ServiceAccount to the ClusterRole

ClusterRole (not Role) is used because Secrets and MaaSModelRefs may exist
across multiple namespaces.

Also adds `deploy/README.md` with usage instructions.

## How Has This Been Tested?

- YAML validated with `python3 -c "import yaml; yaml.safe_load_all(open(...))"` — 3 valid documents
- `export NAMESPACE=default && envsubst < deploy/rbac.yaml | kubectl apply --dry-run=client -f -` — accepted
- Applied on a Kind cluster with `envsubst` — all 3 resources created successfully
- `kubectl auth can-i` verified: list/watch/get secrets = yes, delete secrets = no

Resolves #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a deployment guide with step-by-step instructions for configuring RBAC and deploying the required access for the AI Gateway BBR integration.

* **Chores**
  * Added Kubernetes RBAC manifests that create a service account, cluster-wide read roles for relevant resources, and a binding to grant the integration the necessary cluster access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->