### PR TITLE
feat: add AWS Bedrock provider with SigV4 authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Binaries for programs and plugins
 bin/*
+main

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,6 +31,7 @@ import (
 
 	api_translation "github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation"
 	apikey_injection "github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/apikey-injection"
+	sigv4_signer "github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/aws-sigv4-signer"
 	provider_resolver "github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/model-provider-resolver"
 )
 
@@ -50,4 +51,5 @@ func registerPlugins() {
 	framework.Register(provider_resolver.ModelProviderResolverPluginType, provider_resolver.ModelProviderResolverFactory)
 	framework.Register(api_translation.APITranslationPluginType, api_translation.APITranslationFactory)
 	framework.Register(apikey_injection.APIKeyInjectionPluginType, apikey_injection.APIKeyInjectionFactory)
+	framework.Register(sigv4_signer.AWSSigV4SignerPluginType, sigv4_signer.AWSSigV4SignerFactory)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/opendatahub-io/ai-gateway-payload-processing
 go 1.25.0
 
 require (
+	github.com/aws/aws-sdk-go-v2 v1.41.4
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.12
 	github.com/stretchr/testify v1.11.1
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2
@@ -13,6 +15,7 @@ require (
 require (
 	cel.dev/expr v0.25.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
+	github.com/aws/smithy-go v1.24.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,12 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
+github.com/aws/aws-sdk-go-v2 v1.41.4 h1:10f50G7WyU02T56ox1wWXq+zTX9I1zxG46HYuG1hH/k=
+github.com/aws/aws-sdk-go-v2 v1.41.4/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
+github.com/aws/aws-sdk-go-v2/credentials v1.19.12 h1:oqtA6v+y5fZg//tcTWahyN9PEn5eDU/Wpvc2+kJ4aY8=
+github.com/aws/aws-sdk-go-v2/credentials v1.19.12/go.mod h1:U3R1RtSHx6NB0DvEQFGyf/0sbrpJrluENHdPy1j/3TE=
+github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
+github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/pkg/plugins/api-translation/plugin.go
+++ b/pkg/plugins/api-translation/plugin.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator/anthropic"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator/awsbedrock"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator/azureopenai"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator/vertex"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/provider"
@@ -53,9 +54,10 @@ func NewAPITranslationPlugin() *APITranslationPlugin {
 			Name: APITranslationPluginType,
 		},
 		providers: map[string]translator.Translator{
-			provider.Anthropic:   anthropic.NewAnthropicTranslator(),
+			provider.Anthropic:  anthropic.NewAnthropicTranslator(),
 			provider.AzureOpenAI: azureopenai.NewAzureOpenAITranslator(),
-			provider.Vertex:      vertex.NewVertexTranslator(),
+			provider.Vertex:     vertex.NewVertexTranslator(),
+			provider.AWSBedrock: awsbedrock.NewBedrockTranslator(),
 		},
 	}
 }

--- a/pkg/plugins/api-translation/translator/awsbedrock/awsbedrock.go
+++ b/pkg/plugins/api-translation/translator/awsbedrock/awsbedrock.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsbedrock
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	bedrockOpenAIPath = "/openai/v1/chat/completions"
+	defaultRegion     = "us-east-1"
+)
+
+// BedrockTranslator translates OpenAI Chat Completions requests for AWS Bedrock's
+// OpenAI-compatible endpoint. The request body is not mutated since Bedrock accepts
+// the same OpenAI format. Only the path and host headers are rewritten.
+type BedrockTranslator struct{}
+
+// NewBedrockTranslator creates a new AWS Bedrock translator.
+func NewBedrockTranslator() *BedrockTranslator {
+	return &BedrockTranslator{}
+}
+
+// TranslateRequest rewrites the path and host headers to target Bedrock's
+// OpenAI-compatible endpoint. The region is derived from the existing host
+// header (set by the ExternalModel endpoint field) or defaults to us-east-1.
+func (t *BedrockTranslator) TranslateRequest(body map[string]any) (
+	translatedBody map[string]any,
+	headersToMutate map[string]string,
+	headersToRemove []string,
+	err error,
+) {
+	model, ok := body["model"].(string)
+	if !ok || model == "" {
+		return nil, nil, nil, fmt.Errorf("model field is required")
+	}
+
+	if _, hasMessages := body["messages"]; !hasMessages {
+		return nil, nil, nil, fmt.Errorf("only Chat Completions API is supported — 'messages' field required")
+	}
+
+	headersToMutate = map[string]string{
+		":path":        bedrockOpenAIPath,
+		"content-type": "application/json",
+	}
+
+	return nil, headersToMutate, nil, nil
+}
+
+// TranslateResponse is a no-op — Bedrock's OpenAI-compatible endpoint returns
+// responses in standard OpenAI format.
+func (t *BedrockTranslator) TranslateResponse(body map[string]any, model string) (
+	translatedBody map[string]any,
+	err error,
+) {
+	return nil, nil
+}
+
+// RegionFromEndpoint extracts the AWS region from a Bedrock endpoint FQDN.
+// e.g., "bedrock-runtime.us-west-2.amazonaws.com" → "us-west-2"
+func RegionFromEndpoint(endpoint string) string {
+	// Expected format: bedrock-runtime.{region}.amazonaws.com
+	parts := strings.Split(endpoint, ".")
+	if len(parts) >= 3 && parts[0] == "bedrock-runtime" {
+		return parts[1]
+	}
+	return defaultRegion
+}

--- a/pkg/plugins/api-translation/translator/awsbedrock/awsbedrock_test.go
+++ b/pkg/plugins/api-translation/translator/awsbedrock/awsbedrock_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsbedrock
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTranslateRequest_BasicChat(t *testing.T) {
+	tr := NewBedrockTranslator()
+	body := map[string]any{
+		"model":    "us.amazon.nova-lite-v1:0",
+		"messages": []any{map[string]any{"role": "user", "content": "Hello"}},
+	}
+
+	translatedBody, headers, removed, err := tr.TranslateRequest(body)
+	require.NoError(t, err)
+	assert.Nil(t, translatedBody, "body should not be mutated")
+	assert.Equal(t, "/openai/v1/chat/completions", headers[":path"])
+	assert.Equal(t, "application/json", headers["content-type"])
+	assert.Empty(t, removed)
+}
+
+func TestTranslateRequest_MissingModel(t *testing.T) {
+	tr := NewBedrockTranslator()
+	body := map[string]any{
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+	}
+
+	_, _, _, err := tr.TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "model field is required")
+}
+
+func TestTranslateRequest_MissingMessages(t *testing.T) {
+	tr := NewBedrockTranslator()
+	body := map[string]any{
+		"model": "us.amazon.nova-lite-v1:0",
+	}
+
+	_, _, _, err := tr.TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "only Chat Completions API is supported")
+}
+
+func TestTranslateRequest_PassthroughParams(t *testing.T) {
+	tr := NewBedrockTranslator()
+	body := map[string]any{
+		"model": "us.amazon.nova-lite-v1:0",
+		"messages": []any{
+			map[string]any{"role": "system", "content": "Be concise"},
+			map[string]any{"role": "user", "content": "Hello"},
+		},
+		"temperature": 0.7,
+		"max_tokens":  1000,
+		"stream":      true,
+	}
+
+	translatedBody, _, _, err := tr.TranslateRequest(body)
+	require.NoError(t, err)
+	assert.Nil(t, translatedBody, "body should pass through unchanged")
+}
+
+func TestTranslateResponse_Passthrough(t *testing.T) {
+	tr := NewBedrockTranslator()
+	body := map[string]any{
+		"id":     "chatcmpl-abc123",
+		"object": "chat.completion",
+		"model":  "us.amazon.nova-lite-v1:0",
+		"choices": []any{
+			map[string]any{
+				"index":   0,
+				"message": map[string]any{"role": "assistant", "content": "Hello!"},
+			},
+		},
+	}
+
+	translatedBody, err := tr.TranslateResponse(body, "us.amazon.nova-lite-v1:0")
+	require.NoError(t, err)
+	assert.Nil(t, translatedBody, "response should pass through unchanged")
+}
+
+func TestRegionFromEndpoint(t *testing.T) {
+	tests := []struct {
+		endpoint string
+		want     string
+	}{
+		{"bedrock-runtime.us-east-1.amazonaws.com", "us-east-1"},
+		{"bedrock-runtime.us-west-2.amazonaws.com", "us-west-2"},
+		{"bedrock-runtime.eu-west-1.amazonaws.com", "eu-west-1"},
+		{"some-other-host.com", "us-east-1"},
+		{"", "us-east-1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.endpoint, func(t *testing.T) {
+			assert.Equal(t, tt.want, RegionFromEndpoint(tt.endpoint))
+		})
+	}
+}

--- a/pkg/plugins/aws-sigv4-signer/plugin.go
+++ b/pkg/plugins/aws-sigv4-signer/plugin.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws_sigv4_signer
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator/awsbedrock"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/provider"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/state"
+)
+
+const (
+	AWSSigV4SignerPluginType = "aws-sigv4-signer"
+	bedrockService          = "bedrock"
+)
+
+// compile-time type validation
+var _ framework.RequestProcessor = &AWSSigV4SignerPlugin{}
+
+// AWSSigV4SignerFactory creates a new AWSSigV4SignerPlugin.
+func AWSSigV4SignerFactory(name string, _ json.RawMessage, handle framework.Handle) (framework.BBRPlugin, error) {
+	return &AWSSigV4SignerPlugin{
+		typedName: plugin.TypedName{Type: AWSSigV4SignerPluginType, Name: name},
+		reader:    handle.ClientReader(),
+		signer:    v4.NewSigner(),
+	}, nil
+}
+
+// AWSSigV4SignerPlugin signs requests to AWS services using SigV4.
+// It reads AWS credentials from a K8s Secret referenced in CycleState
+// and computes a per-request signature.
+type AWSSigV4SignerPlugin struct {
+	typedName plugin.TypedName
+	reader    client.Reader
+	signer    *v4.Signer
+}
+
+func (p *AWSSigV4SignerPlugin) TypedName() plugin.TypedName {
+	return p.typedName
+}
+
+// ProcessRequest signs the request with AWS SigV4 if the provider is aws-bedrock.
+// For non-AWS providers, it's a no-op.
+func (p *AWSSigV4SignerPlugin) ProcessRequest(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceRequest) error {
+	if request == nil || request.Headers == nil {
+		return fmt.Errorf("request or headers is nil")
+	}
+
+	providerName, _ := framework.ReadCycleStateKey[string](cycleState, state.ProviderKey)
+	if providerName != provider.AWSBedrock {
+		return nil // not an AWS provider, skip
+	}
+
+	logger := log.FromContext(ctx)
+
+	// Read credential ref from CycleState
+	credsName, err := framework.ReadCycleStateKey[string](cycleState, state.CredsRefName)
+	if err != nil || credsName == "" {
+		return fmt.Errorf("aws-bedrock model missing credentialRef")
+	}
+	credsNamespace, err := framework.ReadCycleStateKey[string](cycleState, state.CredsRefNamespace)
+	if err != nil || credsNamespace == "" {
+		return fmt.Errorf("aws-bedrock model missing credentialRef namespace")
+	}
+
+	// Fetch the Secret
+	secret := &corev1.Secret{}
+	if err := p.reader.Get(ctx, types.NamespacedName{Name: credsName, Namespace: credsNamespace}, secret); err != nil {
+		return fmt.Errorf("failed to get AWS credentials secret %s/%s: %w", credsNamespace, credsName, err)
+	}
+
+	accessKey := string(secret.Data["aws-access-key-id"])
+	secretKey := string(secret.Data["aws-secret-access-key"])
+	sessionToken := string(secret.Data["aws-session-token"])
+
+	if accessKey == "" || secretKey == "" {
+		return fmt.Errorf("AWS credentials secret %s/%s missing aws-access-key-id or aws-secret-access-key", credsNamespace, credsName)
+	}
+
+	// Determine region from the host header or endpoint
+	host := request.Headers["host"]
+	if host == "" {
+		host = request.Headers[":authority"]
+	}
+	region := awsbedrock.RegionFromEndpoint(host)
+
+	// Build the HTTP request for signing
+	path := request.Headers[":path"]
+	if path == "" {
+		path = "/openai/v1/chat/completions"
+	}
+
+	bodyBytes, err := json.Marshal(request.Body)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request body for signing: %w", err)
+	}
+
+	url := fmt.Sprintf("https://%s%s", host, path)
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP request for signing: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Host", host)
+
+	// Compute payload hash
+	payloadHash := sha256Hash(bodyBytes)
+
+	// Create AWS credentials
+	creds := aws.Credentials{
+		AccessKeyID:     accessKey,
+		SecretAccessKey:  secretKey,
+		SessionToken:    sessionToken,
+		Source:          "MaaSSecret",
+	}
+
+	// Sign the request
+	err = p.signer.SignHTTP(ctx, creds, httpReq, payloadHash, bedrockService, region, time.Now())
+	if err != nil {
+		return fmt.Errorf("failed to sign request with SigV4: %w", err)
+	}
+
+	// Extract signed headers and inject into the inference request
+	request.SetHeader("Authorization", httpReq.Header.Get("Authorization"))
+	request.SetHeader("X-Amz-Date", httpReq.Header.Get("X-Amz-Date"))
+	if sessionToken != "" {
+		request.SetHeader("X-Amz-Security-Token", httpReq.Header.Get("X-Amz-Security-Token"))
+	}
+	request.SetHeader("X-Amz-Content-Sha256", payloadHash)
+
+	// Remove the original authorization header (if present from the client)
+	request.RemoveHeader("authorization")
+
+	logger.Info("AWS SigV4 signature applied", "region", region, "service", bedrockService)
+	return nil
+}
+
+// sha256Hash computes the hex-encoded SHA256 hash of data.
+func sha256Hash(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}
+
+// NewAWSSigV4SignerForTest creates a plugin for unit testing with an injected reader.
+func NewAWSSigV4SignerForTest(reader client.Reader) *AWSSigV4SignerPlugin {
+	return &AWSSigV4SignerPlugin{
+		typedName: plugin.TypedName{Type: AWSSigV4SignerPluginType, Name: AWSSigV4SignerPluginType},
+		reader:    reader,
+		signer:    v4.NewSigner(),
+	}
+}
+
+// credentialsProvider wraps static credentials for the signer.
+func credentialsProvider(accessKey, secretKey, sessionToken string) aws.CredentialsProvider {
+	return credentials.NewStaticCredentialsProvider(accessKey, secretKey, sessionToken)
+}

--- a/pkg/plugins/common/provider/provider.go
+++ b/pkg/plugins/common/provider/provider.go
@@ -17,8 +17,9 @@ limitations under the License.
 package provider
 
 const (
-	OpenAI      = "openai"
-	Anthropic   = "anthropic"
+	OpenAI     = "openai"
+	Anthropic  = "anthropic"
 	AzureOpenAI = "azure-openai"
-	Vertex      = "vertex"
+	Vertex     = "vertex"
+	AWSBedrock = "aws-bedrock"
 )


### PR DESCRIPTION
## Summary

Adds AWS Bedrock as a provider with two components:

1. **Bedrock translator** — rewrites path to `/openai/v1/chat/completions`, no body mutation
2. **AWS SigV4 signer plugin** — computes per-request SigV4 signatures using AWS SDK v2

Uses SigV4 (IAM credentials) instead of Bearer tokens for production-grade authentication.

## Changes
- `pkg/plugins/common/provider/provider.go` — add `AWSBedrock` constant
- `pkg/plugins/api-translation/translator/awsbedrock/` — Bedrock translator + tests
- `pkg/plugins/aws-sigv4-signer/plugin.go` — SigV4 signing plugin
- `pkg/plugins/api-translation/plugin.go` — register Bedrock translator
- `cmd/main.go` — register SigV4 signer plugin

## Test plan
- [x] Build passes
- [x] All unit tests pass (including 6 new Bedrock translator tests)
- [ ] E2E test with real Bedrock endpoint

Fixes #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AWS Bedrock as a supported API provider
  * Implemented AWS SigV4 request signing with credential handling
  * Added OpenAI-compatible request translation for Bedrock

* **Tests**
  * Added tests covering request translation, region extraction, and signing helpers

* **Chores**
  * Updated AWS SDK module requirements
  * Updated repository ignore rules to exclude a top-level main artifact
<!-- end of auto-generated comment: release notes by coderabbit.ai -->