### PR TITLE
docs: add per-provider configuration guides

### DIFF
--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -1,0 +1,11 @@
+# Provider Guides
+
+Configuration guides for each supported external model provider.
+
+| Provider | Type | Translation | Auth | Guide |
+|----------|------|------------|------|-------|
+| [OpenAI](openai.md) | `openai` | Pass-through | `Authorization: Bearer` | [openai.md](openai.md) |
+| [Anthropic](anthropic.md) | `anthropic` | OpenAI ↔ Messages API | `x-api-key` | [anthropic.md](anthropic.md) |
+| [AWS Bedrock](bedrock-openai.md) | `bedrock-openai` | Pass-through (Mantle) | `Authorization: Bearer` | [bedrock-openai.md](bedrock-openai.md) |
+| [Azure OpenAI](azure-openai.md) | `azure-openai` | Path rewrite + field stripping | `api-key` | [azure-openai.md](azure-openai.md) |
+| [Vertex AI](vertex-openai.md) | `vertex-openai` | Path rewrite + field stripping | `Authorization: Bearer` (OAuth) | [vertex-openai.md](vertex-openai.md) |

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -1,0 +1,110 @@
+# Anthropic Provider (`anthropic`)
+
+## Overview
+
+The `anthropic` provider translates OpenAI Chat Completions requests to Anthropic's Messages API
+format and translates responses back. This includes system message extraction, tool calling
+translation, and usage field mapping.
+
+## Configuration
+
+| Field | Value |
+|-------|-------|
+| Provider type | `anthropic` |
+| Endpoint | `api.anthropic.com` |
+| Auth header | `x-api-key: <API_KEY>` (NOT Bearer token) |
+| API path | `/v1/messages` |
+| Request format | Translated from OpenAI to Anthropic Messages API |
+| Response format | Translated from Anthropic back to OpenAI format |
+
+## What Gets Translated
+
+**Request:**
+- System messages extracted to top-level `system` field
+- `developer` role mapped to system
+- `max_tokens` / `max_completion_tokens` forwarded
+- `tools[]` converted to Anthropic format with `input_schema`
+- `tool_choice` mapped: `auto` → `{"type":"auto"}`, `required` → `{"type":"any"}`
+- `tool` role messages converted to `tool_result` content blocks
+- `stream` field forwarded
+- `anthropic-version: 2023-06-01` header added
+
+**Response:**
+- `stop_reason` mapped: `end_turn` → `stop`, `max_tokens` → `length`, `tool_use` → `tool_calls`
+- `input_tokens/output_tokens` → `prompt_tokens/completion_tokens`
+- Tool use blocks converted to OpenAI `tool_calls` format
+- Error responses translated to OpenAI error format
+
+## ExternalModel Example
+
+```yaml
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: my-anthropic-model
+  namespace: llm
+spec:
+  provider: anthropic
+  targetModel: claude-haiku-4-5-20251001
+  endpoint: api.anthropic.com
+  credentialRef:
+    name: anthropic-api-key
+```
+
+## Secret Example
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: anthropic-api-key
+  namespace: llm
+  labels:
+    inference.networking.k8s.io/bbr-managed: "true"
+type: Opaque
+stringData:
+  api-key: "sk-ant-api03-..."
+```
+
+## How to Get an API Key
+
+1. Go to https://console.anthropic.com/settings/keys
+2. Create a new API key
+3. Copy the key (starts with `sk-ant-`)
+
+## Supported Models
+
+- `claude-sonnet-4-20250514`
+- `claude-haiku-4-5-20251001`
+- `claude-opus-4-20250514`
+
+Full list: https://docs.anthropic.com/en/docs/about-claude/models
+
+## Known Limitations
+
+- `frequency_penalty`, `presence_penalty`, `logprobs`, `n`, `response_format`, `seed` are silently
+  dropped (Anthropic doesn't support these parameters)
+- Multimodal content (images) is extracted as text-only; full multimodal support is tracked separately
+
+## Testing
+
+```bash
+# Direct API test (native Anthropic format)
+curl -sk "https://api.anthropic.com/v1/messages" \
+  -H "x-api-key: <YOUR_API_KEY>" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"claude-haiku-4-5-20251001","messages":[{"role":"user","content":"Say hello"}],"max_tokens":10}'
+
+# Through MaaS gateway (OpenAI format — translated automatically)
+curl -sk "https://${GATEWAY_HOST}/llm/my-anthropic-model/v1/chat/completions" \
+  -H "Authorization: Bearer ${MAAS_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"claude-haiku-4-5-20251001","messages":[{"role":"user","content":"Say hello"}],"max_tokens":10}'
+```
+
+## Official Documentation
+
+- API Reference: https://docs.anthropic.com/en/api/messages
+- Models: https://docs.anthropic.com/en/docs/about-claude/models
+- Tool Use: https://docs.anthropic.com/en/docs/build-with-claude/tool-use

--- a/docs/providers/azure-openai.md
+++ b/docs/providers/azure-openai.md
@@ -1,0 +1,105 @@
+# Azure OpenAI Provider (`azure-openai`)
+
+## Overview
+
+The `azure-openai` provider routes requests to Azure OpenAI Service. Azure uses the same
+request format as OpenAI but with a different path (`/openai/v1/chat/completions`), a different
+auth header (`api-key` instead of `Authorization: Bearer`), and includes Azure-specific fields
+in responses that the translator strips.
+
+## Configuration
+
+| Field | Value |
+|-------|-------|
+| Provider type | `azure-openai` |
+| Endpoint | `<deployment>.openai.azure.com` (e.g., `testing-azure1.openai.azure.com`) |
+| Auth header | `api-key: <API_KEY>` (NOT Authorization: Bearer) |
+| API path | `/openai/v1/chat/completions` |
+| Request format | OpenAI Chat Completions (pass-through) |
+| Response format | Azure-specific fields stripped (`content_filter_results`, `prompt_filter_results`) |
+
+## Response Field Stripping
+
+Azure adds provider-specific fields to responses that are not part of the OpenAI spec:
+
+- `prompt_filter_results` — content safety results for the prompt (top-level)
+- `content_filter_results` — content safety results per choice (inside each `choices[]` entry)
+
+The translator removes these fields, returning a clean OpenAI-compatible response.
+
+## ExternalModel Example
+
+```yaml
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: my-azure-model
+  namespace: llm
+spec:
+  provider: azure-openai
+  targetModel: gpt-4.1-mini
+  endpoint: testing-azure1.openai.azure.com
+  credentialRef:
+    name: azure-api-key
+```
+
+## Secret Example
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azure-api-key
+  namespace: llm
+  labels:
+    inference.networking.k8s.io/bbr-managed: "true"
+type: Opaque
+stringData:
+  api-key: "<AZURE_API_KEY>"
+```
+
+## How to Get an API Key
+
+1. Go to Azure Portal → Azure OpenAI → your resource
+2. Navigate to "Keys and Endpoint"
+3. Copy Key 1 or Key 2
+4. The endpoint is shown on the same page (e.g., `https://testing-azure1.openai.azure.com/`)
+
+Note: You also need to create a model deployment in Azure OpenAI Studio before you can use it.
+
+## Supported Models
+
+Depends on your Azure OpenAI deployment. Common models:
+- `gpt-4o`, `gpt-4o-mini`
+- `gpt-4.1`, `gpt-4.1-mini`
+- `gpt-3.5-turbo`
+
+The model name in `targetModel` must match the deployment name in your Azure OpenAI resource.
+
+## Known Limitations
+
+- Azure OpenAI has aggressive rate limiting on testing/free tiers — space out requests
+- The `api-key` auth header is Azure-specific (other providers use `Authorization: Bearer`)
+
+## Testing
+
+```bash
+# Direct API test (Azure format)
+curl -sk "https://testing-azure1.openai.azure.com/openai/v1/chat/completions" \
+  -H "api-key: <YOUR_API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4.1-mini","messages":[{"role":"user","content":"Say hello"}],"max_tokens":10}'
+
+# Through MaaS gateway (OpenAI format)
+curl -sk "https://${GATEWAY_HOST}/llm/my-azure-model/v1/chat/completions" \
+  -H "Authorization: Bearer ${MAAS_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4.1-mini","messages":[{"role":"user","content":"Say hello"}],"max_tokens":10}'
+```
+
+## Official Documentation
+
+- Azure OpenAI API Reference: https://learn.microsoft.com/en-us/azure/ai-services/openai/reference
+- Chat Completions: https://learn.microsoft.com/en-us/azure/ai-foundry/openai/latest
+- Models: https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models
+- Quickstart: https://learn.microsoft.com/en-us/azure/ai-services/openai/chatgpt-quickstart

