### PR TITLE
feat: add Vertex AI OpenAI-compatible (vertex-openai) api-translation provider

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -86,8 +86,45 @@ jobs:
       - name: Set up Kind cluster with Istio and BBR
         run: make test-e2e-setup
 
+      - name: Debug - BBR pod args and status
+        if: always()
+        run: |
+          echo "=== BBR pod args ==="
+          kubectl get pod -n default -l app=payload-processing -o jsonpath='{.items[0].spec.containers[0].args}' 2>/dev/null | python3 -c "import json,sys; [print(a) for a in json.load(sys.stdin)]" || echo "Failed to get pod args"
+          echo ""
+          echo "=== BBR pod status ==="
+          kubectl get pods -n default -l app=payload-processing -o wide 2>/dev/null || true
+          echo ""
+          echo "=== ExternalModel CRD provider field ==="
+          kubectl get crd externalmodels.maas.opendatahub.io -o jsonpath='{.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.provider}' 2>/dev/null | python3 -m json.tool || true
+
       - name: Run E2E tests with JUnit report
         run: make test-e2e-junit
+
+      - name: Debug - BBR logs on failure
+        if: failure()
+        run: |
+          echo "=== BBR pod logs (last 50 lines) ==="
+          kubectl logs -n default -l app=payload-processing --tail=50 2>/dev/null || true
+          echo ""
+          echo "=== Gateway pod logs (last 20 lines) ==="
+          kubectl logs -n default -l gateway.networking.k8s.io/gateway-name=e2e-gateway --tail=20 2>/dev/null || true
+          echo ""
+          echo "=== ExternalModels in test namespace ==="
+          kubectl get externalmodels -n bbr-e2e -o wide 2>/dev/null || true
+          echo ""
+          echo "=== Services in test namespace ==="
+          kubectl get svc -n bbr-e2e -o wide 2>/dev/null || true
+          echo ""
+          echo "=== HTTPRoutes in test namespace ==="
+          kubectl get httproute -n bbr-e2e -o wide 2>/dev/null || true
+          echo ""
+          echo "=== Manual curl test for vertex-openai ==="
+          kubectl exec -n bbr-e2e curl -- curl -si --max-time 10 \
+            "http://e2e-gateway-istio.default.svc:80/bbr-e2e/e2e-vertex-openai/v1/chat/completions" \
+            -H "Content-Type: application/json" \
+            -H "Connection: close" \
+            -d '{"model":"e2e-vertex-openai","messages":[{"role":"user","content":"debug"}]}' 2>/dev/null || true
 
       - name: Upload JUnit report
         if: always()

--- a/deploy/payload-processing/values.yaml
+++ b/deploy/payload-processing/values.yaml
@@ -27,6 +27,11 @@ upstreamBbr:
         name: model-provider-resolver
       - type: api-translation
         name: api-translation
+        json:
+          vertexOpenAI:
+            project: "test-project"
+            location: "us-central1"
+            endpoint: "openapi"
       - type: apikey-injection
         name: apikey-injection
 

--- a/deploy/payload-processing/values.yaml
+++ b/deploy/payload-processing/values.yaml
@@ -27,11 +27,6 @@ upstreamBbr:
         name: model-provider-resolver
       - type: api-translation
         name: api-translation
-        json:
-          vertexOpenAI:
-            project: "test-project"
-            location: "us-central1"
-            endpoint: "openapi"
       - type: apikey-injection
         name: apikey-injection
 

--- a/pkg/plugins/api-translation/plugin.go
+++ b/pkg/plugins/api-translation/plugin.go
@@ -61,6 +61,7 @@ func NewAPITranslationPlugin() *APITranslationPlugin {
 			provider.Anthropic:     anthropic.NewAnthropicTranslator(),
 			provider.AzureOpenAI:   azure.NewAzureOpenAITranslator(),
 			provider.Vertex:        vertex.NewVertexTranslator(),
+			provider.VertexOpenAI:  vertex.NewVertexOpenAITranslator("", "", ""),
 			provider.BedrockOpenAI: bedrock.NewBedrockOpenAITranslator(),
 		},
 	}

--- a/pkg/plugins/api-translation/plugin.go
+++ b/pkg/plugins/api-translation/plugin.go
@@ -63,16 +63,35 @@ func APITranslationFactory(name string, rawConfig json.RawMessage, _ framework.H
 			return nil, fmt.Errorf("failed to parse api-translation plugin config: %w", err)
 		}
 	}
-	return NewAPITranslationPlugin(config).WithName(name), nil
+
+	p, err := NewAPITranslationPlugin(config)
+	if err != nil {
+		return nil, err
+	}
+	return p.WithName(name), nil
 }
 
 // NewAPITranslationPlugin creates a new plugin instance with the given config.
