### PR TITLE
feat: enable FIPS compliance in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,19 @@
 # Dockerfile has specific requirement to put this ARG at the beginning:
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
-ARG BUILDER_IMAGE=golang:1.25
-ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
+ARG GOLANG_VERSION=1.25
+
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
 ## Multistage build
-FROM ${BUILDER_IMAGE} AS builder
-ENV CGO_ENABLED=0
-ENV GOOS=linux
-ENV GOARCH=amd64
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:$GOLANG_VERSION AS builder
+ARG CGO_ENABLED=1
+ARG TARGETOS
+ARG TARGETARCH
 ARG COMMIT_SHA=unknown
 ARG BUILD_REF
+
+USER root
 
 # Dependencies
 WORKDIR /src
@@ -22,12 +26,15 @@ COPY pkg/ pkg/
 
 # -X needs the exact import path of the dependency's version package (matches go.mod / module graph).
 RUN VERSION_PKG="$(go list -f '{{.ImportPath}}' sigs.k8s.io/gateway-api-inference-extension/version)" && \
-	go build -ldflags="-X ${VERSION_PKG}.CommitSHA=${COMMIT_SHA} -X ${VERSION_PKG}.BuildRef=${BUILD_REF}" -o /bbr ./cmd
+	CGO_ENABLED=${CGO_ENABLED} GOEXPERIMENT=strictfipsruntime GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
+	go build -a -trimpath -ldflags="-s -w -X ${VERSION_PKG}.CommitSHA=${COMMIT_SHA} -X ${VERSION_PKG}.BuildRef=${BUILD_REF}" -o /bbr ./cmd
 
 # Multistage deploy
-FROM ${BASE_IMAGE}
+FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 WORKDIR /
 COPY --from=builder /bbr /bbr
+
+USER 1001
 
 ENTRYPOINT ["/bbr"]


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                  
  Update Dockerfile for FIPS 140-3 compliance by switching to UBI9 base images and enabling FIPS-certified operations.
                                                                                                                                                                                                                                              
  ## Description                                                                                                                                                                                                                              
  The current Dockerfile uses upstream `golang:1.25` builder and `gcr.io/distroless/static:nonroot` base images with `CGO_ENABLED=0`, which produces a statically-linked pure-Go binary that cannot use FIPS-certified cryptographic modules. 
  This PR updates the Dockerfile to be FIPS 140-3 compliant by:                                                                                                                                                                               
   
  - **Switching builder image** to `registry.access.redhat.com/ubi9/go-toolset` (Red Hat FIPS-capable Go toolchain)                                                                                                                           
  - **Switching base image** to `registry.access.redhat.com/ubi9/ubi-minimal` (includes glibc and OpenSSL for dynamic linking)
  - **Enabling CGO** (`CGO_ENABLED=1`) so the binary dynamically links to system OpenSSL                                                                                                                                                      
  - **Setting `GOEXPERIMENT=strictfipsruntime`** to enforce FIPS-certified BoringCrypto for all cryptographic operations (TLS, certificate validation, token handling via controller-runtime/client-go)                                       
  - **Adding multi-arch support** via `BUILDPLATFORM`/`TARGETPLATFORM`/`TARGETARCH` build args instead of hardcoded `GOARCH=amd64`                                                                                                            
  - **Adding build hardening flags** (`-a -trimpath -ldflags="-s -w"`)                                                                                                                                                                        
                                                                                                                                                                                                                                              
  ## How this was tested                                                                                                                                                                                                                      
                                                                                                                                                                                                                                              
  Built the image locally and verified:                                                                                                                                                                                                       
                                                            
  ```bash                                                                                                                                                                                                                                     
  # Build the image                                         
  docker buildx build -t ai-gateway-payload-processing:fips-test --platform=linux/amd64 --load -f Dockerfile .                                                                                                                                
                                                                                                                                                                                                                                              
  # Verify binary exists and is executable                                                                                                                                                                                                    
  podman run --rm --entrypoint="" ai-gateway-payload-processing:fips-test ls -la /bbr                                                                                                                                                         
                                                                                                                                                                                                                                              
  # Verify base image is RHEL 9 (UBI)                                                                                                                                                                                                         
  podman run --rm --entrypoint="" ai-gateway-payload-processing:fips-test cat /etc/os-release
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated container bases to Red Hat UBI for improved multi-platform support and FIPS-aligned runtime
  * Switched to platform-aware build configuration to support multiple target architectures
  * Optimized compilation pipeline with stricter flags and binary stripping for smaller, more secure artifacts
  * Standardized build/runtime user handling for consistent non-root execution across platforms
<!-- end of auto-generated comment: release notes by coderabbit.ai -->