--- a/docs/providers/bedrock-openai.md
+++ b/docs/providers/bedrock-openai.md
@@ -1,0 +1,148 @@
+# AWS Bedrock OpenAI-Compatible Provider (`bedrock-openai`)
+
+## Overview
+
+The `bedrock-openai` provider routes requests to AWS Bedrock's OpenAI-compatible endpoint.
+This is a pass-through translator — the request body is not mutated since Bedrock's
+OpenAI-compatible API accepts the same format as OpenAI.
+
+## Important: Bedrock Runtime vs Bedrock Mantle
+
+AWS has **two different Bedrock endpoints** with different path formats:
+
+| Endpoint | Path | Auth | Status |
+|----------|------|------|--------|
+| `bedrock-runtime.{region}.amazonaws.com` | `/openai/v1/chat/completions` | AWS SigV4 / IAM | **NOT supported** — path has `/openai/` prefix |
+| `bedrock-mantle.{region}.api.aws` | `/v1/chat/completions` | Bearer token (Bedrock API Key) | **Supported** |
+
+**You must use `bedrock-mantle`**, not `bedrock-runtime`. The translator hardcodes the path to
+`/v1/chat/completions` which only works with Bedrock Mantle.
+
+If you use `bedrock-runtime`, you will get a `404 route_not_found` error because the path doesn't
+match (`/openai/v1/chat/completions` vs `/v1/chat/completions`).
+
+### What is Bedrock Mantle?
+
+Bedrock Mantle (Project Mantle) is AWS's OpenAI-compatible inference gateway, announced at
+AWS re:Invent in late 2025. Key differences from Bedrock Runtime:
+
+- **OpenAI-compatible API** — uses standard OpenAI Chat Completions format
+- **Simple auth** — Bearer tokens and Bedrock API Keys instead of SigV4
+- **OpenAI SDK compatible** — change `OPENAI_BASE_URL` and it works
+- **Growing model catalog** — supports a subset of Bedrock models (actively expanding)
+
+## Configuration
+
+| Field | Value |
+|-------|-------|
+| Provider type | `bedrock-openai` |
+| Endpoint | `bedrock-mantle.{region}.api.aws` (e.g., `bedrock-mantle.us-east-2.api.aws`) |
+| Auth header | `Authorization: Bearer <BEDROCK_API_KEY>` |
+| API path | `/v1/chat/completions` |
+| Request format | OpenAI Chat Completions (pass-through) |
+| Response format | OpenAI Chat Completions (pass-through) |
+
+## ExternalModel Example
+
+```yaml
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: my-bedrock-model
+  namespace: llm
+spec:
+  provider: bedrock-openai
+  targetModel: openai.gpt-oss-20b
+  endpoint: bedrock-mantle.us-east-2.api.aws
+  credentialRef:
+    name: bedrock-api-key
+```
+
+## Secret Example
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bedrock-api-key
+  namespace: llm
+  labels:
+    inference.networking.k8s.io/bbr-managed: "true"
+type: Opaque
+stringData:
+  api-key: "<BEDROCK_API_KEY>"
+```
+
+## How to Get a Bedrock API Key
+
+1. Go to the AWS Console → Amazon Bedrock → API Keys
+2. Create a new Bedrock API Key
+3. Copy the key — it starts with `ABSK` and is a base64-encoded string
+
+When decoded, a Bedrock API Key looks like: `BedrockAPIKey-{id}:{secret}`.
+This is NOT the same as AWS Access Keys (used for SigV4 auth with `bedrock-runtime`).
+Bedrock API Keys are specifically for the Mantle OpenAI-compatible endpoint and use
+simple Bearer token authentication.
+
+## Supported Models
+
+List available models on your endpoint:
+
+```bash
+curl -sk "https://bedrock-mantle.us-east-2.api.aws/v1/models" \
+  -H "Authorization: Bearer <YOUR_API_KEY>"
+```
+
+Common models include:
+- `openai.gpt-oss-20b`, `openai.gpt-oss-120b` (OpenAI open-weight)
+- `mistral.ministral-3-8b-instruct`, `mistral.mistral-large-3-675b-instruct`
+- `deepseek.v3.1`, `deepseek.v3.2`
+- `google.gemma-3-27b-it`
+- `qwen.qwen3-32b`
+
+Note: Anthropic Claude models are NOT available via Bedrock Mantle. Use the `anthropic`
+provider type with `api.anthropic.com` for Claude models.
+
+## Troubleshooting
+
+**404 `route_not_found`:**
+You're using `bedrock-runtime.{region}.amazonaws.com` instead of `bedrock-mantle.{region}.api.aws`.
+Change your ExternalModel endpoint.
+
+**401 `UnauthorizedException`:**
+Your Bedrock API Key is invalid or expired. Generate a new one from the AWS Console.
+
+**`model not found`:**
+The model is not available on your Bedrock Mantle endpoint. Use `/v1/models` to list
+available models. Model availability varies by region and account.
+
+**Reasoning models (`content: null`):**
+Some models (like `openai.gpt-oss-20b`) are reasoning models that return thinking in a
+`reasoning` field. Use `max_tokens: 100` or higher to allow the model to finish thinking
+and produce output in `content`.
+
+## Testing
+
+```bash
+# List available models
+curl -sk "https://bedrock-mantle.us-east-2.api.aws/v1/models" \
+  -H "Authorization: Bearer <YOUR_API_KEY>"
+
+# Direct API test
+curl -sk "https://bedrock-mantle.us-east-2.api.aws/v1/chat/completions" \
+  -H "Authorization: Bearer <YOUR_API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"mistral.ministral-3-8b-instruct","messages":[{"role":"user","content":"Say hello"}],"max_tokens":10}'
+
+# Through MaaS gateway
+curl -sk "https://${GATEWAY_HOST}/llm/my-bedrock-model/v1/chat/completions" \
+  -H "Authorization: Bearer ${MAAS_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"openai.gpt-oss-20b","messages":[{"role":"user","content":"Say hello"}],"max_tokens":100}'
+```
+
+## Official Documentation
+
+- Bedrock OpenAI-compatible API: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-chat-completions.html
+- Bedrock Models: https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-openai.html
+- Bedrock API Keys: https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -1,0 +1,85 @@
+# OpenAI Provider (`openai`)
+
+## Overview
+
+The `openai` provider routes requests to the OpenAI API. Since the gateway uses OpenAI Chat Completions
+as the canonical request format, this translator only rewrites the `:path` header — no body mutation is needed.
+
+## Configuration
+
+| Field | Value |
+|-------|-------|
+| Provider type | `openai` |
+| Endpoint | `api.openai.com` |
+| Auth header | `Authorization: Bearer <API_KEY>` |
+| API path | `/v1/chat/completions` |
+| Request format | OpenAI Chat Completions (pass-through) |
+| Response format | OpenAI Chat Completions (pass-through) |
+
+## ExternalModel Example
+
+```yaml
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: my-openai-model
+  namespace: llm
+spec:
+  provider: openai
+  targetModel: gpt-4o-mini
+  endpoint: api.openai.com
+  credentialRef:
+    name: openai-api-key
+```
+
+## Secret Example
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openai-api-key
+  namespace: llm
+  labels:
+    inference.networking.k8s.io/bbr-managed: "true"
+type: Opaque
+stringData:
+  api-key: "sk-proj-..."
+```
+
+## How to Get an API Key
+
+1. Go to https://platform.openai.com/api-keys
+2. Create a new API key
+3. Copy the key (starts with `sk-proj-`)
+
+## Supported Models
+
+Any model available on the OpenAI API, including:
+- `gpt-4o`, `gpt-4o-mini`
+- `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`
+- `o1`, `o3`, `o3-mini`, `o4-mini`
+
+Full list: https://platform.openai.com/docs/models
+
+## Testing
+
+```bash
+# Direct API test (no gateway)
+curl -sk "https://api.openai.com/v1/chat/completions" \
+  -H "Authorization: Bearer <YOUR_API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Say hello"}],"max_tokens":10}'
+
+# Through MaaS gateway
+curl -sk "https://${GATEWAY_HOST}/llm/my-openai-model/v1/chat/completions" \
+  -H "Authorization: Bearer ${MAAS_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Say hello"}],"max_tokens":10}'
+```
+
+## Official Documentation
+
+- API Reference: https://platform.openai.com/docs/api-reference/chat/create
+- Models: https://platform.openai.com/docs/models
+- Rate Limits: https://platform.openai.com/docs/guides/rate-limits

