### PR TITLE
Align e2e test keys with llm-katan simulator defaults

### DIFF
--- a/pkg/plugins/api-translation/translator/azure/azure_openai_test.go
+++ b/pkg/plugins/api-translation/translator/azure/azure_openai_test.go
@@ -413,7 +413,7 @@ func TestTranslateResponse_LiveMockIntegration(t *testing.T) {
 	req, err := http.NewRequest("POST", url, bytes.NewReader(reqBody))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("api-key", "test-key")
+	req.Header.Set("api-key", "llm-katan-azure-key")
 
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -13,21 +13,32 @@ import (
 
 // Provider represents a provider configuration for testing.
 type Provider struct {
-	Name     string
-	Provider string
+	Name         string
+	Provider     string
+	SimulatorKey string // expected API key for llm-katan --validate-keys
+}
+
+// simulatorKey maps provider names to llm-katan default keys.
+// These match the DEFAULT_API_KEYS in llm-katan's config.py.
+var simulatorKeys = map[string]string{
+	"openai":       "llm-katan-openai-key",
+	"anthropic":    "llm-katan-anthropic-key",
+	"azure-openai": "llm-katan-azure-key",
+	"vertex":       "llm-katan-vertexai-key",
+	"bedrock-openai": "llm-katan-bedrock-key",
 }
 
 var providers = []Provider{
-	{Name: "e2e-openai", Provider: "openai"},
-	{Name: "e2e-anthropic", Provider: "anthropic"},
-	{Name: "e2e-azure", Provider: "azure-openai"},
-	{Name: "e2e-vertex", Provider: "vertex"},
+	{Name: "e2e-openai", Provider: "openai", SimulatorKey: simulatorKeys["openai"]},
+	{Name: "e2e-anthropic", Provider: "anthropic", SimulatorKey: simulatorKeys["anthropic"]},
+	{Name: "e2e-azure", Provider: "azure-openai", SimulatorKey: simulatorKeys["azure-openai"]},
+	{Name: "e2e-vertex", Provider: "vertex", SimulatorKey: simulatorKeys["vertex"]},
 	// bedrock-openai: uncomment once the translator is in the odh-stable image
-	// {Name: "e2e-bedrock", Provider: "bedrock-openai"},
+	// {Name: "e2e-bedrock", Provider: "bedrock-openai", SimulatorKey: simulatorKeys["bedrock-openai"]},
 }
 
 func createProviderResources(p Provider) {
-	// Secret with dummy API key
+	// Secret with API key matching llm-katan simulator defaults
 	kubectlApplyLiteral(fmt.Sprintf(`
 apiVersion: v1
 kind: Secret
@@ -38,8 +49,8 @@ metadata:
     inference.networking.k8s.io/bbr-managed: "true"
 type: Opaque
 stringData:
-  api-key: e2e-test-key-%s
-`, p.Name, nsName, p.Provider))
+  api-key: %s
+`, p.Name, nsName, p.SimulatorKey))
 
 	// ExternalModel CR
 	kubectlApplyLiteral(fmt.Sprintf(`
@@ -192,5 +203,46 @@ var _ = ginkgo.Describe("BBR Plugin Chain", func() {
 				gomega.Expect(len(choices)).To(gomega.BeNumerically(">", 0))
 			})
 		}
+	})
+
+	// Test that an invalid API key is rejected by the simulator when --validate-keys is enabled.
+	// This validates the full api-key-injection pipeline: if the wrong key is injected,
+	// the simulator returns 401 with the expected key in the error message.
+	ginkgo.When("simulator has key validation enabled", func() {
+		ginkgo.It("should reject requests with an invalid API key", func() {
+			// Create a provider with a deliberately wrong key
+			wrongKeyProvider := Provider{
+				Name:         "e2e-wrong-key",
+				Provider:     "openai",
+				SimulatorKey: "intentionally-wrong-key",
+			}
+			createProviderResources(wrongKeyProvider)
+			defer deleteProviderResources(wrongKeyProvider)
+
+			// Wait for reconciler sync
+			time.Sleep(5 * time.Second)
+
+			curlCmd := getCurlCommand(wrongKeyProvider.Name)
+			var resp string
+
+			gomega.Eventually(func() bool {
+				var err error
+				resp, err = execInPod("curl", nsName, "curl", curlCmd)
+				if err != nil {
+					return false
+				}
+				// When --validate-keys is enabled, simulator returns 401 for wrong keys.
+				// When not enabled, any key is accepted (200).
+				// Both are valid outcomes — the test documents the expected behavior.
+				return strings.Contains(resp, "401") || strings.Contains(resp, "200")
+			}, curlTimeout*3, 5*time.Second).Should(gomega.BeTrue(),
+				fmt.Sprintf("Expected 401 or 200 for wrong key test, got:\n%s", resp))
+
+			if strings.Contains(resp, "401") {
+				// Verify the error message contains the expected key hint
+				gomega.Expect(resp).To(gomega.ContainSubstring("expected"),
+					"401 response should include the expected key in the error message")
+			}
+		})
 	})
 })

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -206,11 +207,15 @@ var _ = ginkgo.Describe("BBR Plugin Chain", func() {
 	})
 
 	// Test that an invalid API key is rejected by the simulator when --validate-keys is enabled.
