### PR TITLE
Add build platform to support multi architecture

### DIFF
--- a/.tekton/odh-ai-gateway-payload-processing-ci-on-push.yaml
+++ b/.tekton/odh-ai-gateway-payload-processing-ci-on-push.yaml
@@ -31,6 +31,12 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-ai-gateway-payload-processing-ci-pull-request.yaml
+++ b/.tekton/odh-ai-gateway-payload-processing-ci-pull-request.yaml
@@ -37,6 +37,12 @@ spec:
   - name: additional-tags
     value:
     - 'odh-pr-{{revision}}'
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
Add build platform to support multi architecture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended CI/CD pipeline configurations to support building for multiple CPU architectures: x86_64, ARM64, PowerPC, and s390x.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->