### PR TITLE
refactor: update nemo-request-guard to use a shared nemo guard base

### DIFF
--- a/pkg/plugins/nemo/nemo_guard_base.go
+++ b/pkg/plugins/nemo/nemo_guard_base.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nemo
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+)
+
+const (
+	nemoAllowedStatus    = "success"
+	defaultTimeoutSec    = 360
+	maxNemoResponseBytes = 1 << 20 // 1 MiB
+)
+
+// nemoGuardConfig is the shared JSON configuration for nemo guard plugins.
+type nemoGuardConfig struct {
+	NemoURL        string `json:"nemoURL"`
+	TimeoutSeconds int    `json:"timeoutSeconds"`
+}
+
+// nemoResponse is NeMo's JSON response from /v1/guardrail/checks.
+type nemoResponse struct {
+	Status      string                         `json:"status"`
+	RailsStatus map[string]nemoRailStatusEntry `json:"rails_status"`
+}
+
+type nemoRailStatusEntry struct {
+	Status string `json:"status"`
+}
+
+// nemoGuardBase holds the shared fields and HTTP logic for nemo guard plugins.
+type nemoGuardBase struct {
+	typedName  plugin.TypedName
+	nemoURL    string
+	httpClient *http.Client
+}
+
+func newNemoGuardBase(pluginType, nemoURL string, timeoutSeconds int) (*nemoGuardBase, error) {
+	if nemoURL == "" {
+		return nil, fmt.Errorf("nemoURL is required for plugin '%s'", pluginType)
+	}
+	timeout := time.Duration(timeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = defaultTimeoutSec * time.Second
+	}
+
+	return &nemoGuardBase{
+		typedName: plugin.TypedName{Type: pluginType, Name: pluginType},
+		nemoURL:   nemoURL,
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
+	}, nil
+}
+
+func (b *nemoGuardBase) TypedName() plugin.TypedName {
+	return b.typedName
+}
+
+// WithName sets the name of the plugin instance.
+func (b *nemoGuardBase) WithName(name string) *nemoGuardBase {
+	b.typedName.Name = name
+	return b
+}
+
+// callNemoGuard POSTs the payload to the NeMo guardrail checks endpoint, parses the
+// response, and returns an error with the corresponding error code if the content is
+// blocked or NeMo is unreachable. The caller is responsible for constructing the
+// client-facing errcommon.Error from the returned values.
+func (b *nemoGuardBase) callNemoGuard(ctx context.Context, payload []byte) (string, error) {
+	logger := log.FromContext(ctx)
+	logger.V(logutil.VERBOSE).Info("Calling NeMo guardrails", "pluginType", b.typedName.Type, "pluginName", b.typedName.Name, "url", b.nemoURL)
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, b.nemoURL, bytes.NewReader(payload))
+	if err != nil {
+		return errcommon.Internal, fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := b.httpClient.Do(httpReq)
+	if err != nil {
+		return errcommon.ServiceUnavailable, fmt.Errorf("call failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return errcommon.ServiceUnavailable, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	limited := io.LimitReader(resp.Body, maxNemoResponseBytes)
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		return errcommon.ServiceUnavailable, fmt.Errorf("read response: %w", err)
+	}
+
+	var nemoResp nemoResponse
+	if err := json.Unmarshal(body, &nemoResp); err != nil {
+		return errcommon.ServiceUnavailable, fmt.Errorf("decode response: %w", err)
+	}
+
+	if strings.EqualFold(strings.TrimSpace(nemoResp.Status), nemoAllowedStatus) {
+		logger.V(logutil.VERBOSE).Info("Allowed by NeMo guardrails", "pluginType", b.typedName.Type, "pluginName", b.typedName.Name)
+		return "", nil
+	}
+
+	railsParts := make([]string, 0, len(nemoResp.RailsStatus))
+	for key, value := range nemoResp.RailsStatus {
+		railsParts = append(railsParts, fmt.Sprintf("%s: %s", key, value.Status))
+	}
+	railsStatus := fmt.Sprintf("[ %s ]", strings.Join(railsParts, " "))
+
+	logger.Info("Blocked by NeMo guardrails", "pluginType", b.typedName.Type, "pluginName", b.typedName.Name, "railsStatus", railsStatus)
+	return errcommon.Forbidden, fmt.Errorf("blocked by NeMo guardrails")
+}

--- a/pkg/plugins/nemo/request_guard.go
+++ b/pkg/plugins/nemo/request_guard.go
@@ -17,32 +17,17 @@ limitations under the License.
 package nemo
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-	"strings"
-	"time"
 
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
 	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
-	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
-	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 )
 
 const (
 	// NemoRequestGuardPluginType is the plugin type identifier.
 	NemoRequestGuardPluginType = "nemo-request-guard"
-	// nemoAllowedStatus is the top-level JSON status when a request passes all rails.
-	nemoAllowedStatus = "success"
-	// defaultTimeoutSec allows for CPU-based LLM inference (2-5 min per request).
-	defaultTimeoutSec = 360
-	// maxNemoResponseBytes caps the NeMo response body to prevent memory exhaustion
-	// from a misbehaving or compromised NeMo service (CWE-400).
-	maxNemoResponseBytes = 1 << 20 // 1 MiB
 )
 
 // compile-time type validation
