### PR TITLE
fix(e2e): drop insecureSkipVerify and use Let's Encrypt simulator endpoint

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  E2E_SIMULATOR_ENDPOINT: "3.13.21.181"
+  E2E_SIMULATOR_ENDPOINT: "3-13-21-181.sslip.io"
 
 jobs:
   check-changes:

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	defaultNs                = "bbr-e2e"
-	defaultSimulatorEndpoint = "3.13.21.181"
+	defaultSimulatorEndpoint = "3-13-21-181.sslip.io"
 	defaultGatewayName       = "e2e-gateway"
 	defaultGatewayNamespace  = "default"
 )
@@ -74,15 +74,13 @@ metadata:
   namespace: %s
 spec:
   hosts:
-  - e2e-simulator.external
+  - %s
   location: MESH_EXTERNAL
   ports:
   - number: 443
     name: https
     protocol: HTTPS
-  resolution: STATIC
-  endpoints:
-  - address: %s
+  resolution: DNS
 ---
 apiVersion: networking.istio.io/v1
 kind: DestinationRule
@@ -90,12 +88,11 @@ metadata:
   name: e2e-simulator
   namespace: %s
 spec:
-  host: e2e-simulator.external
+  host: %s
   trafficPolicy:
     tls:
       mode: SIMPLE
-      insecureSkipVerify: true
-`, nsName, simulatorEP, nsName))
+`, nsName, simulatorEP, nsName, simulatorEP))
 
 	ginkgo.By("Creating curl client pod")
 	kubectlApplyLiteral(fmt.Sprintf(`

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -92,7 +92,9 @@ spec:
   trafficPolicy:
     tls:
       mode: SIMPLE
-`, nsName, simulatorEP, nsName, simulatorEP))
+      sni: %s
+      caCertificates: /etc/ssl/certs/ca-certificates.crt
+`, nsName, simulatorEP, nsName, simulatorEP, simulatorEP))
 
 	ginkgo.By("Creating curl client pod")
 	kubectlApplyLiteral(fmt.Sprintf(`

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -78,11 +78,11 @@ metadata:
   namespace: %s
 spec:
   type: ExternalName
-  externalName: e2e-simulator.external
+  externalName: %s
   ports:
   - port: 443
     protocol: TCP
-`, p.Name, nsName))
+`, p.Name, nsName, simulatorEP))
 
 	// HTTPRoute with path-based + header-based routing
 	kubectlApplyLiteral(fmt.Sprintf(`

--- a/test/e2e/scripts/entrypoint.sh
+++ b/test/e2e/scripts/entrypoint.sh
@@ -9,7 +9,7 @@
 #   E2E_NS                   - Test namespace (default: bbr-e2e)
 #   E2E_GATEWAY_NAMESPACE    - Gateway namespace (default: default)
 #   E2E_GATEWAY_NAME         - Gateway name (default: e2e-gateway)
-#   E2E_SIMULATOR_ENDPOINT   - Simulator IP/host (default: 3.13.21.181)
+#   E2E_SIMULATOR_ENDPOINT   - Simulator hostname (default: 3-13-21-181.sslip.io)
 #   E2E_SIMULATOR_VALIDATE_KEYS - Enable key validation tests (true/false)
 
 set -euo pipefail

--- a/test/e2e/scripts/setup-kind.sh
+++ b/test/e2e/scripts/setup-kind.sh
@@ -9,7 +9,7 @@
 # Environment variables:
 #   KIND_CLUSTER_NAME    - Kind cluster name (default: bbr-e2e)
 #   ISTIO_VERSION        - Istio version (default: 1.27.0-alpha.0)
-#   E2E_SIMULATOR_ENDPOINT - Simulator IP (default: 3.13.21.181)
+#   E2E_SIMULATOR_ENDPOINT - Simulator hostname (default: 3-13-21-181.sslip.io)
 
 set -euo pipefail
 
@@ -18,7 +18,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-bbr-e2e}"
 ISTIO_VERSION="${ISTIO_VERSION:-1.29.2}"
-SIMULATOR_ENDPOINT="${E2E_SIMULATOR_ENDPOINT:-3.13.21.181}"
+SIMULATOR_ENDPOINT="${E2E_SIMULATOR_ENDPOINT:-3-13-21-181.sslip.io}"
 GATEWAY_NAMESPACE="default"
 GATEWAY_NAME="e2e-gateway"
 


### PR DESCRIPTION
## Summary

- Remove `insecureSkipVerify: true` from E2E DestinationRule
- Switch simulator from raw IP (`3.13.21.181`) to DNS (`3-13-21-181.sslip.io`) with Let's Encrypt cert
- Switch ServiceEntry from `STATIC` to `DNS` resolution
- Update ExternalName Services to point to DNS directly
- Update all default endpoints in scripts and CI workflow

Fixes #141

## Why

The llm-katan simulator now uses publicly trusted Let's Encrypt certificates.
The `insecureSkipVerify` workaround is no longer needed and doesn't match
production behavior (real providers use trusted certs).

## Test Plan

- [x] Verified on RHOAI cluster: all 3 simulator models (sim-openai, sim-anthropic, sim-bedrock) work with `tls.mode: SIMPLE`, no `insecureSkipVerify`
- [x] Streaming works through Let's Encrypt endpoint
- [x] `go vet ./test/e2e/` passes
- [x] No remaining references to old IP or `insecureSkipVerify` in test code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI and setup configuration to use a DNS-based simulator endpoint hostname instead of a fixed IP for improved connectivity and clarity.

* **Tests**
  * End-to-end test manifests and scripts now parameterize the simulator endpoint and use DNS resolution with updated TLS-related settings to better match real-world simulator connectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->