-	// This validates the full api-key-injection pipeline: if the wrong key is injected,
-	// the simulator returns 401 with the expected key in the error message.
+	// Only runs when E2E_SIMULATOR_VALIDATE_KEYS=true (simulator must be started with --validate-keys).
 	ginkgo.When("simulator has key validation enabled", func() {
+		ginkgo.BeforeEach(func() {
+			if os.Getenv("E2E_SIMULATOR_VALIDATE_KEYS") != "true" {
+				ginkgo.Skip("E2E_SIMULATOR_VALIDATE_KEYS not set, skipping key validation test")
+			}
+		})
+
 		ginkgo.It("should reject requests with an invalid API key", func() {
-			// Create a provider with a deliberately wrong key
 			wrongKeyProvider := Provider{
 				Name:         "e2e-wrong-key",
 				Provider:     "openai",
@@ -219,7 +224,6 @@ var _ = ginkgo.Describe("BBR Plugin Chain", func() {
 			createProviderResources(wrongKeyProvider)
 			defer deleteProviderResources(wrongKeyProvider)
 
-			// Wait for reconciler sync
 			time.Sleep(5 * time.Second)
 
 			curlCmd := getCurlCommand(wrongKeyProvider.Name)
@@ -231,18 +235,13 @@ var _ = ginkgo.Describe("BBR Plugin Chain", func() {
 				if err != nil {
 					return false
 				}
-				// When --validate-keys is enabled, simulator returns 401 for wrong keys.
-				// When not enabled, any key is accepted (200).
-				// Both are valid outcomes — the test documents the expected behavior.
-				return strings.Contains(resp, "401") || strings.Contains(resp, "200")
+				return strings.Contains(resp, "401")
 			}, curlTimeout*3, 5*time.Second).Should(gomega.BeTrue(),
-				fmt.Sprintf("Expected 401 or 200 for wrong key test, got:\n%s", resp))
+				fmt.Sprintf("Expected 401 for wrong key, got:\n%s", resp))
 
-			if strings.Contains(resp, "401") {
-				// Verify the error message contains the expected key hint
-				gomega.Expect(resp).To(gomega.ContainSubstring("expected"),
-					"401 response should include the expected key in the error message")
-			}
+			// Verify the error message contains the expected key hint
+			gomega.Expect(resp).To(gomega.ContainSubstring("expected"),
+				"401 response should include the expected key in the error message")
 		})
 	})
 })

--- a/tools/simulator/README.md
+++ b/tools/simulator/README.md
@@ -27,8 +27,29 @@ llm-katan --model Qwen/Qwen3-0.6B --providers openai,anthropic,vertexai,bedrock,
 | AWS Bedrock | `POST /model/{modelId}/invoke` | `Authorization: AWS4-HMAC-SHA256 <sig>` |
 | Azure OpenAI | `POST /openai/deployments/{id}/chat/completions` | `api-key: <key>` |
 
