### PR TITLE
feat: add AWS SigV4 signing plugin for Bedrock authentication

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,6 +31,7 @@ import (
 
 	api_translation "github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation"
 	apikey_injection "github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/apikey-injection"
+	sigv4_signer "github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/aws-sigv4-signer"
 	provider_resolver "github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/model-provider-resolver"
 )
 
@@ -50,4 +51,5 @@ func registerPlugins() {
 	framework.Register(provider_resolver.ModelProviderResolverPluginType, provider_resolver.ModelProviderResolverFactory)
 	framework.Register(api_translation.APITranslationPluginType, api_translation.APITranslationFactory)
 	framework.Register(apikey_injection.APIKeyInjectionPluginType, apikey_injection.APIKeyInjectionFactory)
+	framework.Register(sigv4_signer.AWSSigV4SignerPluginType, sigv4_signer.AWSSigV4SignerFactory)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/opendatahub-io/ai-gateway-payload-processing
 go 1.25.0
 
 require (
+	github.com/aws/aws-sdk-go-v2 v1.41.4
 	github.com/stretchr/testify v1.11.1
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2
@@ -13,6 +14,7 @@ require (
 require (
 	cel.dev/expr v0.25.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
+	github.com/aws/smithy-go v1.24.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,10 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
+github.com/aws/aws-sdk-go-v2 v1.41.4 h1:10f50G7WyU02T56ox1wWXq+zTX9I1zxG46HYuG1hH/k=
+github.com/aws/aws-sdk-go-v2 v1.41.4/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
+github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
+github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/pkg/plugins/apikey-injection/plugin.go
+++ b/pkg/plugins/apikey-injection/plugin.go
@@ -22,9 +22,11 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 
@@ -60,11 +62,10 @@ func (inj *apiKeyGenerator) generateHeader(apiKey string) (string, string) {
 // defaultApiKeyGenerators returns the built-in provider-to-generator registry.
 func defaultApiKeyGenerators() map[string]*apiKeyGenerator {
 	return map[string]*apiKeyGenerator{
-		provider.OpenAI:        {headerName: "Authorization", headerValuePrefix: "Bearer "},
-		provider.Anthropic:     {headerName: "x-api-key"},
-		provider.AzureOpenAI:   {headerName: "api-key"},
-		provider.Vertex:        {headerName: "Authorization", headerValuePrefix: "Bearer "},
-		provider.BedrockOpenAI: {headerName: "Authorization"}, // TODO THIS IS NOT WORKING
+		provider.OpenAI:      {headerName: "Authorization", headerValuePrefix: "Bearer "},
+		provider.Anthropic:   {headerName: "x-api-key"},
+		provider.AzureOpenAI: {headerName: "api-key"},
+		provider.Vertex:      {headerName: "Authorization", headerValuePrefix: "Bearer "},
 	}
 }
 
@@ -87,7 +88,14 @@ func NewAPIKeyInjectionPlugin(reconcilerBuilder func() *builder.Builder, clientR
 		store:  store,
 	}
 
-	if err := reconcilerBuilder().For(&corev1.Secret{}).WithEventFilter(managedLabelPredicate()).Complete(reconciler); err != nil {
+	labelPredicate, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{
+		MatchLabels: map[string]string{managedLabel: "true"},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to build label predicate for plugin '%s' - %w", APIKeyInjectionPluginType, err)
+	}
+
+	if err := reconcilerBuilder().For(&corev1.Secret{}).WithEventFilter(labelPredicate).Complete(reconciler); err != nil {
 		return nil, fmt.Errorf("failed to register Secret reconciler for plugin '%s' - %w", APIKeyInjectionPluginType, err)
 	}
 
@@ -130,11 +138,15 @@ func (p *ApiKeyInjectionPlugin) ProcessRequest(ctx context.Context, cycleState *
 		return fmt.Errorf("request or headers is nil")
 	}
 
-	// Check if this is an external model (provider set by provider-resolver).
-	// Internal models have no provider in CycleState and don't need API key injection.
-	providerName, err := framework.ReadCycleStateKey[string](cycleState, state.ProviderKey)
-	if err != nil || providerName == "" {
+	// Check if this is a provider that needs API key injection.
+	// Skip if: no provider (internal model) or provider not in generators map
+	// (e.g., aws-bedrock uses SigV4 signing instead of API key injection).
+	providerName, _ := framework.ReadCycleStateKey[string](cycleState, state.ProviderKey)
+	if providerName == "" {
 		return nil
+	}
+	if _, hasGenerator := p.apikeyGenerators[providerName]; !hasGenerator {
+		return nil // provider uses a different auth mechanism (e.g., SigV4)
 	}
 
 	credsName, err := framework.ReadCycleStateKey[string](cycleState, state.CredsRefName)

--- a/pkg/plugins/apikey-injection/plugin_test.go
+++ b/pkg/plugins/apikey-injection/plugin_test.go
@@ -91,14 +91,7 @@ func TestProcessRequest(t *testing.T) {
 				"Authorization": "Bearer vtx-key-456",
 			},
 		},
-		{
-			name:       "unknown provider — falls back to OpenAI Bearer format",
-			secrets:    []*corev1.Secret{testSecret("default", "no-provider", "sk-key")},
-			cycleState: newCycleState("default", "no-provider", "some-unknown-provider"),
-			wantHeaders: map[string]string{
-				"Authorization": "Bearer sk-key",
-			},
-		},
+		// unknown providers are skipped (not in generators map) — handled by TestProcessRequest_UnknownProvider_Skips
 	}
 
 	for _, tt := range tests {
@@ -158,7 +151,7 @@ func TestProcessRequestUnknownProviderFallback(t *testing.T) {
 
 	err := p.ProcessRequest(context.Background(), cs, req)
 	require.NoError(t, err)
-	assert.Equal(t, "Bearer key-789", req.Headers["Authorization"])
+	assert.Empty(t, req.Headers["Authorization"], "unknown provider should be skipped")
 }
 
 func TestProcessRequestNilRequest(t *testing.T) {
@@ -209,7 +202,7 @@ func TestDefaultInjectors(t *testing.T) {
 	assert.Equal(t, "Authorization", injectors[provider.Vertex].headerName)
 	assert.Equal(t, "Bearer ", injectors[provider.Vertex].headerValuePrefix)
 
-	assert.Len(t, injectors, 5)
+	assert.Len(t, injectors, 4) // Bedrock uses SigV4 signing, not API key injection
 }
 
 func TestAPIKeyInjector(t *testing.T) {

--- a/pkg/plugins/aws-sigv4-signer/plugin.go
+++ b/pkg/plugins/aws-sigv4-signer/plugin.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws_sigv4_signer
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/provider"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/state"
+)
+
+const (
+	AWSSigV4SignerPluginType = "aws-sigv4-signer"
+	bedrockService          = "bedrock"
+	defaultRegion           = "us-east-1"
+)
+
+// compile-time type validation
+var _ framework.RequestProcessor = &AWSSigV4SignerPlugin{}
+
+// AWSSigV4SignerFactory creates a new AWSSigV4SignerPlugin.
+func AWSSigV4SignerFactory(name string, _ json.RawMessage, handle framework.Handle) (framework.BBRPlugin, error) {
+	return &AWSSigV4SignerPlugin{
+		typedName: plugin.TypedName{Type: AWSSigV4SignerPluginType, Name: name},
+		reader:    handle.ClientReader(),
+		signer:    v4.NewSigner(),
+	}, nil
+}
+
+// AWSSigV4SignerPlugin signs requests to AWS services using SigV4.
+// It reads AWS credentials from a K8s Secret referenced in CycleState
+// and computes a per-request signature.
+type AWSSigV4SignerPlugin struct {
+	typedName plugin.TypedName
+	reader    client.Reader
+	signer    *v4.Signer
+}
+
+func (p *AWSSigV4SignerPlugin) TypedName() plugin.TypedName {
+	return p.typedName
+}
+
+// ProcessRequest signs the request with AWS SigV4 if the provider is bedrock-openai.
+// For non-AWS providers, it's a no-op.
+func (p *AWSSigV4SignerPlugin) ProcessRequest(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceRequest) error {
+	if request == nil || request.Headers == nil {
+		return fmt.Errorf("request or headers is nil")
+	}
+
+	providerName, _ := framework.ReadCycleStateKey[string](cycleState, state.ProviderKey)
+	if providerName != provider.BedrockOpenAI {
+		return nil // not a Bedrock provider, skip
+	}
+
+	logger := log.FromContext(ctx)
+
+	// Read credential ref from CycleState
+	credsName, err := framework.ReadCycleStateKey[string](cycleState, state.CredsRefName)
+	if err != nil || credsName == "" {
+		return fmt.Errorf("bedrock model missing credentialRef")
+	}
+	credsNamespace, err := framework.ReadCycleStateKey[string](cycleState, state.CredsRefNamespace)
+	if err != nil || credsNamespace == "" {
+		return fmt.Errorf("bedrock model missing credentialRef namespace")
+	}
+
+	// Fetch the Secret containing AWS credentials
+	secret := &corev1.Secret{}
+	if err := p.reader.Get(ctx, types.NamespacedName{Name: credsName, Namespace: credsNamespace}, secret); err != nil {
+		return fmt.Errorf("failed to get AWS credentials secret %s/%s: %w", credsNamespace, credsName, err)
+	}
+
+	accessKey := string(secret.Data["aws-access-key-id"])
+	secretKey := string(secret.Data["aws-secret-access-key"])
+	sessionToken := string(secret.Data["aws-session-token"])
+
+	if accessKey == "" || secretKey == "" {
+		return fmt.Errorf("AWS credentials secret %s/%s missing aws-access-key-id or aws-secret-access-key", credsNamespace, credsName)
+	}
+
+	// Determine region from the host header
+	host := request.Headers["host"]
+	if host == "" {
+		host = request.Headers[":authority"]
+	}
+	region := regionFromEndpoint(host)
+
+	// Build the HTTP request for signing
+	path := request.Headers[":path"]
+	if path == "" {
+		path = "/v1/chat/completions"
+	}
+
+	bodyBytes, err := json.Marshal(request.Body)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request body for signing: %w", err)
+	}
+
+	url := fmt.Sprintf("https://%s%s", host, path)
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP request for signing: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Host", host)
+
+	// Compute payload hash
+	payloadHash := sha256Hash(bodyBytes)
+
+	// Create AWS credentials
+	creds := aws.Credentials{
+		AccessKeyID:    accessKey,
+		SecretAccessKey: secretKey,
+		SessionToken:   sessionToken,
+		Source:         "MaaSSecret",
+	}
+
+	// Sign the request
+	err = p.signer.SignHTTP(ctx, creds, httpReq, payloadHash, bedrockService, region, time.Now())
+	if err != nil {
+		return fmt.Errorf("failed to sign request with SigV4: %w", err)
+	}
+
+	// Extract signed headers and inject into the inference request
+	request.SetHeader("Authorization", httpReq.Header.Get("Authorization"))
+	request.SetHeader("X-Amz-Date", httpReq.Header.Get("X-Amz-Date"))
+	if sessionToken != "" {
+		request.SetHeader("X-Amz-Security-Token", httpReq.Header.Get("X-Amz-Security-Token"))
+	}
+	request.SetHeader("X-Amz-Content-Sha256", payloadHash)
+
+	// Remove the original authorization header (if present from the client)
+	request.RemoveHeader("authorization")
+
+	logger.Info("AWS SigV4 signature applied", "region", region, "service", bedrockService)
+	return nil
+}
+
+// sha256Hash computes the hex-encoded SHA256 hash of data.
+func sha256Hash(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}
+
+// regionFromEndpoint extracts the AWS region from a Bedrock endpoint FQDN.
+// e.g., "bedrock-runtime.us-west-2.amazonaws.com" → "us-west-2"
+func regionFromEndpoint(endpoint string) string {
+	// Expected format: bedrock-runtime.{region}.amazonaws.com
+	parts := splitDots(endpoint)
+	if len(parts) >= 3 && parts[0] == "bedrock-runtime" {
+		return parts[1]
+	}
+	return defaultRegion
+}
+
+func splitDots(s string) []string {
+	result := []string{}
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '.' {
+			result = append(result, s[start:i])
+			start = i + 1
+		}
+	}
+	result = append(result, s[start:])
+	return result
+}

--- a/pkg/plugins/model-provider-resolver/plugin.go
+++ b/pkg/plugins/model-provider-resolver/plugin.go
@@ -36,11 +36,11 @@ const (
 	ModelProviderResolverPluginType = "model-provider-resolver"
 )
 
-// maasModelRefGVK is the GroupVersionKind for MaaSModelRef CRD.
-var maasModelRefGVK = schema.GroupVersionKind{
+// externalModelGVK is the GroupVersionKind for ExternalModel CRD.
+var externalModelGVK = schema.GroupVersionKind{
 	Group:   "maas.opendatahub.io",
 	Version: "v1alpha1",
-	Kind:    "MaaSModelRef",
+	Kind:    "ExternalModel",
 }
 
 // compile-time type validation
@@ -58,17 +58,17 @@ func ModelProviderResolverFactory(name string, _ json.RawMessage, handle framewo
 
 func NewModelProviderResolver(reconcilerBuilder func() *builder.Builder, clientReader client.Reader) (*ModelProviderResolverPlugin, error) {
 	modelInfoStore := newModelInfoStore()
-	reconciler := &maasModelRefReconciler{
+	reconciler := &externalModelReconciler{
 		Reader: clientReader,
 		store:  modelInfoStore,
 	}
 
-	// Watch MaaSModelRef CRDs using unstructured client (no MaaS type dependency)
+	// Watch ExternalModel CRDs directly (no MaaSModelRef dependency)
 	obj := &unstructured.Unstructured{}
-	obj.SetGroupVersionKind(maasModelRefGVK)
+	obj.SetGroupVersionKind(externalModelGVK)
 
 	if err := reconcilerBuilder().For(obj).Complete(reconciler); err != nil {
-		return nil, fmt.Errorf("failed to register MaaSModelRef reconciler for plugin '%s' - %w", ModelProviderResolverPluginType, err)
+		return nil, fmt.Errorf("failed to register ExternalModel reconciler for plugin '%s' - %w", ModelProviderResolverPluginType, err)
 	}
 
 	return &ModelProviderResolverPlugin{
@@ -77,7 +77,7 @@ func NewModelProviderResolver(reconcilerBuilder func() *builder.Builder, clientR
 	}, nil
 }
 
-// ModelProviderResolverPlugin resolves model names to provider info by watching MaaSModelRef CRDs.
+// ModelProviderResolverPlugin resolves model names to provider info by watching ExternalModel CRDs.
 // It writes the model, provider and credential reference to CycleState for downstream plugins
 // (api-translation, api-key-injection).
 type ModelProviderResolverPlugin struct {
@@ -97,7 +97,7 @@ func (p *ModelProviderResolverPlugin) WithName(name string) *ModelProviderResolv
 }
 
 // ProcessRequest reads the model name from the request body, resolves the provider
-// from the modelInfoStore (populated by MaaSModelRef reconciler), and writes model, provider
+// from the modelInfoStore (populated by ExternalModel reconciler), and writes model, provider
 // and credential reference info to CycleState.
 func (p *ModelProviderResolverPlugin) ProcessRequest(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceRequest) error {
 	if request == nil || request.Headers == nil || request.Body == nil {

--- a/pkg/plugins/model-provider-resolver/reconciler.go
+++ b/pkg/plugins/model-provider-resolver/reconciler.go
@@ -27,29 +27,31 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// maasModelRefReconciler watches MaaSModelRef CRDs (via unstructured client)
+// externalModelReconciler watches ExternalModel CRDs (via unstructured client)
 // and updates the model store with provider and credential information.
-type maasModelRefReconciler struct {
+type externalModelReconciler struct {
 	client.Reader
 	store *modelInfoStore
 }
 
-// Reconcile handles create/update/delete events for MaaSModelRef resources.
-func (r *maasModelRefReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+// Reconcile handles create/update/delete events for ExternalModel resources.
+// The ExternalModel CR name is used as the model key in the store, matching
+// the model name in inference request bodies.
+func (r *externalModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
-	logger.Info("Reconciling MaaSModelRef", "name", req.Name, "namespace", req.Namespace)
+	logger.Info("Reconciling ExternalModel", "name", req.Name, "namespace", req.Namespace)
 
 	obj := &unstructured.Unstructured{}
-	obj.SetGroupVersionKind(maasModelRefGVK)
+	obj.SetGroupVersionKind(externalModelGVK)
 
 	err := r.Get(ctx, req.NamespacedName, obj)
 	if errors.IsNotFound(err) {
 		r.store.deleteByResource(req.NamespacedName)
-		logger.Info("MaaSModelRef deleted, cleaned store", "name", req.Name)
+		logger.Info("ExternalModel deleted, cleaned store", "name", req.Name)
 		return ctrl.Result{}, nil
 	}
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("unable to get MaaSModelRef: %w", err)
+		return ctrl.Result{}, fmt.Errorf("unable to get ExternalModel: %w", err)
 	}
 
 	if !obj.GetDeletionTimestamp().IsZero() {
@@ -57,16 +59,10 @@ func (r *maasModelRefReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
-	// Extract spec.modelRef fields
-	kind, _, _ := unstructured.NestedString(obj.Object, "spec", "modelRef", "kind")
-	if kind != "ExternalModel" {
-		return ctrl.Result{}, nil
-	}
-
-	modelName, _, _ := unstructured.NestedString(obj.Object, "spec", "modelRef", "name")
-	provider, _, _ := unstructured.NestedString(obj.Object, "spec", "modelRef", "provider")
+	provider, _, _ := unstructured.NestedString(obj.Object, "spec", "provider")
 	if provider == "" {
-		logger.Info("MaaSModelRef ExternalModel missing provider, skipping", "name", req.Name)
+		logger.Info("ExternalModel missing provider, skipping", "name", req.Name)
+		r.store.deleteByResource(req.NamespacedName)
 		return ctrl.Result{}, nil
 	}
 
@@ -74,7 +70,7 @@ func (r *maasModelRefReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		provider: provider,
 	}
 
-	// Extract spec.credentialRef if present
+	// Extract credentialRef
 	credName, _, _ := unstructured.NestedString(obj.Object, "spec", "credentialRef", "name")
 	credNS, _, _ := unstructured.NestedString(obj.Object, "spec", "credentialRef", "namespace")
 	if credName != "" {
@@ -85,8 +81,9 @@ func (r *maasModelRefReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 	}
 
-	r.store.setModelInfo(modelName, info, req.NamespacedName)
-	logger.Info("Updated model store", "model", modelName, "provider", provider)
+	// ExternalModel name = model key (matches the model name in request body)
+	r.store.setModelInfo(req.Name, info, req.NamespacedName)
+	logger.Info("Updated model store", "model", req.Name, "provider", provider)
 
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
## Summary

Adds a new `aws-sigv4-signer` BBR plugin that computes per-request AWS SigV4 signatures for Bedrock inference requests. This complements the basic Bedrock OpenAI translator from PR #48 (by @srampal) with production-grade IAM authentication.

## Changes

- **New plugin**: `pkg/plugins/aws-sigv4-signer/plugin.go` — SigV4 signing
- **apikey-injection**: Skip providers without a generator match (Bedrock uses SigV4, not API keys)
- **provider-resolver**: Watch ExternalModel CRDs directly (from PR #52)
- **main.go**: Register aws-sigv4-signer plugin

## Verified on cluster

BBR logs confirm: `"AWS SigV4 signature applied" region=us-east-1 service=bedrock`

Full plugin chain: body-field-to-header → model-provider-resolver → api-translation → apikey-injection (skipped) → aws-sigv4-signer ✓

## Test plan
- [x] Build passes
- [x] All tests pass
- [x] Deployed and tested on RHOAI cluster
- [ ] E2E with real Bedrock endpoint (pending SigV4 simulator support)

Fixes #59

Co-authored-by: Sanjeev Rampal <srampal@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AWS SigV4 request signing plugin for Bedrock authentication using AWS credentials.

* **Updates**
  * Modified API key injection behavior to conditionally support providers.
  * Updated model provider resolver to reference new CRD specification.

* **Chores**
  * Added AWS SDK dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->