### PR TITLE
fix: forward stream field in Anthropic request translator

### DIFF
--- a/pkg/plugins/api-translation/translator/anthropic/anthropic.go
+++ b/pkg/plugins/api-translation/translator/anthropic/anthropic.go
@@ -93,6 +93,10 @@ func (t *AnthropicTranslator) TranslateRequest(body map[string]any) (map[string]
 		}
 	}
 
+	if stream, ok := body["stream"].(bool); ok {
+		translated["stream"] = stream
+	}
+
 	headers := map[string]string{
 		"anthropic-version": anthropicAPIVersion,
 		"content-type":      "application/json",

--- a/pkg/plugins/api-translation/translator/anthropic/anthropic_test.go
+++ b/pkg/plugins/api-translation/translator/anthropic/anthropic_test.go
@@ -716,6 +716,53 @@ func TestTranslateRequest_UnknownRoleRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "unknown role")
 }
 
+func TestTranslateRequest_StreamForwarded(t *testing.T) {
+	body := map[string]any{
+		"model":    "claude-sonnet-4-20250514",
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+		"stream":   true,
+	}
+
+	translated, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+	assert.Equal(t, true, translated["stream"])
+}
+
+func TestTranslateRequest_StreamFalseForwarded(t *testing.T) {
+	body := map[string]any{
+		"model":    "claude-sonnet-4-20250514",
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+		"stream":   false,
+	}
+
+	translated, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+	assert.Equal(t, false, translated["stream"])
+}
+
+func TestTranslateRequest_StreamOmittedWhenNotSet(t *testing.T) {
+	body := map[string]any{
+		"model":    "claude-sonnet-4-20250514",
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+	}
+
+	translated, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+	_, exists := translated["stream"]
+	assert.False(t, exists)
+}
+
+func TestTranslateRequest_EmptyMessages(t *testing.T) {
+	body := map[string]any{
+		"model":    "claude-sonnet-4-20250514",
+		"messages": []any{},
+	}
+
+	_, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "non-system message")
+}
+
 func TestTranslateRequest_NonTextContentSkipped(t *testing.T) {
 	// Non-text content (images) is currently extracted as text-only.
 	// Full multimodal support is tracked in a separate issue.


### PR DESCRIPTION
## Summary

- Forward the `stream` boolean field in the Anthropic translator's `TranslateRequest` method
- Add 4 unit tests covering stream=true, stream=false, stream omitted, and empty messages

Fixes #136

## Root Cause

The Anthropic translator builds a new request body from scratch but was not copying the `stream` field. Streaming requests were silently downgraded to non-streaming.

## Test Plan

- [x] Unit tests: `TestTranslateRequest_StreamForwarded`, `TestTranslateRequest_StreamFalseForwarded`, `TestTranslateRequest_StreamOmittedWhenNotSet`, `TestTranslateRequest_EmptyMessages`
- [x] E2E: Verified streaming against real Anthropic API (claude-haiku-4-5-20251001)
- [x] E2E: Verified streaming against llm-katan simulator (sim-anthropic)
- [x] Full test suite passes (`go test ./...`)

Test report: https://github.com/noyitz/api-tests/blob/main/external-model-e2e/external-model-e2e-report.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stream parameter is now properly forwarded in API translation requests.

* **Tests**
  * Added comprehensive test coverage for stream field handling in API translation, including validation of omitted fields and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->