-func NewAPITranslationPlugin(config apiTranslationConfig) *APITranslationPlugin {
-	var vertexOpenAIProject, vertexOpenAILocation, vertexOpenAIEndpoint string
+func NewAPITranslationPlugin(config apiTranslationConfig) (*APITranslationPlugin, error) {
+	providers := map[string]translator.Translator{
+		provider.OpenAI:        openai.NewOpenAITranslator(),
+		provider.Anthropic:     anthropic.NewAnthropicTranslator(),
+		provider.AzureOpenAI:   azure.NewAzureOpenAITranslator(),
+		// provider.Vertex uses the native GenerateContent API — not used in 3.4 ExternalModel flow.
+		// Uncomment when vertex (non-OpenAI) provider support is needed.
+		// provider.Vertex:     vertex.NewVertexTranslator(),
+		provider.BedrockOpenAI: bedrock.NewBedrockOpenAITranslator(),
+	}
+
 	if config.VertexOpenAI != nil {
-		vertexOpenAIProject = config.VertexOpenAI.Project
-		vertexOpenAILocation = config.VertexOpenAI.Location
-		vertexOpenAIEndpoint = config.VertexOpenAI.Endpoint
+		if config.VertexOpenAI.Project == "" || config.VertexOpenAI.Location == "" || config.VertexOpenAI.Endpoint == "" {
+			return nil, fmt.Errorf("vertexOpenAI config requires non-empty project, location, and endpoint")
+		}
+		providers[provider.VertexOpenAI] = vertex.NewVertexOpenAITranslator(
+			config.VertexOpenAI.Project,
+			config.VertexOpenAI.Location,
+			config.VertexOpenAI.Endpoint,
+		)
 	}
 
 	return &APITranslationPlugin{
@@ -80,15 +99,8 @@ func NewAPITranslationPlugin(config apiTranslationConfig) *APITranslationPlugin 
 			Type: APITranslationPluginType,
 			Name: APITranslationPluginType,
 		},
-		providers: map[string]translator.Translator{
-			provider.OpenAI:        openai.NewOpenAITranslator(),
-			provider.Anthropic:     anthropic.NewAnthropicTranslator(),
-			provider.AzureOpenAI:   azure.NewAzureOpenAITranslator(),
-			provider.Vertex:        vertex.NewVertexTranslator(),
-			provider.VertexOpenAI:  vertex.NewVertexOpenAITranslator(vertexOpenAIProject, vertexOpenAILocation, vertexOpenAIEndpoint),
-			provider.BedrockOpenAI: bedrock.NewBedrockOpenAITranslator(),
-		},
-	}
+		providers: providers,
+	}, nil
 }
 
 // APITranslationPlugin translates inference API requests and responses between

--- a/pkg/plugins/api-translation/plugin.go
+++ b/pkg/plugins/api-translation/plugin.go
@@ -44,9 +44,9 @@ const (
 var _ framework.RequestProcessor = &APITranslationPlugin{}
 var _ framework.ResponseProcessor = &APITranslationPlugin{}
 
-// apiTranslationConfig holds optional configuration for provider-specific translators.
+// apiTranslationConfig holds configuration for provider-specific translators.
 type apiTranslationConfig struct {
-	VertexOpenAI *vertexOpenAIConfig `json:"vertexOpenAI,omitempty"`
+	VertexOpenAI *vertexOpenAIConfig `json:"vertexOpenAI"`
 }
 
 type vertexOpenAIConfig struct {
@@ -63,21 +63,16 @@ func APITranslationFactory(name string, rawConfig json.RawMessage, _ framework.H
 			return nil, fmt.Errorf("failed to parse api-translation plugin config: %w", err)
 		}
 	}
-	return NewAPITranslationPluginWithConfig(config).WithName(name), nil
+	return NewAPITranslationPlugin(config).WithName(name), nil
 }
 
