### PR TITLE
Refactor Azure response stripping to use configurable field paths

### DIFF
--- a/pkg/plugins/api-translation/translator/azure/azure_openai.go
+++ b/pkg/plugins/api-translation/translator/azure/azure_openai.go
@@ -31,15 +31,23 @@ const (
 // compile-time interface check
 var _ translator.Translator = &AzureOpenAITranslator{}
 
-// NewAzureOpenAITranslator initializes a new AzureOpenAITranslator and returns its pointer.
+// NewAzureOpenAITranslator initializes a new AzureOpenAITranslator.
 func NewAzureOpenAITranslator() *AzureOpenAITranslator {
-	return &AzureOpenAITranslator{}
+	return &AzureOpenAITranslator{
+		stripper: translator.NewResponseFieldStripper([]string{
+			"prompt_filter_results",
+			"choices[].content_filter_results",
+		}),
+	}
 }
 
 // AzureOpenAITranslator translates between OpenAI Chat Completions format and
 // Azure OpenAI Service format. Azure OpenAI uses the same request/response schema
-// as OpenAI, so translation is limited to path rewriting and header adjustments.
-type AzureOpenAITranslator struct{}
+// as OpenAI, so translation is limited to path rewriting, header adjustments,
+// and stripping provider-specific response fields.
+type AzureOpenAITranslator struct {
+	stripper *translator.ResponseFieldStripper
+}
 
 // TranslateRequest rewrites the path and headers for Azure OpenAI v1 API.
 // The request body is not mutated since Azure OpenAI accepts the same schema as OpenAI.
@@ -57,29 +65,8 @@ func (t *AzureOpenAITranslator) TranslateRequest(body map[string]any) (map[strin
 	return nil, headers, nil, nil
 }
 
-// TranslateResponse strips Azure-specific fields (content_filter_results, prompt_filter_results)
-// from the response body, returning a clean OpenAI-compatible response.
+// TranslateResponse strips configured provider-specific fields from the response body.
 func (t *AzureOpenAITranslator) TranslateResponse(body map[string]any, model string) (map[string]any, error) {
-	mutated := false
-
-	if _, ok := body["prompt_filter_results"]; ok {
-		delete(body, "prompt_filter_results")
-		mutated = true
-	}
-
-	if choices, ok := body["choices"].([]any); ok {
-		for _, raw := range choices {
-			if choice, ok := raw.(map[string]any); ok {
-				if _, ok := choice["content_filter_results"]; ok {
-					delete(choice, "content_filter_results")
-					mutated = true
-				}
-			}
-		}
-	}
-
-	if !mutated {
-		return nil, nil
-	}
-	return body, nil
+	result, _ := t.stripper.Strip(body)
+	return result, nil
 }

--- a/pkg/plugins/api-translation/translator/azure/azure_openai.go
+++ b/pkg/plugins/api-translation/translator/azure/azure_openai.go
@@ -31,7 +31,7 @@ const (
 // compile-time interface check
 var _ translator.Translator = &AzureOpenAITranslator{}
 
-// NewAzureOpenAITranslator initializes a new AzureOpenAITranslator.
+// NewAzureOpenAITranslator initializes a new AzureOpenAITranslator and returns its pointer.
 func NewAzureOpenAITranslator() *AzureOpenAITranslator {
 	return &AzureOpenAITranslator{
 		stripper: translator.NewResponseFieldStripper([]string{

--- a/pkg/plugins/api-translation/translator/response_field_stripper.go
+++ b/pkg/plugins/api-translation/translator/response_field_stripper.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package translator
+
+import "strings"
+
+// ResponseFieldStripper removes provider-specific fields from a response body
+// based on configurable dot-separated paths. Any translator that wraps an
+// OpenAI-compatible provider can use this to strip extra fields before returning
+// the response to the client.
+//
+// Path format conventions:
+//   - "prompt_filter_results"            → deletes a top-level key
+//   - "choices[].content_filter_results" → iterates an array and deletes from each element
+//   - "metadata.debug_info"              → navigates into a nested object and deletes the leaf key
+type ResponseFieldStripper struct {
+	fieldPaths []fieldPath
+}
+
+// NewResponseFieldStripper creates a stripper that will remove the given field paths
+// from response bodies. Paths are parsed once at construction time.
+// Pass nil or an empty slice for a no-op stripper.
+func NewResponseFieldStripper(fieldsToStrip []string) *ResponseFieldStripper {
+	return &ResponseFieldStripper{
+		fieldPaths: parseFieldPaths(fieldsToStrip),
+	}
+}
+
+// Strip walks the configured field paths and removes matching fields from the body.
+// Returns the mutated body and true if at least one field was removed.
+// If nothing was removed, returns nil and false.
+func (s *ResponseFieldStripper) Strip(body map[string]any) (map[string]any, bool) {
+	mutated := false
+	for _, fp := range s.fieldPaths {
+		if stripField(body, fp, 0) {
+			mutated = true
+		}
+	}
+	if !mutated {
+		return nil, false
+	}
+	return body, true
+}
+
+// fieldSegment represents one segment of a dot-separated strip path.
+type fieldSegment struct {
+	key     string
+	isArray bool // true when the segment had a "[]" suffix
+}
+
+// fieldPath is a parsed sequence of segments.
+type fieldPath []fieldSegment
+
+// parseFieldPaths converts raw dot-separated path strings into parsed fieldPaths.
+func parseFieldPaths(raw []string) []fieldPath {
+	paths := make([]fieldPath, 0, len(raw))
+	for _, r := range raw {
+		parts := strings.Split(r, ".")
+		segments := make(fieldPath, 0, len(parts))
+		for _, p := range parts {
+			if strings.HasSuffix(p, "[]") {
+				segments = append(segments, fieldSegment{key: strings.TrimSuffix(p, "[]"), isArray: true})
+			} else {
+				segments = append(segments, fieldSegment{key: p})
+			}
+		}
+		paths = append(paths, segments)
+	}
+	return paths
+}
+
+// stripField recursively walks the body according to the parsed path and deletes
+// the leaf key. Returns true if at least one deletion occurred.
+func stripField(obj map[string]any, path fieldPath, idx int) bool {
+	if idx >= len(path) {
+		return false
+	}
+
+	seg := path[idx]
+	isLast := idx == len(path)-1
+
+	if isLast {
+		if _, ok := obj[seg.key]; ok {
+			delete(obj, seg.key)
+			return true
+		}
+		return false
+	}
+
+	if seg.isArray {
+		arr, ok := obj[seg.key].([]any)
+		if !ok {
+			return false
+		}
+		mutated := false
+		for _, elem := range arr {
+			if m, ok := elem.(map[string]any); ok {
+				if stripField(m, path, idx+1) {
+					mutated = true
+				}
+			}
+		}
+		return mutated
+	}
+
+	child, ok := obj[seg.key].(map[string]any)
+	if !ok {
+		return false
+	}
+	return stripField(child, path, idx+1)
+}

--- a/pkg/plugins/api-translation/translator/response_field_stripper_test.go
+++ b/pkg/plugins/api-translation/translator/response_field_stripper_test.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package translator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStrip_TopLevelField(t *testing.T) {
+	body := map[string]any{
+		"id":                    "chatcmpl-abc123",
+		"object":                "chat.completion",
+		"prompt_filter_results": []any{map[string]any{"prompt_index": float64(0)}},
+	}
+
+	stripper := NewResponseFieldStripper([]string{"prompt_filter_results"})
+	result, mutated := stripper.Strip(body)
+
+	require.True(t, mutated)
+	require.NotNil(t, result)
+	assert.NotContains(t, result, "prompt_filter_results")
+	assert.Equal(t, "chatcmpl-abc123", result["id"])
+}
+
+func TestStrip_ArrayElementField(t *testing.T) {
+	body := map[string]any{
+		"choices": []any{
+			map[string]any{
+				"index":                  float64(0),
+				"content_filter_results": map[string]any{"hate": "safe"},
+				"message":                map[string]any{"role": "assistant", "content": "Hi"},
+			},
+			map[string]any{
+				"index":                  float64(1),
+				"content_filter_results": map[string]any{"hate": "safe"},
+				"message":                map[string]any{"role": "assistant", "content": "Hello"},
+			},
+		},
+	}
+
+	stripper := NewResponseFieldStripper([]string{"choices[].content_filter_results"})
+	result, mutated := stripper.Strip(body)
+
+	require.True(t, mutated)
+	require.NotNil(t, result)
+	choices := result["choices"].([]any)
+	for i, raw := range choices {
+		choice := raw.(map[string]any)
+		assert.NotContains(t, choice, "content_filter_results", "choices[%d]", i)
+		assert.Contains(t, choice, "message", "choices[%d]", i)
+	}
+}
+
+func TestStrip_NestedMapPath(t *testing.T) {
+	body := map[string]any{
+		"id":     "chatcmpl-abc123",
+		"object": "chat.completion",
+		"metadata": map[string]any{
+			"internal_id": "xyz",
+			"debug_info":  "should-be-stripped",
+			"region":      "eastus",
+		},
+	}
+
+	stripper := NewResponseFieldStripper([]string{"metadata.debug_info"})
+	result, mutated := stripper.Strip(body)
+
+	require.True(t, mutated)
+	require.NotNil(t, result)
+	metadata := result["metadata"].(map[string]any)
+	assert.NotContains(t, metadata, "debug_info")
+	assert.Equal(t, "xyz", metadata["internal_id"])
+	assert.Equal(t, "eastus", metadata["region"])
+}
+
+func TestStrip_MultiplePaths(t *testing.T) {
+	body := map[string]any{
+		"id":     "chatcmpl-abc123",
+		"object": "chat.completion",
+		"choices": []any{
+			map[string]any{
+				"index":                  float64(0),
+				"content_filter_results": map[string]any{"hate": "safe"},
+				"custom_provider_field":  "should-be-stripped",
+				"message":                map[string]any{"role": "assistant", "content": "Hello!"},
+			},
+		},
+		"prompt_filter_results": []any{map[string]any{"prompt_index": float64(0)}},
+		"system_fingerprint":    "fp_abc123",
+	}
+
+	stripper := NewResponseFieldStripper([]string{
+		"system_fingerprint",
+		"choices[].custom_provider_field",
+	})
+	result, mutated := stripper.Strip(body)
+
+	require.True(t, mutated)
+	require.NotNil(t, result)
+
+	assert.NotContains(t, result, "system_fingerprint")
+	assert.Contains(t, result, "prompt_filter_results", "only configured paths should be stripped")
+
+	choices := result["choices"].([]any)
+	choice := choices[0].(map[string]any)
+	assert.NotContains(t, choice, "custom_provider_field")
+	assert.Contains(t, choice, "content_filter_results", "only configured paths should be stripped")
+	assert.Equal(t, "Hello!", choice["message"].(map[string]any)["content"])
+}
+
+func TestStrip_NilPaths(t *testing.T) {
+	body := map[string]any{
+		"id":                    "chatcmpl-abc123",
+		"prompt_filter_results": []any{map[string]any{"prompt_index": float64(0)}},
+	}
+
+	stripper := NewResponseFieldStripper(nil)
+	result, mutated := stripper.Strip(body)
+
+	assert.False(t, mutated)
+	assert.Nil(t, result, "nil paths should result in no-op")
+}
+
+func TestStrip_EmptyPaths(t *testing.T) {
+	body := map[string]any{
+		"id":                    "chatcmpl-abc123",
+		"prompt_filter_results": []any{map[string]any{"prompt_index": float64(0)}},
+	}
+
+	stripper := NewResponseFieldStripper([]string{})
+	result, mutated := stripper.Strip(body)
+
+	assert.False(t, mutated)
+	assert.Nil(t, result, "empty paths should result in no-op")
+}
+
+func TestStrip_NoMatchingFields(t *testing.T) {
+	body := map[string]any{
+		"id":     "chatcmpl-abc123",
+		"object": "chat.completion",
+	}
+
+	stripper := NewResponseFieldStripper([]string{"nonexistent_field", "choices[].missing"})
+	result, mutated := stripper.Strip(body)
+
+	assert.False(t, mutated)
+	assert.Nil(t, result)
+}
+
+func TestStrip_EmptyBody(t *testing.T) {
+	body := map[string]any{}
+
+	stripper := NewResponseFieldStripper([]string{"prompt_filter_results"})
+	result, mutated := stripper.Strip(body)
+
+	assert.False(t, mutated)
+	assert.Nil(t, result)
+}
+
+func TestStrip_ArrayWithMixedTypes(t *testing.T) {
+	body := map[string]any{
+		"choices": []any{
+			map[string]any{
+				"index":       float64(0),
+				"extra_field": "strip-me",
+			},
+			"not-a-map",
+			float64(42),
+			nil,
+			map[string]any{
+				"index":       float64(1),
+				"extra_field": "strip-me-too",
+			},
+		},
+	}
+
+	stripper := NewResponseFieldStripper([]string{"choices[].extra_field"})
+	result, mutated := stripper.Strip(body)
+
+	require.True(t, mutated)
+	require.NotNil(t, result)
+	choices := result["choices"].([]any)
+	assert.NotContains(t, choices[0].(map[string]any), "extra_field")
+	assert.Equal(t, "not-a-map", choices[1])
+	assert.Equal(t, float64(42), choices[2])
+	assert.Nil(t, choices[3])
+	assert.NotContains(t, choices[4].(map[string]any), "extra_field")
+}
+
+func TestStrip_ArrayFieldNotArray(t *testing.T) {
+	body := map[string]any{
+		"choices": "not-an-array",
+	}
+
+	stripper := NewResponseFieldStripper([]string{"choices[].content_filter_results"})
+	result, mutated := stripper.Strip(body)
+
+	assert.False(t, mutated)
+	assert.Nil(t, result)
+}
+
+func TestStrip_NestedFieldNotMap(t *testing.T) {
+	body := map[string]any{
+		"metadata": "not-a-map",
+	}
+
+	stripper := NewResponseFieldStripper([]string{"metadata.debug_info"})
+	result, mutated := stripper.Strip(body)
+
+	assert.False(t, mutated)
+	assert.Nil(t, result)
+}


### PR DESCRIPTION
## Description

Azure OpenAI responses include provider-specific fields (`content_filter_results`, `prompt_filter_results`) that leak through to clients. The previous implementation (PR #57) hardcoded the stripping logic with explicit `if` checks and `delete` calls for each known field.

This PR introduces a **general-purpose `ResponseFieldStripper`** under `pkg/plugins/api-translation/translator/` that any translator can reuse. The stripping logic is data-driven and configurable via dot-separated field paths.

**Implementation:**

- `translator/response_field_stripper.go` — a shared `ResponseFieldStripper` struct with `NewResponseFieldStripper(fieldsToStrip []string)` and a `Strip(body)` method. Lives in the `translator` package so all providers can import it.
- `azure/azure_openai.go` — the Azure translator holds a `*translator.ResponseFieldStripper` and delegates response stripping to it via `t.stripper.Strip(body)`.
- `translator/response_field_stripper_test.go` — tests for the generic stripping mechanism (custom paths, nested maps, nil/empty paths, mixed array types, edge cases).
- `azure/azure_openai_test.go` — Azure-specific tests (default fields, streaming chunks, live mock integration).

**Path format conventions:**
- `"prompt_filter_results"` — deletes a top-level key
- `"choices[].content_filter_results"` — iterates an array and deletes from each element
- `"metadata.debug_info"` — navigates into a nested object and deletes the leaf key

**Default Azure configuration:**
var DefaultResponseFieldsToStrip = []string{
"prompt_filter_results",
"choices[].content_filter_results",
}



**Reusability:** Any future translator (e.g., Bedrock) can hold a `*translator.ResponseFieldStripper` and call `Strip()` with its own provider-specific field paths — no code duplication needed.

Addresses #67.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced a configurable response-field filtering system and integrated it into the Azure translation pathway to standardize returned responses.

* **Tests**
  * Added comprehensive tests covering nested paths, array element handling, mixed element types, no-op scenarios, and various edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->