### PR TITLE
fix: update llm-katan simulator IP to Elastic IP

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  E2E_SIMULATOR_ENDPOINT: "3.150.113.9"
+  E2E_SIMULATOR_ENDPOINT: "3.13.21.181"
 
 jobs:
   check-changes:

--- a/pkg/plugins/api-translation/translator/azure/azure_openai_test.go
+++ b/pkg/plugins/api-translation/translator/azure/azure_openai_test.go
@@ -369,7 +369,7 @@ func TestTranslateResponse_StreamingChunkStripsAzureFields(t *testing.T) {
 
 // TestTranslateResponse_LiveMockIntegration fetches a real Azure OpenAI response from
 // the llm-katan mock server and verifies that TranslateResponse strips Azure-specific fields.
-// Set LLM_KATAN_URL to enable (e.g. LLM_KATAN_URL=http://3.150.113.9:8000).
+// Set LLM_KATAN_URL to enable (e.g. LLM_KATAN_URL=http://3.13.21.181:8000).
 func TestTranslateResponse_LiveMockIntegration(t *testing.T) {
 	baseURL := os.Getenv("LLM_KATAN_URL")
 	if baseURL == "" {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	defaultNs                = "bbr-e2e"
-	defaultSimulatorEndpoint = "3.150.113.9"
+	defaultSimulatorEndpoint = "3.13.21.181"
 	defaultGatewayName       = "e2e-gateway"
 	defaultGatewayNamespace  = "default"
 )

--- a/test/e2e/scripts/entrypoint.sh
+++ b/test/e2e/scripts/entrypoint.sh
@@ -9,7 +9,7 @@
 #   E2E_NS                   - Test namespace (default: bbr-e2e)
 #   E2E_GATEWAY_NAMESPACE    - Gateway namespace (default: default)
 #   E2E_GATEWAY_NAME         - Gateway name (default: e2e-gateway)
-#   E2E_SIMULATOR_ENDPOINT   - Simulator IP/host (default: 3.150.113.9)
+#   E2E_SIMULATOR_ENDPOINT   - Simulator IP/host (default: 3.13.21.181)
 #   E2E_SIMULATOR_VALIDATE_KEYS - Enable key validation tests (true/false)
 
 set -euo pipefail

--- a/test/e2e/scripts/setup-kind.sh
+++ b/test/e2e/scripts/setup-kind.sh
@@ -9,7 +9,7 @@
 # Environment variables:
 #   KIND_CLUSTER_NAME    - Kind cluster name (default: bbr-e2e)
 #   ISTIO_VERSION        - Istio version (default: 1.27.0-alpha.0)
-#   E2E_SIMULATOR_ENDPOINT - Simulator IP (default: 3.150.113.9)
+#   E2E_SIMULATOR_ENDPOINT - Simulator IP (default: 3.13.21.181)
 
 set -euo pipefail
 
@@ -18,7 +18,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-bbr-e2e}"
 ISTIO_VERSION="${ISTIO_VERSION:-1.29.2}"
-SIMULATOR_ENDPOINT="${E2E_SIMULATOR_ENDPOINT:-3.150.113.9}"
+SIMULATOR_ENDPOINT="${E2E_SIMULATOR_ENDPOINT:-3.13.21.181}"
 GATEWAY_NAMESPACE="default"
 GATEWAY_NAME="e2e-gateway"
 


### PR DESCRIPTION
## Summary
- Updated default simulator endpoint from ephemeral IP `3.150.113.9` to Elastic IP `3.13.21.181`
- Affects E2E test defaults and setup script
- IP is now permanent (Elastic IP) and will survive instance reboots/stop-starts

## Test plan
- [ ] Verify simulator is reachable at new IP: `curl http://3.13.21.181:8000/v1/models`
- [ ] Run E2E tests with default endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure endpoint configuration to use new simulator endpoint address.

---

**Note:** This release contains internal test infrastructure updates with no impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->