@@ -51,31 +36,13 @@ var _ framework.RequestProcessor = &NemoRequestGuardPlugin{}
 // NemoRequestGuardPlugin calls a NeMo Guardrails service over HTTP to check request content
 // using input rails. It implements RequestProcessor to intercept requests before forwarding.
 type NemoRequestGuardPlugin struct {
-	typedName  plugin.TypedName
-	nemoURL    string
-	httpClient *http.Client
-}
-
-// nemoRequestGuardConfig is the JSON configuration for the plugin.
-type nemoRequestGuardConfig struct {
-	NemoURL        string `json:"nemoURL"`
-	TimeoutSeconds int    `json:"timeoutSeconds"`
-}
-
-type nemoResponse struct {
-	Status      string                         `json:"status"`
-	RailsStatus map[string]nemoRailStatusEntry `json:"rails_status"`
-}
-
-// nemoRailStatusEntry is one rail's outcome inside NeMo's rails_status object.
-type nemoRailStatusEntry struct {
-	Status string `json:"status"`
+	nemoGuardBase
 }
 
 // NemoRequestGuardFactory is the factory function for NemoRequestGuardPlugin.
 func NemoRequestGuardFactory(name string, rawParameters json.RawMessage, _ framework.Handle) (framework.BBRPlugin, error) {
-	config := nemoRequestGuardConfig{
-		TimeoutSeconds: defaultTimeoutSec, // if no timeout set in raw params, default will be used
+	config := nemoGuardConfig{
+		TimeoutSeconds: defaultTimeoutSec,
 	}
 
 	if len(rawParameters) > 0 {
@@ -89,38 +56,18 @@ func NemoRequestGuardFactory(name string, rawParameters json.RawMessage, _ frame
 		return nil, fmt.Errorf("failed to create '%s' plugin - %w", NemoRequestGuardPluginType, err)
 	}
 
-	return p.WithName(name), nil
+	p.WithName(name)
+	return p, nil
 }
 
 // NewNemoRequestGuardPlugin builds a NeMo request guard plugin from validated parameters.
 // The NeMo server is expected to have a default configuration (--default-config-id).
 func NewNemoRequestGuardPlugin(nemoURL string, timeoutSeconds int) (*NemoRequestGuardPlugin, error) {
-	if nemoURL == "" {
-		return nil, fmt.Errorf("nemoURL is required for plugin '%s'", NemoRequestGuardPluginType)
+	base, err := newNemoGuardBase(NemoRequestGuardPluginType, nemoURL, timeoutSeconds)
+	if err != nil {
+		return nil, err
 	}
-	timeout := time.Duration(timeoutSeconds) * time.Second
-	if timeout <= 0 {
-		timeout = defaultTimeoutSec * time.Second
-	}
-
-	return &NemoRequestGuardPlugin{
-		typedName: plugin.TypedName{Type: NemoRequestGuardPluginType, Name: NemoRequestGuardPluginType},
-		nemoURL:   nemoURL,
-		httpClient: &http.Client{
-			Timeout: timeout,
-		},
-	}, nil
-}
-
-// TypedName returns the type and name tuple of this plugin instance.
-func (p *NemoRequestGuardPlugin) TypedName() plugin.TypedName {
-	return p.typedName
-}
-
-// WithName sets the name of the plugin instance.
-func (p *NemoRequestGuardPlugin) WithName(name string) *NemoRequestGuardPlugin {
-	p.typedName.Name = name
-	return p
+	return &NemoRequestGuardPlugin{nemoGuardBase: *base}, nil
 }
 
 // ProcessRequest calls NeMo Guardrails to evaluate input rails on the incoming request.
@@ -138,7 +85,7 @@ func (p *NemoRequestGuardPlugin) ProcessRequest(ctx context.Context, _ *framewor
 
 	messages, err := extractMessages(request.Body)
 	if err != nil {
-		return errcommon.Error{Code: errcommon.BadRequest, Msg: fmt.Sprintf("nemo-request-guard: malformed request body: %v", err)}
+		return errcommon.Error{Code: errcommon.BadRequest, Msg: fmt.Sprintf("malformed request body: %v", err)}
 	}
 	if len(messages) == 0 {
 		return nil // no messages to check (e.g. non-chat request) → allow
@@ -152,53 +99,17 @@ func (p *NemoRequestGuardPlugin) ProcessRequest(ctx context.Context, _ *framewor
 	}
 	payload, err := json.Marshal(reqBody)
 	if err != nil {
-		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("nemo-request-guard: marshal request: %v", err)}
+		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("marshal request: %v", err)}
 	}
 
-	logger := log.FromContext(ctx)
-	logger.V(logutil.VERBOSE).Info("calling NeMo guardrails", "url", p.nemoURL)
-
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.nemoURL, bytes.NewReader(payload))
-	if err != nil {
-		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("nemo-request-guard: create request: %v", err)}
+	code, callErr := p.callNemoGuard(ctx, payload)
+	if callErr != nil {
+		if code == errcommon.Forbidden {
+			return errcommon.Error{Code: code, Msg: "request blocked by NeMo guardrails"}
+		}
+		return errcommon.Error{Code: code, Msg: callErr.Error()}
 	}
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	resp, err := p.httpClient.Do(httpReq)
-	if err != nil {
-		return errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: fmt.Sprintf("nemo-request-guard: call failed: %v", err)}
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: fmt.Sprintf("nemo-request-guard: unexpected status %d", resp.StatusCode)}
-	}
-
-	limited := io.LimitReader(resp.Body, maxNemoResponseBytes)
-	body, err := io.ReadAll(limited)
-	if err != nil {
-		return errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: fmt.Sprintf("nemo-request-guard: read response: %v", err)}
-	}
-
-	var response nemoResponse
-	if err := json.Unmarshal(body, &response); err != nil {
-		return errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: fmt.Sprintf("nemo-request-guard: decode response: %v", err)}
-	}
-
-	if strings.EqualFold(strings.TrimSpace(response.Status), nemoAllowedStatus) {
-		logger.V(logutil.VERBOSE).Info("request allowed by NeMo guardrails")
-		return nil
-	}
-
-	// handle block message
-	railsParts := make([]string, 0, len(response.RailsStatus))
-	for key, value := range response.RailsStatus {
-		railsParts = append(railsParts, fmt.Sprintf("%s: %s", key, value.Status))
-	}
-	railsStatus := fmt.Sprintf("[ %s ]", strings.Join(railsParts, " "))
-
-	logger.Info("request blocked by NeMo guardrails", "railsStatus", railsStatus)
-	return errcommon.Error{Code: errcommon.Forbidden, Msg: "request blocked by NeMo guardrails"}
+	return nil
 }
 
 // extractMessages pulls OpenAI-style "messages" from the body and returns the last user message

