### PR TITLE
docs: clarify vertex-openai plugin config endpoint field

### DIFF
--- a/docs/providers/vertex-openai.md
+++ b/docs/providers/vertex-openai.md
@@ -46,12 +46,20 @@ kubectl create secret generic vertex-api-key -n llm \
 | Field | Value |
 |-------|-------|
 | Provider type | `vertex-openai` |
-| Endpoint | `{region}-aiplatform.googleapis.com` (e.g., `us-central1-aiplatform.googleapis.com`) |
+| ExternalModel endpoint | `{region}-aiplatform.googleapis.com` (e.g., `us-central1-aiplatform.googleapis.com`) |
 | Auth header | `Authorization: Bearer <OAUTH_TOKEN>` |
-| API path | `/v1/projects/{project}/locations/{location}/endpoints/openapi/chat/completions` |
+| API path | `/v1/projects/{project}/locations/{location}/endpoints/{endpoint}/chat/completions` |
 | Request format | OpenAI Chat Completions (pass-through) |
 | Response format | `usage.extra_properties` stripped; rest is OpenAI-compatible |
-| Plugin config | Required: `project`, `location`, `endpoint` |
+| Plugin config | Required: `project`, `location`, `endpoint` (see below) |
+
+### Plugin Config Fields
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| `project` | GCP project ID | `my-gcp-project` |
+| `location` | GCP region | `us-central1` |
+| `endpoint` | Vertex AI endpoint ID — use `openapi` for the OpenAI-compatible endpoint | `openapi` |
 
 ## Response Field Stripping
 


### PR DESCRIPTION
Fixes the vertex-openai provider guide to clearly document the plugin config `endpoint` field.

- Added a separate Plugin Config Fields table explaining each field
- Clarified that `endpoint` refers to the Vertex AI endpoint ID (`openapi` for the OpenAI-compatible endpoint), not the ExternalModel FQDN
- Changed API path from hardcoded `openapi` to `{endpoint}` placeholder for clarity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Vertex OpenAI configuration documentation to clarify required plugin fields (`project`, `location`, `endpoint`) with detailed examples and descriptions
  * Refined API path specification to reflect dynamic endpoint routing for improved accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->