### PR TITLE
fix(e2e): always build BBR image from source for E2E tests

### DIFF
--- a/test/e2e/scripts/setup-kind.sh
+++ b/test/e2e/scripts/setup-kind.sh
@@ -117,15 +117,17 @@ EOF
 deploy_bbr() {
     echo "Deploying BBR via Helm chart..."
 
-    # Build and load image for arm64 if on Mac (quay.io image is x86 only)
+    local image_tag="quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable"
+
+    # Always build from source to ensure E2E tests run against the current code.
+    # The quay.io image may not include changes from the PR being tested.
+    echo "  Building BBR image from source..."
+    local platform="linux/amd64"
     if [[ "$(uname -m)" == "arm64" ]]; then
-        echo "  Building arm64 image for Kind..."
-        (cd "$PROJECT_ROOT" && make image-local-load \
-            IMAGE_TAG=quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable \
-            PLATFORMS=linux/arm64 2>/dev/null)
-        kind load docker-image quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable \
-            --name "$KIND_CLUSTER_NAME"
+        platform="linux/arm64"
     fi
+    docker build -t "$image_tag" --platform "$platform" "$PROJECT_ROOT"
+    kind load docker-image "$image_tag" --name "$KIND_CLUSTER_NAME"
 
     helm install payload-processing "$PROJECT_ROOT/deploy/payload-processing" \
         --namespace "$GATEWAY_NAMESPACE" \


### PR DESCRIPTION
## Problem

The E2E CI setup uses the pre-built `quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-stable`
image, which doesn't include changes from the PR being tested. This means new providers, translators,
or bug fixes in a PR are never actually tested in E2E — the tests run against the old released binary.

This was the root cause of the `vertex-openai` timeout in PR #133: the BBR pod had the config args
for `vertex-openai`, but the binary didn't have the translator code because it was using the old image.

## Fix

Always build the Docker image from the PR's source code and load it into Kind:

```bash
docker build -t "$image_tag" --platform "$platform" "$PROJECT_ROOT"
kind load docker-image "$image_tag" --name "$KIND_CLUSTER_NAME"
```

This replaces the previous approach which only built from source on arm64 Macs and used the
pre-built quay.io image on x86 CI (GitHub Actions).

## Impact

- CI build time increases by ~1-2 minutes (Docker build step)
- E2E tests now actually validate the PR's code changes
- Works on both x86 (CI) and arm64 (Mac) environments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal test environment setup scripts to improve multi-architecture build support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->