### PR TITLE
[Feat]: migrate Azure OpenAI translator to v1 API

### DIFF
--- a/pkg/plugins/api-translation/plugin_test.go
+++ b/pkg/plugins/api-translation/plugin_test.go
@@ -122,7 +122,7 @@ func TestProcessRequest_AzureOpenAIProvider(t *testing.T) {
 	assert.Equal(t, 0.7, req.Body["temperature"])
 
 	mutated := req.MutatedHeaders()
-	assert.Equal(t, "/openai/deployments/gpt-4o/chat/completions?api-version=2024-10-21", mutated[":path"])
+	assert.Equal(t, "/openai/v1/chat/completions", mutated[":path"])
 	assert.Equal(t, "application/json", mutated["content-type"])
 
 	removed := req.RemovedHeaders()

--- a/pkg/plugins/api-translation/translator/azure/azure_openai.go
+++ b/pkg/plugins/api-translation/translator/azure/azure_openai.go
@@ -18,20 +18,14 @@ package azure
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator"
 )
 
 const (
-	// defaultAPIVersion is the default Azure OpenAI API version.
-	// Reference: https://learn.microsoft.com/en-us/azure/ai-services/openai/reference
-	defaultAPIVersion = "2024-10-21"
-
-	// Azure OpenAI endpoint path template.
-	// The deployment ID typically matches the deployed model name.
-	// Reference: https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference#chat-completions
-	azurePathTemplate = "/openai/deployments/%s/chat/completions?api-version=%s"
+	// Azure OpenAI v1 API chat completions path.
+	// Reference: https://learn.microsoft.com/en-us/azure/foundry/openai/latest#create-chat-completion
+	azureChatCompletionsPath = "/openai/v1/chat/completions"
 )
 
 // compile-time interface check
