### PR TITLE
fix: request-nemo-guardrails factory returns base type, silently disabling the plugin

### DIFF
--- a/pkg/plugins/nemo/request_guard.go
+++ b/pkg/plugins/nemo/request_guard.go
@@ -56,7 +56,8 @@ func NemoRequestGuardFactory(name string, rawParameters json.RawMessage, _ frame
 		return nil, fmt.Errorf("failed to create '%s' plugin - %w", NemoRequestGuardPluginType, err)
 	}
 
-	return p.WithName(name), nil
+	p.WithName(name)
+	return p, nil
 }
 
 // NewNemoRequestGuardPlugin builds a NeMo request guard plugin from validated parameters.


### PR DESCRIPTION
## fix: nemo-request-guard factory returns wrong type, disabling the plugin at runtime
### Problem
The `NemoRequestGuardFactory` introduced in #130 returns the result of `p.WithName(name)`, which is `*nemoGuardBase` (the base's return type), not `*NemoRequestGuardPlugin`.
Since `*nemoGuardBase` satisfies `BBRPlugin` (via `TypedName()`), this **compiles without error**. However at runtime, when the framework type-asserts the plugin to `RequestProcessor`, the assertion fails silently - the guardrail plugin is never invoked and all requests pass through unguarded.
### Fix
Split the fluent call into two lines so the factory returns the concrete `*NemoRequestGuardPlugin`:
```go
// Before (returns *nemoGuardBase — wrong type)
return p.WithName(name), nil
// After (returns *NemoRequestGuardPlugin — correct type)
p.WithName(name)
return p, nil

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed control flow in Nemo plugin request guard initialization to properly handle instance processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->