--- a/docs/providers/vertex-openai.md
+++ b/docs/providers/vertex-openai.md
@@ -1,0 +1,158 @@
+# Vertex AI OpenAI-Compatible Provider (`vertex-openai`)
+
+## Overview
+
+The `vertex-openai` provider routes requests to Google Vertex AI's OpenAI-compatible
+chat/completions endpoint. This is a pass-through translator — the request body is not
+mutated since the endpoint accepts OpenAI format natively. The translator rewrites the
+`:path` header to include the GCP project, location, and endpoint.
+
+## Important: Plugin Configuration Required
+
+Unlike other providers, `vertex-openai` requires plugin-level configuration with your
+GCP project, location, and endpoint. These values are set in the Helm chart's plugin config:
+
+```yaml
+plugins:
+  - type: api-translation
+    name: api-translation
+    json:
+      vertexOpenAI:
+        project: "<GCP_PROJECT_ID>"
+        location: "us-central1"
+        endpoint: "openapi"
+```
+
+Without this config, the `vertex-openai` translator will not be registered and requests
+will fail with `unsupported provider - 'vertex-openai'`.
+
+## Important: OAuth Token Expiry
+
+Vertex AI uses OAuth2 tokens that **expire every hour**. Unlike other providers where
+the API key is long-lived, the Vertex token in the K8s Secret must be refreshed manually:
+
+```bash
+# Generate a new token
+gcloud auth print-access-token
+
+# Update the Secret
+kubectl create secret generic vertex-api-key -n llm \
+  --from-literal=api-key="$(gcloud auth print-access-token)" \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+## Configuration
+
+| Field | Value |
+|-------|-------|
+| Provider type | `vertex-openai` |
+| Endpoint | `{region}-aiplatform.googleapis.com` (e.g., `us-central1-aiplatform.googleapis.com`) |
+| Auth header | `Authorization: Bearer <OAUTH_TOKEN>` |
+| API path | `/v1/projects/{project}/locations/{location}/endpoints/openapi/chat/completions` |
+| Request format | OpenAI Chat Completions (pass-through) |
+| Response format | `usage.extra_properties` stripped; rest is OpenAI-compatible |
+| Plugin config | Required: `project`, `location`, `endpoint` |
+
+## Response Field Stripping
+
+Vertex adds `usage.extra_properties` (containing Google-specific metadata like `traffic_type`)
+to responses. The translator strips this field automatically.
+
+## ExternalModel Example
+
+```yaml
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: my-vertex-model
+  namespace: llm
+spec:
+  provider: vertex-openai
+  targetModel: google/gemini-2.5-flash
+  endpoint: us-central1-aiplatform.googleapis.com
+  credentialRef:
+    name: vertex-api-key
+```
+
+Note: The `targetModel` must use `publisher/model` format (e.g., `google/gemini-2.5-flash`).
+
+## Secret Example
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vertex-api-key
+  namespace: llm
+  labels:
+    inference.networking.k8s.io/bbr-managed: "true"
+type: Opaque
+stringData:
+  api-key: "ya29.a0..."  # OAuth token from gcloud auth print-access-token
+```
+
+## How to Get Access
+
+1. Create a GCP project at https://console.cloud.google.com
+2. Enable Vertex AI API: https://console.cloud.google.com/apis/library/aiplatform.googleapis.com
+3. Ensure your account has the `Vertex AI User` role (`roles/aiplatform.user`)
+4. Install gcloud CLI: `brew install google-cloud-sdk`
+5. Authenticate: `gcloud auth login`
+6. Generate token: `gcloud auth print-access-token`
+
+## Supported Models
+
+Any model available on Vertex AI's OpenAI-compatible endpoint:
+- `google/gemini-2.5-flash`, `google/gemini-2.5-pro`
+- `google/gemini-2.0-flash`
+- Third-party models deployed on Vertex AI
+
+Use the `publisher/model` format for all model names.
+
+## Troubleshooting
+
+**`unsupported provider - 'vertex-openai'`:**
+The plugin config is missing. Ensure the Helm values include `vertexOpenAI` config with
+`project`, `location`, and `endpoint`.
+
+**404 on inference:**
+- Check that `targetModel` uses `publisher/model` format (e.g., `google/gemini-2.5-flash`,
+  not just `gemini-2.5-flash`)
+- Check that the `endpoint` in plugin config is `openapi` (not a custom endpoint name)
+- Verify the API version — `v1beta` may return 404; the translator uses `v1`
+
+**Empty response / timeout:**
+The OAuth token in the Secret has likely expired. Refresh it with
+`gcloud auth print-access-token` and update the Secret.
+
+**`ExternalModel is invalid: spec.provider: Unsupported value: "vertex-openai"`:**
+The ExternalModel CRD on your cluster doesn't include `vertex-openai` in the provider enum.
+Update the CRD from the latest MaaS repo or patch it:
+```bash
+oc patch crd externalmodels.maas.opendatahub.io --type=json -p '[
+  {"op":"add","path":"/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/provider/enum/-","value":"vertex-openai"}
+]'
+```
+
+## Testing
+
+```bash
+# Direct API test (Vertex native OpenAI-compatible)
+curl -sk "https://us-central1-aiplatform.googleapis.com/v1/projects/<PROJECT>/locations/us-central1/endpoints/openapi/chat/completions" \
+  -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"google/gemini-2.5-flash","messages":[{"role":"user","content":"Say hello"}],"max_tokens":100}'
+
+# Through MaaS gateway
+curl -sk "https://${GATEWAY_HOST}/llm/my-vertex-model/v1/chat/completions" \
+  -H "Authorization: Bearer ${MAAS_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"google/gemini-2.5-flash","messages":[{"role":"user","content":"Say hello"}],"max_tokens":100}'
+```
+
+## Official Documentation
+
+- Vertex AI OpenAI-compatible API: https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/call-gemini-using-openai-library
+- Chat Completions: https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/projects.locations.endpoints.chat/completions
+- Models: https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models
+- Authentication: https://cloud.google.com/docs/authentication


### PR DESCRIPTION
## Summary

Adds documentation under `docs/providers/` with configuration guides for each supported
ExternalModel provider:

- **openai.md** — pass-through, API key auth
- **anthropic.md** — full request/response translation details, dropped fields, tool calling
- **bedrock-openai.md** — Bedrock Mantle vs bedrock-runtime (common confusion), troubleshooting
- **azure-openai.md** — content_filter stripping, api-key auth header
- **vertex-openai.md** — plugin config requirement, OAuth token expiry, model name format

Each guide includes:
- ExternalModel and Secret YAML examples
- How to obtain credentials
- Supported models
- Troubleshooting common errors
- Curl commands for direct and gateway testing
- Links to official provider documentation

Motivated by wspinks encountering a 404 with bedrock-runtime — these guides prevent similar
confusion for other providers.

CC: @nir-rozenbaum

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive provider configuration guides for supported AI model providers (OpenAI, Anthropic, Azure OpenAI, AWS Bedrock, and Google Vertex AI).
  * Each guide includes configuration examples, authentication requirements, supported models, and troubleshooting steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->