--- a/pkg/plugins/nemo/request_guard.go
+++ b/pkg/plugins/nemo/request_guard.go
@@ -56,8 +56,7 @@ func NemoRequestGuardFactory(name string, rawParameters json.RawMessage, _ frame
 		return nil, fmt.Errorf("failed to create '%s' plugin - %w", NemoRequestGuardPluginType, err)
 	}
 
-	p.WithName(name)
-	return p, nil
+	return p.WithName(name), nil
 }
 
 // NewNemoRequestGuardPlugin builds a NeMo request guard plugin from validated parameters.

--- a/pkg/plugins/nemo/request_guard_test.go
+++ b/pkg/plugins/nemo/request_guard_test.go
@@ -79,7 +79,7 @@ func TestNemoRequestGuardTypedName(t *testing.T) {
 
 	assert.Equal(t, NemoRequestGuardPluginType, p.TypedName().Name)
 
-	p = p.WithName("my-guardrail")
+	p.WithName("my-guardrail")
 	tn := p.TypedName()
 	assert.Equal(t, NemoRequestGuardPluginType, tn.Type)
 	assert.Equal(t, "my-guardrail", tn.Name)


### PR DESCRIPTION
## Summary

Extract shared HTTP/config logic from `nemo-request-guard` into a new `nemo_guard.go` file (`nemoGuardBase` struct), preparing for the upcoming `nemo-response-guard` plugin which will reuse the same base.

- **New file `nemo_guard.go`**: shared types (`nemoGuardConfig`, `nemoResponse`, `nemoRailStatusEntry`), constants, `nemoGuardBase` struct with `callNemoGuard` method
- **Refactored `request_guard.go`**: embeds `nemoGuardBase` instead of duplicating HTTP client, config types, and NeMo communication logic
- **Sanitized logging**: `callNemoGuard` logs only the host portion of the NeMo URL, not the full URL (avoids leaking credentials if URL contains userinfo or query tokens) - something that coderabbit catches in the response guard old PR (https://github.com/opendatahub-io/ai-gateway-payload-processing/pull/113#discussion_r3059437830)

### Minor behavioral change

The 403 error message changed from `"request blocked by NeMo guardrails"` to `"nemo-request-guard: blocked by NeMo guardrails"` — the plugin type prefix is added by the shared `callNemoGuard` method to identify which guard plugin blocked the request (useful when both request and response guards are active).

## Test plan

- [x] All 26 unit tests pass (`go test ./pkg/plugins/nemo/`)
- [x] 2 new URL validation tests added
- [x] `go vet` clean
- [x] E2E tested on Kind cluster: Istio Gateway → Envoy ext-proc → BBR (refactored plugin) → NeMo guardrails
  - Safe requests → 200 (passed through to backend)
  - Bad request → 403 (blocked by NeMo)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal reorganization of the NeMo request-guard plugin to introduce a shared guardrail base, consolidate NeMo request/response handling, centralize plugin naming, and simplify error routing.
* **Tests**
  * Updated unit test to reflect the new naming/initialization approach for the plugin instance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->