-All endpoints require auth headers (any value accepted — validates the header exists, not the key value).
-All endpoints support streaming.
+All endpoints require auth headers. All endpoints support streaming.
+
+### API Key Validation
+
+By default, the simulator only checks that auth headers are present (any value accepted). To validate actual key values, use `--validate-keys`:
+
+```bash
+llm-katan --model test --backend echo --validate-keys --providers openai,anthropic,vertexai,bedrock,azure_openai
+```
+
+Default keys per provider (used when `--validate-keys` is enabled):
+
+| Provider | Default Key |
+|----------|------------|
+| OpenAI | `llm-katan-openai-key` |
+| Anthropic | `llm-katan-anthropic-key` |
+| Vertex AI | `llm-katan-vertexai-key` |
+| Bedrock | `llm-katan-bedrock-key` |
+| Azure OpenAI | `llm-katan-azure-key` |
+
+Override specific keys: `--api-keys openai=custom-key,anthropic=other-key`
+
+When a wrong key is sent, the error response includes the expected key — because this is a test simulator, not a security boundary.
 
 ### Bedrock InvokeModel Families
 
@@ -142,4 +163,7 @@ Optional:
   -t, --temperature FLOAT       Temperature (default: 0.7)
   --max-concurrent INTEGER      Concurrent requests (default: 1)
   --quantize/--no-quantize      CPU int8 quantization (default: enabled)
+  --tls                         Enable HTTPS with self-signed certificate
+  --validate-keys               Validate API key values (uses defaults or --api-keys overrides)
+  --api-keys TEXT               Override keys: openai=mykey,anthropic=mykey2
 ```


### PR DESCRIPTION
## Summary

- Update e2e test API key secrets to match llm-katan simulator default keys
- Update Azure live mock test to use the correct default key
- Add invalid key rejection test
- Document `--validate-keys`, `--api-keys`, and `--tls` in simulator README

## Context

The llm-katan simulator ([v0.10.0](https://pypi.org/project/llm-katan/0.10.0/)) now supports API key **value** validation via `--validate-keys` ([GitHub](https://github.com/yossiovadia/llm-katan)). Previously it only checked that auth headers were present — now it can validate the actual key value matches what's expected.

When a wrong key is sent, the error response includes the expected key:
```json
{"error": {"message": "invalid API key for openai: got 'wrong-key', expected 'llm-katan-openai-key'"}}
```

This is safe for a test simulator (not a security boundary) and makes debugging e2e failures trivial.

### How it works

```bash
# Without --validate-keys (current behavior, unchanged)
llm-katan --model test --backend echo --providers openai,anthropic
# Any key value accepted, only header presence checked

# With --validate-keys (opt-in)
llm-katan --model test --backend echo --providers openai,anthropic --validate-keys
# Key values validated against defaults, wrong keys get 401 with hint
```

Default keys per provider:

| Provider | Default Key |
|----------|------------|
| OpenAI | `llm-katan-openai-key` |
| Anthropic | `llm-katan-anthropic-key` |
| Vertex AI | `llm-katan-vertexai-key` |
| Bedrock | `llm-katan-bedrock-key` |
| Azure OpenAI | `llm-katan-azure-key` |

## Changes

| File | Change |
|------|--------|
| `test/e2e/e2e_test.go` | Secrets use `llm-katan-{provider}-key` instead of `e2e-test-key-*` |
| `test/e2e/e2e_test.go` | New test: sends wrong key, expects 401 with key hint |
| `pkg/.../azure/azure_openai_test.go` | `test-key` → `llm-katan-azure-key` |
| `tools/simulator/README.md` | Document `--validate-keys`, `--api-keys`, `--tls`, default key table |

## Backward compatible

- Without `--validate-keys`, simulator accepts any key value (current behavior)
- E2e tests work in both modes: correct keys pass with validation on, any keys pass with validation off
- The invalid key test handles both: expects 401 when validation is on, 200 when off

Related: #114

## Requires

llm-katan >= 0.10.0: `pip install llm-katan>=0.10.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added simulator CLI options: --validate-keys, --api-keys, and --tls for HTTPS with self-signed certs.

* **Documentation**
  * Clarified simulator authentication behavior and documented the new CLI options and per-provider default keys.

* **Tests**
  * Updated tests to use simulator default keys and added an end-to-end scenario that validates API key verification when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->