### PR TITLE
feat: add NetworkPolicy to restrict ingress to BBR pod

### DIFF
--- a/deploy/payload-processing/templates/networkpolicy.yaml
+++ b/deploy/payload-processing/templates/networkpolicy.yaml
@@ -1,0 +1,19 @@
+{{- $bbr := .Values.upstreamBbr.bbr }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $bbr.name }}-allow-grpc
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $bbr.name }}
+  policyTypes:
+  - Ingress
+  ingress:
+  - ports:
+    - port: {{ $bbr.port }}
+      protocol: TCP
+    - port: {{ $bbr.healthCheckPort }}
+      protocol: TCP


### PR DESCRIPTION
## Summary

Add a `NetworkPolicy` to the Helm chart that restricts ingress to the
BBR pod to only the ext_proc gRPC port and health check port.

## Changes

- `deploy/payload-processing/templates/networkpolicy.yaml`: NetworkPolicy
  allowing ingress on ports from `values.yaml` (`bbr.port` and
  `bbr.healthCheckPort`)

## Security

Blocks all ingress traffic to the BBR pod except:
- Port 9004 (gRPC ext_proc — used by the Istio gateway)
- Port 9005 (health check — used by Kubernetes probes)

```release-note
NONE
```