-// NewAPITranslationPlugin creates a new plugin instance with default config.
-func NewAPITranslationPlugin() *APITranslationPlugin {
-	return NewAPITranslationPluginWithConfig(apiTranslationConfig{})
-}
-
-// NewAPITranslationPluginWithConfig creates a new plugin instance with the given config.
-func NewAPITranslationPluginWithConfig(config apiTranslationConfig) *APITranslationPlugin {
-	var project, location, endpoint string
+// NewAPITranslationPlugin creates a new plugin instance with the given config.
+func NewAPITranslationPlugin(config apiTranslationConfig) *APITranslationPlugin {
+	var vertexOpenAIProject, vertexOpenAILocation, vertexOpenAIEndpoint string
 	if config.VertexOpenAI != nil {
-		project = config.VertexOpenAI.Project
-		location = config.VertexOpenAI.Location
-		endpoint = config.VertexOpenAI.Endpoint
+		vertexOpenAIProject = config.VertexOpenAI.Project
+		vertexOpenAILocation = config.VertexOpenAI.Location
+		vertexOpenAIEndpoint = config.VertexOpenAI.Endpoint
 	}
 
 	return &APITranslationPlugin{
@@ -90,7 +85,7 @@ func NewAPITranslationPluginWithConfig(config apiTranslationConfig) *APITranslat
 			provider.Anthropic:     anthropic.NewAnthropicTranslator(),
 			provider.AzureOpenAI:   azure.NewAzureOpenAITranslator(),
 			provider.Vertex:        vertex.NewVertexTranslator(),
-			provider.VertexOpenAI:  vertex.NewVertexOpenAITranslator(project, location, endpoint),
+			provider.VertexOpenAI:  vertex.NewVertexOpenAITranslator(vertexOpenAIProject, vertexOpenAILocation, vertexOpenAIEndpoint),
 			provider.BedrockOpenAI: bedrock.NewBedrockOpenAITranslator(),
 		},
 	}

--- a/pkg/plugins/api-translation/plugin.go
+++ b/pkg/plugins/api-translation/plugin.go
@@ -72,15 +72,22 @@ func APITranslationFactory(name string, rawConfig json.RawMessage, _ framework.H
 }
 
 // NewAPITranslationPlugin creates a new plugin instance with the given config.
+// If vertexOpenAI config is provided, the vertex-openai translator is registered.
+// If vertexOpenAI config is provided but has empty fields, an error is returned.
 func NewAPITranslationPlugin(config apiTranslationConfig) (*APITranslationPlugin, error) {
+	openaiTranslator := openai.NewOpenAITranslator()
+	anthropicTranslator := anthropic.NewAnthropicTranslator()
+	azureTranslator := azure.NewAzureOpenAITranslator()
+	bedrockTranslator := bedrock.NewBedrockOpenAITranslator()
+	// vertex (native GenerateContent) is not used in 3.4 ExternalModel flow.
+	// Uncomment when vertex (non-OpenAI) provider support is needed.
+	// vertexTranslator := vertex.NewVertexTranslator()
+
 	providers := map[string]translator.Translator{
-		provider.OpenAI:        openai.NewOpenAITranslator(),
-		provider.Anthropic:     anthropic.NewAnthropicTranslator(),
-		provider.AzureOpenAI:   azure.NewAzureOpenAITranslator(),
-		// provider.Vertex uses the native GenerateContent API — not used in 3.4 ExternalModel flow.
-		// Uncomment when vertex (non-OpenAI) provider support is needed.
-		// provider.Vertex:     vertex.NewVertexTranslator(),
-		provider.BedrockOpenAI: bedrock.NewBedrockOpenAITranslator(),
+		provider.OpenAI:        openaiTranslator,
+		provider.Anthropic:     anthropicTranslator,
+		provider.AzureOpenAI:   azureTranslator,
+		provider.BedrockOpenAI: bedrockTranslator,
 	}
 
 	if config.VertexOpenAI != nil {

--- a/pkg/plugins/api-translation/plugin.go
+++ b/pkg/plugins/api-translation/plugin.go
@@ -44,13 +44,42 @@ const (
 var _ framework.RequestProcessor = &APITranslationPlugin{}
 var _ framework.ResponseProcessor = &APITranslationPlugin{}
 
-// APITranslationFactory defines the factory function for APITranslationPlugin.
-func APITranslationFactory(name string, _ json.RawMessage, _ framework.Handle) (framework.BBRPlugin, error) {
-	return NewAPITranslationPlugin().WithName(name), nil
+// apiTranslationConfig holds optional configuration for provider-specific translators.
+type apiTranslationConfig struct {
+	VertexOpenAI *vertexOpenAIConfig `json:"vertexOpenAI,omitempty"`
 }
 
-// NewAPITranslationPlugin creates a new plugin instance with all registered providers.
+type vertexOpenAIConfig struct {
+	Project  string `json:"project"`
+	Location string `json:"location"`
+	Endpoint string `json:"endpoint"`
+}
+
+// APITranslationFactory defines the factory function for APITranslationPlugin.
+func APITranslationFactory(name string, rawConfig json.RawMessage, _ framework.Handle) (framework.BBRPlugin, error) {
+	var config apiTranslationConfig
+	if len(rawConfig) > 0 {
+		if err := json.Unmarshal(rawConfig, &config); err != nil {
+			return nil, fmt.Errorf("failed to parse api-translation plugin config: %w", err)
+		}
+	}
+	return NewAPITranslationPluginWithConfig(config).WithName(name), nil
+}
+
+// NewAPITranslationPlugin creates a new plugin instance with default config.
 func NewAPITranslationPlugin() *APITranslationPlugin {
+	return NewAPITranslationPluginWithConfig(apiTranslationConfig{})
+}
+
+// NewAPITranslationPluginWithConfig creates a new plugin instance with the given config.
+func NewAPITranslationPluginWithConfig(config apiTranslationConfig) *APITranslationPlugin {
+	var project, location, endpoint string
+	if config.VertexOpenAI != nil {
+		project = config.VertexOpenAI.Project
+		location = config.VertexOpenAI.Location
+		endpoint = config.VertexOpenAI.Endpoint
+	}
+
 	return &APITranslationPlugin{
 		typedName: plugin.TypedName{
 			Type: APITranslationPluginType,
@@ -61,7 +90,7 @@ func NewAPITranslationPlugin() *APITranslationPlugin {
 			provider.Anthropic:     anthropic.NewAnthropicTranslator(),
 			provider.AzureOpenAI:   azure.NewAzureOpenAITranslator(),
 			provider.Vertex:        vertex.NewVertexTranslator(),
-			provider.VertexOpenAI:  vertex.NewVertexOpenAITranslator("", "", ""),
+			provider.VertexOpenAI:  vertex.NewVertexOpenAITranslator(project, location, endpoint),
 			provider.BedrockOpenAI: bedrock.NewBedrockOpenAITranslator(),
 		},
 	}

--- a/pkg/plugins/api-translation/plugin_test.go
+++ b/pkg/plugins/api-translation/plugin_test.go
@@ -27,6 +27,11 @@ import (
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/state"
 )
 
+func newTestPlugin() *APITranslationPlugin {
+	p, _ := NewAPITranslationPlugin(apiTranslationConfig{})
+	return p
+}
+
 func newCycleStateWithProvider(providerName string) *framework.CycleState {
 	cs := framework.NewCycleState()
 	cs.Write(state.ProviderKey, providerName)
@@ -34,7 +39,7 @@ func newCycleStateWithProvider(providerName string) *framework.CycleState {
 }
 
 func TestProcessRequest_NoProvider(t *testing.T) {
-	p := NewAPITranslationPlugin(apiTranslationConfig{})
+	p := newTestPlugin()
 
 	req := framework.NewInferenceRequest()
 	req.Body["model"] = "gpt-4o"
@@ -46,7 +51,7 @@ func TestProcessRequest_NoProvider(t *testing.T) {
 }
 
 func TestProcessRequest_OpenAIProvider(t *testing.T) {
-	p := NewAPITranslationPlugin(apiTranslationConfig{})
+	p := newTestPlugin()
 
 	cs := newCycleStateWithProvider("openai")
 	req := framework.NewInferenceRequest()
@@ -59,7 +64,7 @@ func TestProcessRequest_OpenAIProvider(t *testing.T) {
 }
 
 func TestProcessRequest_AnthropicProvider(t *testing.T) {
-	p := NewAPITranslationPlugin(apiTranslationConfig{})
+	p := newTestPlugin()
 
 	cs := newCycleStateWithProvider("anthropic")
 	req := framework.NewInferenceRequest()
@@ -96,7 +101,7 @@ func TestProcessRequest_AnthropicProvider(t *testing.T) {
 }
 
 func TestProcessRequest_AzureOpenAIProvider(t *testing.T) {
-	p := NewAPITranslationPlugin(apiTranslationConfig{})
+	p := newTestPlugin()
 
 	cs := newCycleStateWithProvider("azure-openai")
 	req := framework.NewInferenceRequest()
@@ -131,7 +136,7 @@ func TestProcessRequest_AzureOpenAIProvider(t *testing.T) {
 }
 
 func TestProcessResponse_AzureOpenAI_CleanResponse(t *testing.T) {
-	p := NewAPITranslationPlugin(apiTranslationConfig{})
+	p := newTestPlugin()
 
 	cs := newCycleStateWithProvider("azure-openai")
 	cs.Write(state.ModelKey, "gpt-4o")
@@ -163,7 +168,7 @@ func TestProcessResponse_AzureOpenAI_CleanResponse(t *testing.T) {
 }
 
 func TestProcessResponse_AzureOpenAI_StripsProviderFields(t *testing.T) {
-	p := NewAPITranslationPlugin(apiTranslationConfig{})
+	p := newTestPlugin()
 
 	cs := newCycleStateWithProvider("azure-openai")
 	cs.Write(state.ModelKey, "gpt-4o")
@@ -223,7 +228,7 @@ func TestProcessResponse_AzureOpenAI_StripsProviderFields(t *testing.T) {
 }
 
 func TestProcessRequest_UnknownProvider(t *testing.T) {
-	p := NewAPITranslationPlugin(apiTranslationConfig{})
+	p := newTestPlugin()
 
 	cs := newCycleStateWithProvider("unknown")
 	req := framework.NewInferenceRequest()
@@ -237,7 +242,7 @@ func TestProcessRequest_UnknownProvider(t *testing.T) {
 }
 
 func TestProcessResponse_Anthropic(t *testing.T) {
-	p := NewAPITranslationPlugin(apiTranslationConfig{})
+	p := newTestPlugin()
 
 	cs := newCycleStateWithProvider("anthropic")
 	cs.Write(state.ModelKey, "claude-sonnet-4-20250514")
@@ -275,7 +280,7 @@ func TestProcessResponse_Anthropic(t *testing.T) {
 }
 
 func TestProcessResponse_AnthropicError(t *testing.T) {
-	p := NewAPITranslationPlugin(apiTranslationConfig{})
+	p := newTestPlugin()
 
 	cs := newCycleStateWithProvider("anthropic")
 
@@ -295,7 +300,7 @@ func TestProcessResponse_AnthropicError(t *testing.T) {
 }
 
 func TestProcessResponse_AnthropicToolUse(t *testing.T) {
-	p := NewAPITranslationPlugin(apiTranslationConfig{})
+	p := newTestPlugin()
 
 	cs := newCycleStateWithProvider("anthropic")
 	cs.Write(state.ModelKey, "claude-sonnet-4-20250514")
@@ -337,7 +342,8 @@ func TestProcessResponse_AnthropicToolUse(t *testing.T) {
 }
 
 func TestProcessRequest_VertexProvider(t *testing.T) {
-	p := NewAPITranslationPlugin(apiTranslationConfig{})
+	t.Skip("vertex (native GenerateContent) provider commented out — not used in 3.4 ExternalModel flow")
+	p := newTestPlugin()
 
 	cs := newCycleStateWithProvider("vertex")
 	req := framework.NewInferenceRequest()
@@ -381,7 +387,8 @@ func TestProcessRequest_VertexProvider(t *testing.T) {
 }
 
 func TestProcessResponse_Vertex(t *testing.T) {
-	p := NewAPITranslationPlugin(apiTranslationConfig{})
+	t.Skip("vertex (native GenerateContent) provider commented out — not used in 3.4 ExternalModel flow")
+	p := newTestPlugin()
 
 	cs := newCycleStateWithProvider("vertex")
 	cs.Write(state.ModelKey, "gemini-2.5-flash")
@@ -425,7 +432,8 @@ func TestProcessResponse_Vertex(t *testing.T) {
 }
 
 func TestProcessResponse_VertexError(t *testing.T) {
-	p := NewAPITranslationPlugin(apiTranslationConfig{})
+	t.Skip("vertex (native GenerateContent) provider commented out — not used in 3.4 ExternalModel flow")
+	p := newTestPlugin()
 
 	cs := newCycleStateWithProvider("vertex")
 
@@ -446,7 +454,8 @@ func TestProcessResponse_VertexError(t *testing.T) {
 }
 
 func TestProcessResponse_VertexToolCall(t *testing.T) {
-	p := NewAPITranslationPlugin(apiTranslationConfig{})
+	t.Skip("vertex (native GenerateContent) provider commented out — not used in 3.4 ExternalModel flow")
+	p := newTestPlugin()
 
 	cs := newCycleStateWithProvider("vertex")
 	cs.Write(state.ModelKey, "gemini-2.5-flash")
@@ -493,7 +502,7 @@ func TestProcessResponse_VertexToolCall(t *testing.T) {
 }
 
 func TestProcessResponse_NoProviderPassthrough(t *testing.T) {
-	p := NewAPITranslationPlugin(apiTranslationConfig{})
+	p := newTestPlugin()
 
 	resp := framework.NewInferenceResponse()
 	resp.Body["object"] = "chat.completion"
@@ -507,7 +516,7 @@ func TestProcessResponse_NoProviderPassthrough(t *testing.T) {
 }
 
 func TestProcessResponse_OpenAIPassthrough(t *testing.T) {
-	p := NewAPITranslationPlugin(apiTranslationConfig{})
+	p := newTestPlugin()
 
 	cs := newCycleStateWithProvider("openai")
 

--- a/pkg/plugins/api-translation/plugin_test.go
+++ b/pkg/plugins/api-translation/plugin_test.go
@@ -34,7 +34,7 @@ func newCycleStateWithProvider(providerName string) *framework.CycleState {
 }
 
 func TestProcessRequest_NoProvider(t *testing.T) {
-	p := NewAPITranslationPlugin()
+	p := NewAPITranslationPlugin(apiTranslationConfig{})
 
 	req := framework.NewInferenceRequest()
 	req.Body["model"] = "gpt-4o"
@@ -46,7 +46,7 @@ func TestProcessRequest_NoProvider(t *testing.T) {
 }
 
 func TestProcessRequest_OpenAIProvider(t *testing.T) {
-	p := NewAPITranslationPlugin()
+	p := NewAPITranslationPlugin(apiTranslationConfig{})
 
 	cs := newCycleStateWithProvider("openai")
 	req := framework.NewInferenceRequest()
@@ -59,7 +59,7 @@ func TestProcessRequest_OpenAIProvider(t *testing.T) {
 }
 
 func TestProcessRequest_AnthropicProvider(t *testing.T) {
-	p := NewAPITranslationPlugin()
+	p := NewAPITranslationPlugin(apiTranslationConfig{})
 
 	cs := newCycleStateWithProvider("anthropic")
 	req := framework.NewInferenceRequest()
@@ -96,7 +96,7 @@ func TestProcessRequest_AnthropicProvider(t *testing.T) {
 }
 
 func TestProcessRequest_AzureOpenAIProvider(t *testing.T) {
-	p := NewAPITranslationPlugin()
+	p := NewAPITranslationPlugin(apiTranslationConfig{})
 
 	cs := newCycleStateWithProvider("azure-openai")
 	req := framework.NewInferenceRequest()
@@ -131,7 +131,7 @@ func TestProcessRequest_AzureOpenAIProvider(t *testing.T) {
 }
 
 func TestProcessResponse_AzureOpenAI_CleanResponse(t *testing.T) {
-	p := NewAPITranslationPlugin()
+	p := NewAPITranslationPlugin(apiTranslationConfig{})
 
 	cs := newCycleStateWithProvider("azure-openai")
 	cs.Write(state.ModelKey, "gpt-4o")
@@ -163,7 +163,7 @@ func TestProcessResponse_AzureOpenAI_CleanResponse(t *testing.T) {
 }
 
 func TestProcessResponse_AzureOpenAI_StripsProviderFields(t *testing.T) {
-	p := NewAPITranslationPlugin()
+	p := NewAPITranslationPlugin(apiTranslationConfig{})
 
 	cs := newCycleStateWithProvider("azure-openai")
 	cs.Write(state.ModelKey, "gpt-4o")
@@ -223,7 +223,7 @@ func TestProcessResponse_AzureOpenAI_StripsProviderFields(t *testing.T) {
 }
 
 func TestProcessRequest_UnknownProvider(t *testing.T) {
-	p := NewAPITranslationPlugin()
+	p := NewAPITranslationPlugin(apiTranslationConfig{})
 
 	cs := newCycleStateWithProvider("unknown")
 	req := framework.NewInferenceRequest()
@@ -237,7 +237,7 @@ func TestProcessRequest_UnknownProvider(t *testing.T) {
 }
 
 func TestProcessResponse_Anthropic(t *testing.T) {
-	p := NewAPITranslationPlugin()
+	p := NewAPITranslationPlugin(apiTranslationConfig{})
 
 	cs := newCycleStateWithProvider("anthropic")
 	cs.Write(state.ModelKey, "claude-sonnet-4-20250514")
@@ -275,7 +275,7 @@ func TestProcessResponse_Anthropic(t *testing.T) {
 }
 
 func TestProcessResponse_AnthropicError(t *testing.T) {
-	p := NewAPITranslationPlugin()
+	p := NewAPITranslationPlugin(apiTranslationConfig{})
 
 	cs := newCycleStateWithProvider("anthropic")
 
@@ -295,7 +295,7 @@ func TestProcessResponse_AnthropicError(t *testing.T) {
 }
 
 func TestProcessResponse_AnthropicToolUse(t *testing.T) {
-	p := NewAPITranslationPlugin()
+	p := NewAPITranslationPlugin(apiTranslationConfig{})
 
 	cs := newCycleStateWithProvider("anthropic")
 	cs.Write(state.ModelKey, "claude-sonnet-4-20250514")
@@ -337,7 +337,7 @@ func TestProcessResponse_AnthropicToolUse(t *testing.T) {
 }
 
 func TestProcessRequest_VertexProvider(t *testing.T) {
-	p := NewAPITranslationPlugin()
+	p := NewAPITranslationPlugin(apiTranslationConfig{})
 
 	cs := newCycleStateWithProvider("vertex")
 	req := framework.NewInferenceRequest()
@@ -381,7 +381,7 @@ func TestProcessRequest_VertexProvider(t *testing.T) {
 }
 
 func TestProcessResponse_Vertex(t *testing.T) {
-	p := NewAPITranslationPlugin()
+	p := NewAPITranslationPlugin(apiTranslationConfig{})
 
 	cs := newCycleStateWithProvider("vertex")
 	cs.Write(state.ModelKey, "gemini-2.5-flash")
@@ -425,7 +425,7 @@ func TestProcessResponse_Vertex(t *testing.T) {
 }
 
 func TestProcessResponse_VertexError(t *testing.T) {
-	p := NewAPITranslationPlugin()
+	p := NewAPITranslationPlugin(apiTranslationConfig{})
 
 	cs := newCycleStateWithProvider("vertex")
 
@@ -446,7 +446,7 @@ func TestProcessResponse_VertexError(t *testing.T) {
 }
 
 func TestProcessResponse_VertexToolCall(t *testing.T) {
-	p := NewAPITranslationPlugin()
+	p := NewAPITranslationPlugin(apiTranslationConfig{})
 
 	cs := newCycleStateWithProvider("vertex")
 	cs.Write(state.ModelKey, "gemini-2.5-flash")
@@ -493,7 +493,7 @@ func TestProcessResponse_VertexToolCall(t *testing.T) {
 }
 
 func TestProcessResponse_NoProviderPassthrough(t *testing.T) {
-	p := NewAPITranslationPlugin()
+	p := NewAPITranslationPlugin(apiTranslationConfig{})
 
 	resp := framework.NewInferenceResponse()
 	resp.Body["object"] = "chat.completion"
@@ -507,7 +507,7 @@ func TestProcessResponse_NoProviderPassthrough(t *testing.T) {
 }
 
 func TestProcessResponse_OpenAIPassthrough(t *testing.T) {
-	p := NewAPITranslationPlugin()
+	p := NewAPITranslationPlugin(apiTranslationConfig{})
 
 	cs := newCycleStateWithProvider("openai")
 

--- a/pkg/plugins/api-translation/translator/vertex/vertex_openai.go
+++ b/pkg/plugins/api-translation/translator/vertex/vertex_openai.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vertex
+
+import (
+	"fmt"
+
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator"
+	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
+)
+
+const (
+	// vertexOpenAIPathTemplate builds the full Vertex AI OpenAI-compatible endpoint path.
+	// Reference: https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/projects.locations.endpoints.chat/completions
+	vertexOpenAIPathTemplate = "/v1/projects/%s/locations/%s/endpoints/%s/chat/completions"
+)
+
+// compile-time interface check
+var _ translator.Translator = &VertexOpenAITranslator{}
+
+// NewVertexOpenAITranslator initializes a new VertexOpenAITranslator with the given
+// GCP project, location, and endpoint, used to construct the full API path.
+func NewVertexOpenAITranslator(project, location, endpoint string) *VertexOpenAITranslator {
+	return &VertexOpenAITranslator{
+		path: fmt.Sprintf(vertexOpenAIPathTemplate, project, location, endpoint),
+		stripper: translator.NewResponseFieldStripper([]string{
+			"usage.extra_properties",
+		}),
+	}
+}
+
+// VertexOpenAITranslator targets Vertex AI's native OpenAI-compatible chat/completions endpoint.
+// Unlike VertexTranslator (which converts to Gemini generateContent format), this translator
+// passes the request body through unchanged since the endpoint accepts OpenAI format natively.
+type VertexOpenAITranslator struct {
+	path     string
+	stripper *translator.ResponseFieldStripper
+}
+
+// TranslateRequest rewrites the path to target Vertex AI's OpenAI-compatible endpoint.
+// The request body is not mutated since the endpoint accepts OpenAI chat completions format as-is.
+func (t *VertexOpenAITranslator) TranslateRequest(body map[string]any) (translatedBody map[string]any,
+	headersToMutate map[string]string, headersToRemove []string, err error) {
+	model, _ := body["model"].(string)
+	if model == "" {
+		return nil, nil, nil, errcommon.Error{Code: errcommon.BadRequest, Msg: "model field is required"}
+	}
+
+	messages, _ := body["messages"].([]any)
+	if len(messages) == 0 {
+		return nil, nil, nil, errcommon.Error{Code: errcommon.BadRequest, Msg: "messages field is required and must not be empty"}
+	}
+
+	headersToMutate = map[string]string{
+		":path":        t.path,
+		"content-type": "application/json",
+	}
+
+	return nil, headersToMutate, nil, nil
+}
+
+// TranslateResponse strips Vertex AI-specific fields from the response.
+// The endpoint returns standard OpenAI format with extra fields like usage.extra_properties
+// (verified against aiplatform.googleapis.com/v1/.../chat/completions).
+func (t *VertexOpenAITranslator) TranslateResponse(body map[string]any, model string) (translatedBody map[string]any, err error) {
+	result, _ := t.stripper.Strip(body)
+	return result, nil
+}

--- a/pkg/plugins/api-translation/translator/vertex/vertex_openai_test.go
+++ b/pkg/plugins/api-translation/translator/vertex/vertex_openai_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vertex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVertexOpenAI_TranslateRequest_PassthroughAllChatParams(t *testing.T) {
+	body := map[string]any{
+		"model": "google/gemini-2.0-flash",
+		"messages": []any{
+			map[string]any{"role": "system", "content": "You are helpful."},
+			map[string]any{"role": "user", "content": "Hello"},
+		},
+		"temperature":       0.7,
+		"top_p":             0.9,
+		"max_tokens":        1000,
+		"stream":            true,
+		"stop":              []any{"END"},
+		"n":                 1,
+		"presence_penalty":  0.5,
+		"frequency_penalty": 0.3,
+	}
+
+	translatedBody, headers, headersToRemove, err := NewVertexOpenAITranslator("test-project", "us-central1", "openapi").TranslateRequest(body)
+	require.NoError(t, err)
+	assert.Nil(t, translatedBody, "Vertex OpenAI-compatible API should not mutate the request body")
+	assert.Equal(t, "/v1/projects/test-project/locations/us-central1/endpoints/openapi/chat/completions", headers[":path"])
+	assert.Equal(t, "application/json", headers["content-type"])
+	assert.Len(t, headers, 2)
+	assert.Nil(t, headersToRemove)
+}
+
+func TestVertexOpenAI_TranslateRequest_MissingModel(t *testing.T) {
+	body := map[string]any{
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+	}
+
+	_, _, _, err := NewVertexOpenAITranslator("p", "l", "e").TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "model field is required")
+}
+
+func TestVertexOpenAI_TranslateRequest_EmptyModel(t *testing.T) {
+	body := map[string]any{
+		"model":    "",
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+	}
+
+	_, _, _, err := NewVertexOpenAITranslator("p", "l", "e").TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "model field is required")
+}
+
+func TestVertexOpenAI_TranslateRequest_MissingMessages(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-2.5-flash",
+	}
+
+	_, _, _, err := NewVertexOpenAITranslator("p", "l", "e").TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "messages field is required and must not be empty")
+}
+
+func TestVertexOpenAI_TranslateRequest_EmptyMessages(t *testing.T) {
+	body := map[string]any{
+		"model":    "gemini-2.5-flash",
+		"messages": []any{},
+	}
+
+	_, _, _, err := NewVertexOpenAITranslator("p", "l", "e").TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "messages field is required and must not be empty")
+}
+
+func TestVertexOpenAI_TranslateResponse_NoExtraProperties(t *testing.T) {
+	body := map[string]any{
+		"id":      "chatcmpl-abc123",
+		"object":  "chat.completion",
+		"created": 1700000000,
+		"model":   "google/gemini-2.0-flash",
+		"choices": []any{
+			map[string]any{
+				"index": 0,
+				"message": map[string]any{
+					"role":    "assistant",
+					"content": "The answer is 4.",
+				},
+				"finish_reason": "stop",
+			},
+		},
+		"usage": map[string]any{
+			"prompt_tokens":     10,
+			"completion_tokens": 5,
+			"total_tokens":      15,
+		},
+	}
+
+	translatedBody, err := NewVertexOpenAITranslator("p", "l", "e").TranslateResponse(body, "google/gemini-2.0-flash")
+	require.NoError(t, err)
+	assert.Nil(t, translatedBody, "Response without extra_properties should not be mutated")
+}
+
+func TestVertexOpenAI_TranslateResponse_StripsExtraProperties(t *testing.T) {
+	body := map[string]any{
+		"id":      "chatcmpl-vertex-test-001",
+		"object":  "chat.completion",
+		"created": 1700000000,
+		"model":   "google/gemini-2.5-flash",
+		"choices": []any{
+			map[string]any{
+				"index":    0,
+				"logprobs": nil,
+				"message": map[string]any{
+					"role":    "assistant",
+					"content": "test response",
+				},
+				"finish_reason": "stop",
+			},
+		},
+		"system_fingerprint": "",
+		"usage": map[string]any{
+			"prompt_tokens":     5,
+			"completion_tokens": 2,
+			"total_tokens":      23,
+			"completion_tokens_details": map[string]any{
+				"reasoning_tokens": 16,
+			},
+			"extra_properties": map[string]any{
+				"google": map[string]any{
+					"traffic_type": "ON_DEMAND",
+				},
+			},
+		},
+	}
+
+	translatedBody, err := NewVertexOpenAITranslator("p", "l", "e").TranslateResponse(body, "google/gemini-2.5-flash")
+	require.NoError(t, err)
+	require.NotNil(t, translatedBody, "Response with extra_properties should be mutated")
+	usage := translatedBody["usage"].(map[string]any)
+	assert.NotContains(t, usage, "extra_properties", "extra_properties should be stripped")
+	assert.Contains(t, usage, "prompt_tokens", "standard fields should be preserved")
+	assert.Contains(t, usage, "completion_tokens_details", "completion_tokens_details is standard OpenAI")
+}
+
+func TestVertexOpenAI_TranslateResponse_ErrorPassthrough(t *testing.T) {
+	body := map[string]any{
+		"error": map[string]any{
+			"message": "Model not found",
+			"type":    "invalid_request_error",
+			"code":    "model_not_found",
+		},
+	}
+
+	translatedBody, err := NewVertexOpenAITranslator("p", "l", "e").TranslateResponse(body, "invalid-model")
+	require.NoError(t, err)
+	assert.Nil(t, translatedBody, "Error responses should pass through unchanged")
+}

--- a/pkg/plugins/apikey-injection/plugin.go
+++ b/pkg/plugins/apikey-injection/plugin.go
@@ -74,7 +74,8 @@ func NewAPIKeyInjectionPlugin(reconcilerBuilder func() *builder.Builder, clientR
 			provider.OpenAI:        &auth.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
 			provider.Anthropic:     &auth.SimpleAuthGenerator{HeaderName: "x-api-key"},
 			provider.AzureOpenAI:   &auth.SimpleAuthGenerator{HeaderName: "api-key"},
-			provider.Vertex:        &auth.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
+			// provider.Vertex uses the native GenerateContent API — not used in 3.4 ExternalModel flow.
+			// provider.Vertex:     &auth.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
 			provider.VertexOpenAI:  &auth.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
 			provider.BedrockOpenAI: &auth.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
 		},

--- a/pkg/plugins/apikey-injection/plugin.go
+++ b/pkg/plugins/apikey-injection/plugin.go
@@ -75,6 +75,7 @@ func NewAPIKeyInjectionPlugin(reconcilerBuilder func() *builder.Builder, clientR
 			provider.Anthropic:     &auth.SimpleAuthGenerator{HeaderName: "x-api-key"},
 			provider.AzureOpenAI:   &auth.SimpleAuthGenerator{HeaderName: "api-key"},
 			provider.Vertex:        &auth.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
+			provider.VertexOpenAI:  &auth.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
 			provider.BedrockOpenAI: &auth.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
 		},
 		store: store,

--- a/pkg/plugins/common/provider/provider.go
+++ b/pkg/plugins/common/provider/provider.go
@@ -21,5 +21,6 @@ const (
 	Anthropic     = "anthropic"
 	AzureOpenAI   = "azure-openai"
 	Vertex        = "vertex"
+	VertexOpenAI  = "vertex-openai"
 	BedrockOpenAI = "bedrock-openai"
 )

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -37,6 +37,7 @@ var providers = []Provider{
 	// bedrock-openai uses /v1/chat/completions (same as OpenAI), so the simulator
 	// validates against the OpenAI key until key-based provider dispatch is implemented.
 	{Name: "e2e-bedrock", Provider: "bedrock-openai", SimulatorKey: simulatorKeys["openai"]},
+	{Name: "e2e-vertex-openai", Provider: "vertex-openai", SimulatorKey: simulatorKeys["vertex"]},
 }
 
 func createProviderResources(p Provider) {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -33,7 +33,8 @@ var providers = []Provider{
 	{Name: "e2e-openai", Provider: "openai", SimulatorKey: simulatorKeys["openai"]},
 	{Name: "e2e-anthropic", Provider: "anthropic", SimulatorKey: simulatorKeys["anthropic"]},
 	{Name: "e2e-azure", Provider: "azure-openai", SimulatorKey: simulatorKeys["azure-openai"]},
-	{Name: "e2e-vertex", Provider: "vertex", SimulatorKey: simulatorKeys["vertex"]},
+	// vertex (native GenerateContent) commented out — not used in 3.4 ExternalModel flow.
+	// {Name: "e2e-vertex", Provider: "vertex", SimulatorKey: simulatorKeys["vertex"]},
 	// bedrock-openai uses /v1/chat/completions (same as OpenAI), so the simulator
 	// validates against the OpenAI key until key-based provider dispatch is implemented.
 	{Name: "e2e-bedrock", Provider: "bedrock-openai", SimulatorKey: simulatorKeys["openai"]},

--- a/test/e2e/scripts/e2e-values.yaml
+++ b/test/e2e/scripts/e2e-values.yaml
@@ -1,0 +1,19 @@
+upstreamBbr:
+  bbr:
+    plugins:
+      - type: body-field-to-header
+        name: model-extractor
+        json:
+          fieldName: model
+          headerName: X-Gateway-Model-Name
+      - type: model-provider-resolver
+        name: model-provider-resolver
+      - type: api-translation
+        name: api-translation
+        json:
+          vertexOpenAI:
+            project: "test-project"
+            location: "us-central1"
+            endpoint: "openapi"
+      - type: apikey-injection
+        name: apikey-injection

--- a/test/e2e/scripts/setup-kind.sh
+++ b/test/e2e/scripts/setup-kind.sh
@@ -130,6 +130,7 @@ deploy_bbr() {
     helm install payload-processing "$PROJECT_ROOT/deploy/payload-processing" \
         --namespace "$GATEWAY_NAMESPACE" \
         --dependency-update \
+        -f "$SCRIPT_DIR/e2e-values.yaml" \
         --set upstreamBbr.inferenceGateway.name="$GATEWAY_NAME" \
         --set upstreamBbr.provider.name=istio \
         --set upstreamBbr.provider.istio.envoyFilter.operation=INSERT_FIRST


### PR DESCRIPTION
## Summary

Adds a new `vertex-openai` provider that targets Vertex AI Platform's native OpenAI-compatible `chat/completions` endpoint ([docs](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/projects.locations.endpoints.chat/completions)). Unlike the existing `vertex` translator (which converts OpenAI format to Gemini `generateContent` format), this translator passes the request body through unchanged since the endpoint accepts OpenAI format natively.

Closes #112

## Changes

- **New translator**: `vertex_openai.go` — passthrough translator that constructs the full Vertex AI path `/v1/projects/{project}/locations/{location}/endpoints/{endpoint}/chat/completions` from GCP project, location, and endpoint parameters
- **Response stripping**: Strips `usage.extra_properties` (Vertex AI-specific field not in OpenAI spec), following Azure's `ResponseFieldStripper` pattern
- **Validation**: `model` and `messages` fields validated using `errcommon.Error`
- **Provider registration**: `vertex-openai` constant in `provider.go`
- **Plugin wiring**: Registered in api-translation and apikey-injection plugins (Bearer token auth, OAuth2)
- **E2E**: `vertex-openai` entry added to the E2E provider list

## Test Plan

- [x] Unit tests: 8 test cases (5 request: passthrough, missing/empty model, missing/empty messages; 3 response: no-op, extra_properties stripping, error passthrough)
- [x] Integration: `golangci-lint run ./...` — 0 issues
- [x] Real endpoint: tested against `aiplatform.googleapis.com/v1/projects/.../endpoints/openapi/chat/completions` — HTTP 200, verified response format and identified `usage.extra_properties` for stripping
- [x] All 14 packages pass (`go test`)

## Note: Vertex AI Platform vs Generative Language API

This PR targets Vertex AI Platform (`aiplatform.googleapis.com`) per issue #112. The Generative Language API (`generativelanguage.googleapis.com`) uses a different path (`/v1beta/openai/chat/completions`) and is tracked separately in issue #143.

## Follow-up

Config wiring to inject project/location/endpoint from the ExternalModel CRD into the translator constructor (currently initialized with empty defaults in `plugin.go`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Vertex OpenAI provider: request/response translation, routing to Vertex endpoints, and automatic API key / auth header handling.
* **Configuration**
  * New JSON settings to specify Vertex project, location, and endpoint for the API translation plugin.
* **Tests**
  * Unit tests for the Vertex translator and expanded end-to-end tests to include the Vertex OpenAI provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->