### PR TITLE
fix bedrock openai api translation, key injection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.26.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/pkg/plugins/api-translation/plugin.go
+++ b/pkg/plugins/api-translation/plugin.go
@@ -27,6 +27,7 @@ import (
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator/anthropic"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator/azure"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator/bedrock"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator/openai"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator/vertex"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/provider"
@@ -54,11 +55,11 @@ func NewAPITranslationPlugin() *APITranslationPlugin {
 			Name: APITranslationPluginType,
 		},
 		providers: map[string]translator.Translator{
-			provider.OpenAI:      openai.NewOpenAITranslator(),
-			provider.Anthropic:   anthropic.NewAnthropicTranslator(),
-			provider.AzureOpenAI: azure.NewAzureOpenAITranslator(),
-			provider.Vertex:      vertex.NewVertexTranslator(),
-			// provider.BedrockOpenAI: bedrock.NewBedrockOpenAITranslator(), TODO comment out until apikey injection is implemented
+			provider.OpenAI:        openai.NewOpenAITranslator(),
+			provider.Anthropic:     anthropic.NewAnthropicTranslator(),
+			provider.AzureOpenAI:   azure.NewAzureOpenAITranslator(),
+			provider.Vertex:        vertex.NewVertexTranslator(),
+			provider.BedrockOpenAI: bedrock.NewBedrockOpenAITranslator(),
 		},
 	}
 }

--- a/pkg/plugins/api-translation/translator/bedrock/bedrock_openai.go
+++ b/pkg/plugins/api-translation/translator/bedrock/bedrock_openai.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	// Bedrock OpenAI-compatible endpoint path
-	bedrockOpenAIPath = "/v1/chat/completions"
+	bedrockOpenAIPath = "/openai/v1/chat/completions"
 )
 
 // compile-time interface check

--- a/pkg/plugins/api-translation/translator/bedrock/bedrock_openai_test.go
+++ b/pkg/plugins/api-translation/translator/bedrock/bedrock_openai_test.go
@@ -43,7 +43,7 @@ func TestTranslateRequest_PassthroughAllChatParams(t *testing.T) {
 	translatedBody, headers, headersToRemove, err := NewBedrockOpenAITranslator().TranslateRequest(body)
 	require.NoError(t, err)
 	assert.Nil(t, translatedBody, "Bedrock OpenAI-compatible API should not mutate the request body")
-	assert.Equal(t, "/v1/chat/completions", headers[":path"])
+	assert.Equal(t, "/openai/v1/chat/completions", headers[":path"])
 	assert.Equal(t, "application/json", headers["content-type"])
 	assert.Len(t, headers, 2)      // translator sets only path header
 	assert.Nil(t, headersToRemove) // no headers to remove

--- a/pkg/plugins/apikey-injection/plugin.go
+++ b/pkg/plugins/apikey-injection/plugin.go
@@ -71,11 +71,11 @@ func NewAPIKeyInjectionPlugin(reconcilerBuilder func() *builder.Builder, clientR
 			Name: APIKeyInjectionPluginType,
 		},
 		authHeadersGenerators: map[string]auth.AuthHeadersGenerator{
-			provider.OpenAI:      &auth.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
-			provider.Anthropic:   &auth.SimpleAuthGenerator{HeaderName: "x-api-key"},
-			provider.AzureOpenAI: &auth.SimpleAuthGenerator{HeaderName: "api-key"},
-			provider.Vertex:      &auth.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
-			// provider.BedrockOpenAI: &apikey_generation.SimpleAuthGenerator{HeaderName: "Authorization"}, // TODO THIS IS NOT WORKING
+			provider.OpenAI:        &auth.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
+			provider.Anthropic:     &auth.SimpleAuthGenerator{HeaderName: "x-api-key"},
+			provider.AzureOpenAI:   &auth.SimpleAuthGenerator{HeaderName: "api-key"},
+			provider.Vertex:        &auth.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
+			provider.BedrockOpenAI: &auth.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
 		},
 		store: store,
 	}), nil


### PR DESCRIPTION
## Description
Fix the Bedrock Openai translator plugin issue. Fix the path re-write, add back the bearer token based api-key injection. Re-enable the plugin

## How Has This Been Tested?
All unit tests passing. Will add results from e2e testing with the real AWS Bedrock service before merging.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- AWS Bedrock integration enabled as an OpenAI-compatible provider, granting users access to Bedrock language models through a unified API translation layer
- Full authentication support for Bedrock with bearer token-based authorization for secure communication with AWS services
- Optimized API endpoint routing for Bedrock compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->