### PR TITLE
fix: use sslip.io FQDN for llm-katan simulator endpoint

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  E2E_SIMULATOR_ENDPOINT: "3.13.21.181"
+  E2E_SIMULATOR_ENDPOINT: "3-13-21-181.sslip.io"
 
 jobs:
   check-changes:

--- a/pkg/plugins/api-translation/translator/azure/azure_openai_test.go
+++ b/pkg/plugins/api-translation/translator/azure/azure_openai_test.go
@@ -369,7 +369,7 @@ func TestTranslateResponse_StreamingChunkStripsAzureFields(t *testing.T) {
 
 // TestTranslateResponse_LiveMockIntegration fetches a real Azure OpenAI response from
 // the llm-katan mock server and verifies that TranslateResponse strips Azure-specific fields.
-// Set LLM_KATAN_URL to enable (e.g. LLM_KATAN_URL=http://3.13.21.181:8000).
+// Set LLM_KATAN_URL to enable (e.g. LLM_KATAN_URL=http://3-13-21-181.sslip.io:8000).
 func TestTranslateResponse_LiveMockIntegration(t *testing.T) {
 	baseURL := os.Getenv("LLM_KATAN_URL")
 	if baseURL == "" {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -74,15 +74,13 @@ metadata:
   namespace: %s
 spec:
   hosts:
-  - e2e-simulator.external
+  - %s
   location: MESH_EXTERNAL
   ports:
   - number: 443
     name: https
     protocol: HTTPS
-  resolution: STATIC
-  endpoints:
-  - address: %s
+  resolution: DNS
 ---
 apiVersion: networking.istio.io/v1
 kind: DestinationRule
@@ -90,12 +88,11 @@ metadata:
   name: e2e-simulator
   namespace: %s
 spec:
-  host: e2e-simulator.external
+  host: %s
   trafficPolicy:
     tls:
       mode: SIMPLE
-      insecureSkipVerify: true
-`, nsName, simulatorEP, nsName))
+`, nsName, simulatorEP, nsName, simulatorEP))
 
 	ginkgo.By("Creating curl client pod")
 	kubectlApplyLiteral(fmt.Sprintf(`

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	defaultNs                = "bbr-e2e"
-	defaultSimulatorEndpoint = "3.13.21.181"
+	defaultSimulatorEndpoint = "3-13-21-181.sslip.io"
 	defaultGatewayName       = "e2e-gateway"
 	defaultGatewayNamespace  = "default"
 )

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -78,11 +78,11 @@ metadata:
   namespace: %s
 spec:
   type: ExternalName
-  externalName: e2e-simulator.external
+  externalName: %s
   ports:
   - port: 443
     protocol: TCP
-`, p.Name, nsName))
+`, p.Name, nsName, simulatorEP))
 
 	// HTTPRoute with path-based + header-based routing
 	kubectlApplyLiteral(fmt.Sprintf(`

--- a/test/e2e/scripts/entrypoint.sh
+++ b/test/e2e/scripts/entrypoint.sh
@@ -9,7 +9,7 @@
 #   E2E_NS                   - Test namespace (default: bbr-e2e)
 #   E2E_GATEWAY_NAMESPACE    - Gateway namespace (default: default)
 #   E2E_GATEWAY_NAME         - Gateway name (default: e2e-gateway)
-#   E2E_SIMULATOR_ENDPOINT   - Simulator IP/host (default: 3.13.21.181)
+#   E2E_SIMULATOR_ENDPOINT   - Simulator FQDN (default: 3-13-21-181.sslip.io)
 #   E2E_SIMULATOR_VALIDATE_KEYS - Enable key validation tests (true/false)
 
 set -euo pipefail

--- a/test/e2e/scripts/setup-kind.sh
+++ b/test/e2e/scripts/setup-kind.sh
@@ -9,7 +9,7 @@
 # Environment variables:
 #   KIND_CLUSTER_NAME    - Kind cluster name (default: bbr-e2e)
 #   ISTIO_VERSION        - Istio version (default: 1.27.0-alpha.0)
-#   E2E_SIMULATOR_ENDPOINT - Simulator IP (default: 3.13.21.181)
+#   E2E_SIMULATOR_ENDPOINT - Simulator FQDN (default: 3-13-21-181.sslip.io)
 
 set -euo pipefail
 
@@ -18,7 +18,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-bbr-e2e}"
 ISTIO_VERSION="${ISTIO_VERSION:-1.29.2}"
-SIMULATOR_ENDPOINT="${E2E_SIMULATOR_ENDPOINT:-3.13.21.181}"
+SIMULATOR_ENDPOINT="${E2E_SIMULATOR_ENDPOINT:-3-13-21-181.sslip.io}"
 GATEWAY_NAMESPACE="default"
 GATEWAY_NAME="e2e-gateway"
 


### PR DESCRIPTION
## Summary
- Replace bare IP (`3.13.21.181`) with sslip.io FQDN (`3-13-21-181.sslip.io`) for the llm-katan test simulator endpoint
- `sslip.io` is a free DNS service that resolves `X-X-X-X.sslip.io` → `X.X.X.X`, so connectivity is unchanged
- The simulator now has a Let's Encrypt TLS certificate for the sslip.io domain, enabling proper cert verification in Istio without `insecureSkipVerify`

## Why
- Bare IPs are rejected by community Istio's ServiceEntry validation (`resolution: DNS` requires a hostname)
- Self-signed certs cause `CERTIFICATE_VERIFY_FAILED` with `tls.mode: SIMPLE` in Envoy
- Let's Encrypt blocks `*.amazonaws.com` domains by policy, so EC2 public DNS names can't get certs
- `sslip.io` solves both: valid FQDN for Istio + trusted TLS cert from Let's Encrypt

## Test plan
- [ ] CI E2E tests pass with the new FQDN
- [ ] `curl https://3-13-21-181.sslip.io/health` returns 200 with valid cert
- [ ] `curl http://3-13-21-181.sslip.io:8000/health` returns 200 (HTTP still works)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test simulator endpoint configuration from IP address to DNS hostname across CI/CD workflows and test infrastructure scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->