### PR TITLE
fix: use /v1/chat/completions for bedrock-openai translator

### DIFF
--- a/pkg/plugins/api-translation/translator/bedrock/bedrock_openai.go
+++ b/pkg/plugins/api-translation/translator/bedrock/bedrock_openai.go
@@ -23,8 +23,9 @@ import (
 )
 
 const (
-	// Bedrock OpenAI-compatible endpoint path
-	bedrockOpenAIPath = "/openai/v1/chat/completions"
+	// Bedrock OpenAI-compatible endpoint path.
+	// Same as OpenAI — auth differentiation is via SigV4 or Bearer token.
+	bedrockOpenAIPath = "/v1/chat/completions"
 )
 
 // compile-time interface check

--- a/pkg/plugins/api-translation/translator/bedrock/bedrock_openai_test.go
+++ b/pkg/plugins/api-translation/translator/bedrock/bedrock_openai_test.go
@@ -43,7 +43,7 @@ func TestTranslateRequest_PassthroughAllChatParams(t *testing.T) {
 	translatedBody, headers, headersToRemove, err := NewBedrockOpenAITranslator().TranslateRequest(body)
 	require.NoError(t, err)
 	assert.Nil(t, translatedBody, "Bedrock OpenAI-compatible API should not mutate the request body")
-	assert.Equal(t, "/openai/v1/chat/completions", headers[":path"])
+	assert.Equal(t, "/v1/chat/completions", headers[":path"])
 	assert.Equal(t, "application/json", headers["content-type"])
 	assert.Len(t, headers, 2)      // translator sets only path header
 	assert.Nil(t, headersToRemove) // no headers to remove

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -34,8 +34,9 @@ var providers = []Provider{
 	{Name: "e2e-anthropic", Provider: "anthropic", SimulatorKey: simulatorKeys["anthropic"]},
 	{Name: "e2e-azure", Provider: "azure-openai", SimulatorKey: simulatorKeys["azure-openai"]},
 	{Name: "e2e-vertex", Provider: "vertex", SimulatorKey: simulatorKeys["vertex"]},
-	// bedrock-openai: uncomment once the translator is in the odh-stable image
-	// {Name: "e2e-bedrock", Provider: "bedrock-openai", SimulatorKey: simulatorKeys["bedrock-openai"]},
+	// bedrock-openai uses /v1/chat/completions (same as OpenAI), so the simulator
+	// validates against the OpenAI key until key-based provider dispatch is implemented.
+	{Name: "e2e-bedrock", Provider: "bedrock-openai", SimulatorKey: simulatorKeys["openai"]},
 }
 
 func createProviderResources(p Provider) {
@@ -62,10 +63,11 @@ metadata:
   namespace: %s
 spec:
   provider: %s
+  targetModel: %s
   endpoint: %s
   credentialRef:
     name: %s-api-key
-`, p.Name, nsName, p.Provider, simulatorEP, p.Name))
+`, p.Name, nsName, p.Provider, p.Name, simulatorEP, p.Name))
 
 	// ExternalName Service pointing to simulator
 	kubectlApplyLiteral(fmt.Sprintf(`


### PR DESCRIPTION
## Problem

The `bedrock-openai` translator rewrites the path to
`/openai/v1/chat/completions`. This is incorrect — AWS Bedrock's
OpenAI-compatible endpoint uses `/v1/chat/completions` (same path
as OpenAI). The `/openai/` prefix causes backends that distinguish
by path to route the request to the Azure OpenAI handler instead.

## Fix

Change `bedrockOpenAIPath` from `/openai/v1/chat/completions` to
`/v1/chat/completions`.

Bedrock OpenAI-compatible mode differentiates from standard OpenAI
via auth headers (SigV4 or Bearer with a provider-specific key),
not by path.

## Tested

On RHOAI cluster with llm-katan simulator:
- Before: "invalid API key for **azure_openai**" (wrong handler)
- After: request reaches OpenAI handler correctly

Fixes #118

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Bedrock OpenAI-compatible integration endpoint path to align with API specification

* **Tests**
  * Introduced automated end-to-end testing in continuous integration pipeline
  * Implemented containerized test execution environment
  * Added test categorization and filtering capabilities for organized test runs
  * Enhanced test reporting with JUnit XML output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->