### PR TITLE
fix(e2e): install ExternalModel CRD in entrypoint if not present

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -37,7 +37,7 @@ var (
 
 func TestE2E(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "BBR Plugin Chain E2E Suite")
+	ginkgo.RunSpecs(t, "Inference Payload Processor")
 }
 
 var _ = ginkgo.BeforeSuite(func() {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -152,8 +152,8 @@ func getCurlCommand(modelName string) []string {
 	}
 }
 
-var _ = ginkgo.Describe("BBR Plugin Chain", ginkgo.Label("e2e"), func() {
-	ginkgo.When("BBR is deployed with all plugins", ginkgo.Label("tier1"), func() {
+var _ = ginkgo.Describe("IPP Plugin Chain", ginkgo.Label("e2e"), func() {
+	ginkgo.When("IPP is deployed with all plugins", ginkgo.Label("tier1"), func() {
 		for _, p := range providers {
 			p := p // capture range variable
 

--- a/test/e2e/scripts/entrypoint.sh
+++ b/test/e2e/scripts/entrypoint.sh
@@ -38,6 +38,15 @@ if ! kubectl cluster-info --request-timeout=10s >/dev/null 2>&1; then
 fi
 echo "Cluster connectivity OK."
 
+# Ensure ExternalModel CRD is installed (required for E2E tests).
+if ! kubectl get crd externalmodels.maas.opendatahub.io >/dev/null 2>&1; then
+    echo "ExternalModel CRD not found, installing..."
+    kubectl apply -f https://raw.githubusercontent.com/opendatahub-io/models-as-a-service/refs/heads/main/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_externalmodels.yaml
+    echo "ExternalModel CRD installed."
+else
+    echo "ExternalModel CRD already installed."
+fi
+
 # Build test arguments.
 TEST_ARGS=(
     -test.v


### PR DESCRIPTION
The E2E test container entrypoint now checks for the ExternalModel CRD
and installs it if missing. This fixes the shift-left Jenkins pipeline
where the cluster may not have MaaS fully deployed.

The GitHub Actions CI doesn't hit this because `setup-kind.sh` installs
the CRD during cluster setup. Jenkins runs the container directly via
`podman run` without the setup script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced E2E test setup to ensure required CustomResourceDefinition is available before test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->