@@ -39,38 +33,27 @@ var _ translator.Translator = &AzureOpenAITranslator{}
 
 // NewAzureOpenAITranslator initializes a new AzureOpenAITranslator and returns its pointer.
 func NewAzureOpenAITranslator() *AzureOpenAITranslator {
-	return &AzureOpenAITranslator{
-		apiVersion:          defaultAPIVersion,
-		deploymentIDPattern: regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`), // deploymentIDPattern validates Azure deployment IDs to prevent path/query injection.
-	}
+	return &AzureOpenAITranslator{}
 }
 
 // AzureOpenAITranslator translates between OpenAI Chat Completions format and
 // Azure OpenAI Service format. Azure OpenAI uses the same request/response schema
 // as OpenAI, so translation is limited to path rewriting and header adjustments.
-type AzureOpenAITranslator struct {
-	apiVersion          string
-	deploymentIDPattern *regexp.Regexp
-}
+type AzureOpenAITranslator struct{}
 
-// TranslateRequest rewrites the path and headers for Azure OpenAI.
+// TranslateRequest rewrites the path and headers for Azure OpenAI v1 API.
 // The request body is not mutated since Azure OpenAI accepts the same schema as OpenAI.
-// Azure ignores the model field in the body and uses the deployment ID from the URI path.
 func (t *AzureOpenAITranslator) TranslateRequest(body map[string]any) (map[string]any, map[string]string, []string, error) {
 	model, _ := body["model"].(string)
 	if model == "" {
 		return nil, nil, nil, fmt.Errorf("model field is required")
 	}
-	if !t.deploymentIDPattern.MatchString(model) {
-		return nil, nil, nil, fmt.Errorf("model '%s' contains invalid characters for Azure deployment ID", model)
-	}
 
 	headers := map[string]string{
-		":path":        fmt.Sprintf(azurePathTemplate, model, t.apiVersion),
+		":path":        azureChatCompletionsPath,
 		"content-type": "application/json",
 	}
 
-	// Return nil body — no body mutation is needed, Azure accepts the OpenAI request format as-is.
 	return nil, headers, nil, nil
 }
 

--- a/pkg/plugins/api-translation/translator/azure/azure_openai_test.go
+++ b/pkg/plugins/api-translation/translator/azure/azure_openai_test.go
@@ -19,7 +19,6 @@ package azure
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -52,14 +51,13 @@ func TestTranslateRequest_BodyPassthrough(t *testing.T) {
 
 	assert.Nil(t, translatedBody, "body should not be mutated for Azure OpenAI")
 
-	expectedPath := fmt.Sprintf("/openai/deployments/gpt-4o/chat/completions?api-version=%s", defaultAPIVersion)
-	assert.Equal(t, expectedPath, headers[":path"])
+	assert.Equal(t, "/openai/v1/chat/completions", headers[":path"])
 	assert.Equal(t, "application/json", headers["content-type"])
 	assert.Len(t, headers, 2)
 	assert.Nil(t, headersToRemove)
 }
 
-func TestTranslateRequest_ModelUsedAsDeploymentID(t *testing.T) {
+func TestTranslateRequest_FixedPathForAnyModel(t *testing.T) {
 	tests := []struct {
 		name  string
 		model string
@@ -69,6 +67,7 @@ func TestTranslateRequest_ModelUsedAsDeploymentID(t *testing.T) {
 		{"custom deployment name", "my-custom-deployment"},
 		{"with dots", "gpt-4o.2025"},
 		{"with underscore", "my_deployment"},
+		{"with slash", "org/model-name"},
 	}
 
 	for _, tt := range tests {
@@ -81,8 +80,8 @@ func TestTranslateRequest_ModelUsedAsDeploymentID(t *testing.T) {
 			_, headers, _, err := NewAzureOpenAITranslator().TranslateRequest(body)
 			require.NoError(t, err)
 
-			expectedPath := fmt.Sprintf("/openai/deployments/%s/chat/completions?api-version=%s", tt.model, defaultAPIVersion)
-			assert.Equal(t, expectedPath, headers[":path"])
+			assert.Equal(t, "/openai/v1/chat/completions", headers[":path"],
+				"path should be fixed regardless of model name")
 		})
 	}
 }
@@ -106,33 +105,6 @@ func TestTranslateRequest_EmptyModel(t *testing.T) {
 	_, _, _, err := NewAzureOpenAITranslator().TranslateRequest(body)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "model")
-}
-
-func TestTranslateRequest_InvalidModelCharacters(t *testing.T) {
-	tests := []struct {
-		name  string
-		model string
-	}{
-		{"query injection", "gpt-4o?api-version=hijacked&x="},
-		{"path traversal", "../../../etc/passwd"},
-		{"slash in model", "org/model-name"},
-		{"space in model", "gpt 4o"},
-		{"starts with hyphen", "-gpt-4o"},
-		{"starts with dot", ".hidden"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			body := map[string]any{
-				"model":    tt.model,
-				"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
-			}
-
-			_, _, _, err := NewAzureOpenAITranslator().TranslateRequest(body)
-			assert.Error(t, err)
-			assert.Contains(t, err.Error(), "invalid characters")
-		})
-	}
 }
 
 func TestTranslateResponse_CleanResponse(t *testing.T) {
@@ -409,7 +381,7 @@ func TestTranslateResponse_LiveMockIntegration(t *testing.T) {
 		"messages": []any{map[string]any{"role": "user", "content": "What is 2+2?"}},
 	})
 
-	url := baseURL + "/openai/deployments/gpt-4o/chat/completions?api-version=2024-10-21"
+	url := baseURL + "/openai/v1/chat/completions"
 	req, err := http.NewRequest("POST", url, bytes.NewReader(reqBody))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")

--- a/pkg/plugins/api-translation/translator/openai/openai.go
+++ b/pkg/plugins/api-translation/translator/openai/openai.go
@@ -30,7 +30,7 @@ const (
 // compile-time interface check
 var _ translator.Translator = &OpenAITranslator{}
 
-// NewAzureOpenAITranslator initializes a new OpenAITranslator and returns its pointer.
+// NewOpenAITranslator initializes a new OpenAITranslator and returns its pointer.
 func NewOpenAITranslator() *OpenAITranslator {
 	return &OpenAITranslator{}
 }
@@ -50,7 +50,7 @@ func (t *OpenAITranslator) TranslateRequest(body map[string]any) (map[string]any
 		":path": openAIPath, // needed in case the original request uses different relative path and include the model.
 	}
 
-	// Return nil body — no body mutation is needed, Azure accepts the OpenAI request format as-is.
+	// Return nil body — no body mutation is needed, OpenAI request format is used as-is.
 	return nil, headers, nil, nil
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -22,10 +22,10 @@ type Provider struct {
 // simulatorKey maps provider names to llm-katan default keys.
 // These match the DEFAULT_API_KEYS in llm-katan's config.py.
 var simulatorKeys = map[string]string{
-	"openai":       "llm-katan-openai-key",
-	"anthropic":    "llm-katan-anthropic-key",
-	"azure-openai": "llm-katan-azure-key",
-	"vertex":       "llm-katan-vertexai-key",
+	"openai":         "llm-katan-openai-key",
+	"anthropic":      "llm-katan-anthropic-key",
+	"azure-openai":   "llm-katan-azure-key",
+	"vertex":         "llm-katan-vertexai-key",
 	"bedrock-openai": "llm-katan-bedrock-key",
 }
 

--- a/tools/simulator/README.md
+++ b/tools/simulator/README.md
@@ -25,7 +25,7 @@ llm-katan --model Qwen/Qwen3-0.6B --providers openai,anthropic,vertexai,bedrock,
 | Vertex AI / Gemini | `POST /v1beta/models/{model}:generateContent` | `Authorization: Bearer <token>` |
 | AWS Bedrock | `POST /model/{modelId}/converse` | `Authorization: AWS4-HMAC-SHA256 <sig>` |
 | AWS Bedrock | `POST /model/{modelId}/invoke` | `Authorization: AWS4-HMAC-SHA256 <sig>` |
-| Azure OpenAI | `POST /openai/deployments/{id}/chat/completions` | `api-key: <key>` |
+| Azure OpenAI | `POST /openai/v1/chat/completions` | `api-key: <key>` |
 
 All endpoints require auth headers. All endpoints support streaming.
 
@@ -111,10 +111,10 @@ curl -X POST http://localhost:8000/model/anthropic.claude-v2/invoke \
 
 ### Azure OpenAI
 ```bash
-curl -X POST http://localhost:8000/openai/deployments/gpt-4/chat/completions?api-version=2024-10-21 \
+curl -X POST http://localhost:8000/openai/v1/chat/completions \
   -H "api-key: test-key" \
   -H "Content-Type: application/json" \
-  -d '{"messages":[{"role":"user","content":"Hello"}]}'
+  -d '{"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]}'
 ```
 
 ## Shared Endpoints


### PR DESCRIPTION
## Description

Migrates the Azure OpenAI translator from the [previous API](https://learn.microsoft.com/en-us/azure/foundry/openai/reference) to the [new v1 API](https://learn.microsoft.com/en-us/azure/foundry/openai/latest#create-chat-completion).

**What changed:**
- Path rewritten from `/openai/deployments/{deployment-id}/chat/completions?api-version=2024-10-21` to the fixed `/openai/v1/chat/completions`
- `api-version` query parameter removed (not required in v1, defaults to `v1`)
- Deployment ID validation regex removed (model stays in the request body, no longer injected into the URL path)
- Response stripping (`prompt_filter_results`, `content_filter_results`) kept as-is since the v1 API still returns these Azure-specific fields

**Additional fixes:**
- Fixed pre-existing comment typos in `openai/openai.go` that incorrectly referenced Azure
- Added `targetModel` field to e2e `ExternalModel` CR (required by updated upstream CRD)
- Updated simulator README with v1 endpoint format and example

Closes #116

## How Has This Been Tested?

- **Unit tests**: `go test ./pkg/plugins/api-translation/translator/azure/... -v` — all 12 tests pass (path assertions, model validation, response stripping, streaming chunks)
- **Plugin-level tests**: `go test ./pkg/plugins/api-translation/... -v -run Azure` — all 3 Azure plugin tests pass
- **Manual curl tests**: Sent 8 different requests to `http://3.150.113.9:8000/openai/v1/chat/completions` (different models, params, auth scenarios, edge cases) — all returned expected results
- **E2e tests**: Set up a Kind cluster with Istio + BBR, built a local image from this branch, and ran `make test-e2e` — all 8 tests passed (including `azure-openai` provider tests that validate the full gateway pipeline)

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work