### PR TITLE
fix: set namespaced X-Gateway-Model-Name for namespace isolation

### DIFF
--- a/pkg/plugins/model-provider-resolver/plugin.go
+++ b/pkg/plugins/model-provider-resolver/plugin.go
@@ -134,6 +134,10 @@ func (p *ModelProviderResolverPlugin) ProcessRequest(ctx context.Context, cycleS
 	cycleState.Write(state.CredsRefName, externalModelInfo.secretName)
 	cycleState.Write(state.CredsRefNamespace, externalModelInfo.secretNamespace)
 
+	// Overwrite X-Gateway-Model-Name with namespace/name so the header-based
+	// HTTPRoute rule matches the correct namespace after ClearRouteCache.
+	request.SetHeader("X-Gateway-Model-Name", modelKey.Namespace+"/"+modelKey.Name)
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Overwrite `X-Gateway-Model-Name` header with `namespace/name` after
resolving the provider. This ensures the header-based HTTPRoute rule
matches the correct namespace when same-name models exist in different
namespaces.

## Problem

`body-field-to-header` sets `X-Gateway-Model-Name` from the body's
`model` field (e.g., `openai.gpt-oss-20b`). When two namespaces have
models with the same name, both HTTPRoutes match the same header value
after ClearRouteCache — Envoy picks the wrong one.

## Fix

After `model-provider-resolver` parses `<namespace>/<model>` from the
path, overwrite the header to `namespace/name` (e.g.,
`llm/openai.gpt-oss-20b` vs `prod-models/openai.gpt-oss-20b`).

Companion PR: opendatahub-io/models-as-a-service#746 (reconciler uses
`namespace/name` in HTTPRoute header match)

Fixes #126

```release-note
NONE
```