### PR TITLE
fix: use namespace/model path pattern in E2E tests

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -101,16 +101,10 @@ spec:
   - matches:
     - path:
         type: PathPrefix
-        value: /%s/
+        value: /%s/%s/
     backendRefs:
     - name: %s-backend
       port: 443
-    filters:
-    - type: URLRewrite
-      urlRewrite:
-        path:
-          type: ReplacePrefixMatch
-          replacePrefixMatch: /
   - matches:
     - headers:
       - name: X-Gateway-Model-Name
@@ -122,7 +116,7 @@ spec:
     backendRefs:
     - name: %s-backend
       port: 443
-`, p.Name, nsName, gatewayName, gatewayNs, p.Name, p.Name, p.Name, p.Name))
+`, p.Name, nsName, gatewayName, gatewayNs, nsName, p.Name, p.Name, p.Name, p.Name))
 }
 
 func deleteProviderResources(p Provider) {
@@ -144,8 +138,8 @@ func getCurlCommand(modelName string) []string {
 	// Access gateway service from inside the cluster via DNS.
 	// Istio creates a service named <gateway-name>-istio for each Gateway.
 	svcName := gatewayName + "-istio"
-	gatewayURL := fmt.Sprintf("http://%s.%s.svc:80/%s/v1/chat/completions",
-		svcName, gatewayNs, modelName)
+	gatewayURL := fmt.Sprintf("http://%s.%s.svc:80/%s/%s/v1/chat/completions",
+		svcName, gatewayNs, nsName, modelName)
 
 	return []string{
 		"curl", "-si", "--max-time", strconv.Itoa(int(curlTimeout.Seconds())),


### PR DESCRIPTION
## Problem

PR #111 changed the `model-provider-resolver` to parse the request
path as `/<namespace>/<model>`. The E2E tests still use `/<model>/`
paths, causing the plugin to fail to resolve providers — all tests
timeout with 90s.

## Fix

Update HTTPRoute path prefix from `/<model>/` to `/<namespace>/<model>/`
and curl command URL to match.

Verified locally: 10 of 11 specs pass (11th skipped — key validation).

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Routing now matches requests with an additional namespace path segment, ensuring correct request delivery.

* **Tests**
  * Updated test scenarios to verify namespace-aware routing, adjusted request path construction, and removal of the prior URL rewrite behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->