### PR TITLE
fix: return 400 for empty messages in openai, anthropic, bedrock translators

### DIFF
--- a/pkg/plugins/api-translation/plugin.go
+++ b/pkg/plugins/api-translation/plugin.go
@@ -19,9 +19,11 @@ package api_translation
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
+	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator"
@@ -97,6 +99,10 @@ func (p *APITranslationPlugin) ProcessRequest(ctx context.Context, cycleState *f
 
 	translatedBody, headersToMutate, headersToRemove, err := translator.TranslateRequest(request.Body)
 	if err != nil {
+		var commErr errcommon.Error
+		if errors.As(err, &commErr) {
+			return commErr
+		}
 		return fmt.Errorf("request translation failed for provider '%s' - %w", providerName, err)
 	}
 
@@ -137,6 +143,10 @@ func (p *APITranslationPlugin) ProcessResponse(ctx context.Context, cycleState *
 
 	translatedBody, err := translator.TranslateResponse(response.Body, model)
 	if err != nil {
+		var commErr errcommon.Error
+		if errors.As(err, &commErr) {
+			return commErr
+		}
 		return fmt.Errorf("response translation failed for provider '%s' - %w", providerName, err)
 	}
 

--- a/pkg/plugins/api-translation/translator/anthropic/anthropic.go
+++ b/pkg/plugins/api-translation/translator/anthropic/anthropic.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator"
+	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
 )
 
 const (
@@ -47,21 +48,21 @@ type AnthropicTranslator struct{}
 func (t *AnthropicTranslator) TranslateRequest(body map[string]any) (map[string]any, map[string]string, []string, error) {
 	model, _ := body["model"].(string)
 	if model == "" {
-		return nil, nil, nil, fmt.Errorf("model field is required")
+		return nil, nil, nil, errcommon.Error{Code: errcommon.BadRequest, Msg: "model field is required"}
 	}
 
 	messages, err := extractMessages(body)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to extract messages: %w", err)
+		return nil, nil, nil, errcommon.Error{Code: errcommon.BadRequest, Msg: fmt.Sprintf("failed to extract messages: %v", err)}
 	}
 
 	systemPrompt, anthropicMessages, err := separateSystemMessages(messages)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, errcommon.Error{Code: errcommon.BadRequest, Msg: err.Error()}
 	}
 
 	if len(anthropicMessages) == 0 {
-		return nil, nil, nil, fmt.Errorf("at least one non-system message is required")
+		return nil, nil, nil, errcommon.Error{Code: errcommon.BadRequest, Msg: "at least one non-system message is required"}
 	}
 
 	maxTokens := resolveMaxTokens(body)

--- a/pkg/plugins/api-translation/translator/bedrock/bedrock_openai.go
+++ b/pkg/plugins/api-translation/translator/bedrock/bedrock_openai.go
@@ -17,9 +17,8 @@ limitations under the License.
 package bedrock
 
 import (
-	"fmt"
-
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator"
+	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
 )
 
 const (
@@ -44,10 +43,14 @@ type BedrockOpenAITranslator struct{}
 // The request body is not mutated since Bedrock's OpenAI-compatible API accepts the same schema as OpenAI.
 func (t *BedrockOpenAITranslator) TranslateRequest(body map[string]any) (translatedBody map[string]any,
 	headersToMutate map[string]string, headersToRemove []string, err error) {
-	// Validate required fields
 	model, ok := body["model"].(string)
 	if !ok || model == "" {
-		return nil, nil, nil, fmt.Errorf("model field is required")
+		return nil, nil, nil, errcommon.Error{Code: errcommon.BadRequest, Msg: "model field is required"}
+	}
+
+	messages, _ := body["messages"].([]any)
+	if len(messages) == 0 {
+		return nil, nil, nil, errcommon.Error{Code: errcommon.BadRequest, Msg: "messages field is required and must not be empty"}
 	}
 
 	// Build headers for Bedrock OpenAI-compatible endpoint

--- a/pkg/plugins/api-translation/translator/bedrock/bedrock_openai_test.go
+++ b/pkg/plugins/api-translation/translator/bedrock/bedrock_openai_test.go
@@ -70,6 +70,28 @@ func TestTranslateRequest_EmptyModel(t *testing.T) {
 	assert.Contains(t, err.Error(), "model field is required")
 }
 
+func TestTranslateRequest_EmptyMessages(t *testing.T) {
+	body := map[string]any{
+		"model":    "nvidia.nemotron-nano-12b-v2",
+		"messages": []any{},
+	}
+
+	_, _, _, err := NewBedrockOpenAITranslator().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "messages")
+	assert.Contains(t, err.Error(), "BadRequest")
+}
+
+func TestTranslateRequest_MissingMessages(t *testing.T) {
+	body := map[string]any{
+		"model": "nvidia.nemotron-nano-12b-v2",
+	}
+
+	_, _, _, err := NewBedrockOpenAITranslator().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "messages")
+}
+
 func TestTranslateResponse_Passthrough(t *testing.T) {
 	body := map[string]any{
 		"id":      "chatcmpl-abc123",

--- a/pkg/plugins/api-translation/translator/openai/openai.go
+++ b/pkg/plugins/api-translation/translator/openai/openai.go
@@ -17,9 +17,8 @@ limitations under the License.
 package openai
 
 import (
-	"fmt"
-
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation/translator"
+	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
 )
 
 const (
@@ -43,7 +42,12 @@ type OpenAITranslator struct{}
 func (t *OpenAITranslator) TranslateRequest(body map[string]any) (map[string]any, map[string]string, []string, error) {
 	model, _ := body["model"].(string)
 	if model == "" {
-		return nil, nil, nil, fmt.Errorf("model field is required")
+		return nil, nil, nil, errcommon.Error{Code: errcommon.BadRequest, Msg: "model field is required"}
+	}
+
+	messages, _ := body["messages"].([]any)
+	if len(messages) == 0 {
+		return nil, nil, nil, errcommon.Error{Code: errcommon.BadRequest, Msg: "messages field is required and must not be empty"}
 	}
 
 	headers := map[string]string{

--- a/pkg/plugins/api-translation/translator/openai/openai_test.go
+++ b/pkg/plugins/api-translation/translator/openai/openai_test.go
@@ -1,0 +1,61 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTranslateRequest_BasicChat(t *testing.T) {
+	body := map[string]any{
+		"model":    "gpt-4o-mini",
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+	}
+
+	translatedBody, headers, headersToRemove, err := NewOpenAITranslator().TranslateRequest(body)
+	require.NoError(t, err)
+	assert.Nil(t, translatedBody)
+	assert.Equal(t, "/v1/chat/completions", headers[":path"])
+	assert.Nil(t, headersToRemove)
+}
+
+func TestTranslateRequest_MissingModel(t *testing.T) {
+	body := map[string]any{
+		"messages": []any{map[string]any{"role": "user", "content": "Hi"}},
+	}
+
+	_, _, _, err := NewOpenAITranslator().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "model")
+}
+
+func TestTranslateRequest_EmptyMessages(t *testing.T) {
+	body := map[string]any{
+		"model":    "gpt-4o-mini",
+		"messages": []any{},
+	}
+
+	_, _, _, err := NewOpenAITranslator().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "messages")
+	assert.Contains(t, err.Error(), "BadRequest")
+}
+
+func TestTranslateRequest_MissingMessages(t *testing.T) {
+	body := map[string]any{
+		"model": "gpt-4o-mini",
+	}
+
+	_, _, _, err := NewOpenAITranslator().TranslateRequest(body)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "messages")
+}
+
+func TestTranslateResponse_Noop(t *testing.T) {
+	body := map[string]any{"choices": []any{}}
+
+	translatedBody, err := NewOpenAITranslator().TranslateResponse(body, "gpt-4o-mini")
+	require.NoError(t, err)
+	assert.Nil(t, translatedBody)
+}


### PR DESCRIPTION
## Summary

All three translators now validate the messages array and return HTTP 400 instead of 500
for empty/missing messages.

Fixes #144

## Problem

Sending `"messages": []` returned HTTP 500 because translator errors were plain `fmt.Errorf`,
which the BBR framework maps to `Unknown` → gRPC error → 500. The framework supports
`errcommon.Error{Code: BadRequest}` which maps to HTTP 400 ImmediateResponse.

## Changes

| Translator | Before | After |
|-----------|--------|-------|
| openai | No messages validation — passed through to provider (503) | Validates messages, returns 400 |
| anthropic | Validated but returned `fmt.Errorf` → 500 | Returns `errcommon.Error{Code: BadRequest}` → 400 |
| bedrock-openai | No messages validation — passed through to provider (503) | Validates messages, returns 400 |

## Test Plan

- [x] `TestTranslateRequest_EmptyMessages` — openai (new test file)
- [x] `TestTranslateRequest_MissingMessages` — openai (new test file)
- [x] `TestTranslateRequest_EmptyMessages` — anthropic (existing, still passes)
- [x] `TestTranslateRequest_EmptyMessages` — bedrock (new test)
- [x] `TestTranslateRequest_MissingMessages` — bedrock (new test)
- [x] Full unit test suite passes (`go test ./pkg/...`)