### PR TITLE
fix: forward full conversation context to NeMo, filter unsupported system role

### DIFF
--- a/pkg/plugins/nemo/request_guard.go
+++ b/pkg/plugins/nemo/request_guard.go
@@ -133,7 +133,7 @@ func (p *NemoRequestGuardPlugin) ProcessRequest(ctx context.Context, _ *framewor
 // extractMessages returns user-supplied text as a message slice suitable for NeMo's
 // OpenAI-compatible chat endpoint. It supports two payload formats:
 //
-//  1. OpenAI chat: top-level "messages" array → returns the last user message.
+//  1. OpenAI chat: top-level "messages" array → forwards all non-system messages.
 //  2. MCP JSON-RPC: {"jsonrpc":"2.0","params":{"arguments":{…}}} → concatenates
 //     all string argument values into a single user message.
 //
@@ -148,8 +148,9 @@ func extractMessages(body map[string]any) ([]map[string]string, error) {
 	return nil, nil // not an inference request (e.g. API key management, model listing)
 }
 
-// extractOpenAIMessages parses an OpenAI-style "messages" value and returns the
-// last user message, or all messages as a fallback when no user message exists.
+// extractOpenAIMessages parses an OpenAI-style "messages" value. System messages are
+// filtered. TrustyAI does not support this role. All other roles are forwarded so NeMo can evaluate
+// the full conversation context.
 func extractOpenAIMessages(raw any) ([]map[string]string, error) {
 	slice, ok := raw.([]any)
 	if !ok {
@@ -163,18 +164,13 @@ func extractOpenAIMessages(raw any) ([]map[string]string, error) {
 			continue
 		}
 		role, _ := msg["role"].(string)
+		if role == "system" {
+			continue
+		}
 		content, _ := msg["content"].(string)
 		messages = append(messages, map[string]string{"role": role, "content": content})
 	}
-	for i := len(messages) - 1; i >= 0; i-- {
-		if messages[i]["role"] == "user" {
-			return messages[i : i+1], nil
-		}
-	}
-	if len(messages) > 0 {
-		return messages, nil
-	}
-	return nil, nil
+	return messages, nil
 }
 
 // extractMCPArguments extracts text from an MCP JSON-RPC tools/call

--- a/pkg/plugins/nemo/request_guard_test.go
+++ b/pkg/plugins/nemo/request_guard_test.go
@@ -362,6 +362,43 @@ func TestNemoRequestGuardSendsCorrectPayloadMCP(t *testing.T) {
 	assert.Equal(t, "hello world", msg["content"])
 }
 
+// TestNemoRequestGuardForwardsAllNonSystemMessages verifies that user, assistant, and tool
+// messages are forwarded to NeMo while system messages are filtered out (the /v1/guardrail/checks
+// endpoint rejects the system role with status "error").
+func TestNemoRequestGuardForwardsAllNonSystemMessages(t *testing.T) {
+	var capturedReq map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&capturedReq))
+		require.NoError(t, json.NewEncoder(w).Encode(nemoAllowedJSON()))
+	}))
+	defer srv.Close()
+
+	p, err := NewNemoRequestGuardPlugin(srv.URL, 30)
+	require.NoError(t, err)
+
+	req := framework.NewInferenceRequest()
+	req.Body["model"] = "gpt-4"
+	req.Body["messages"] = []any{
+		map[string]any{"role": "system", "content": "You are helpful"},
+		map[string]any{"role": "user", "content": "First question"},
+		map[string]any{"role": "assistant", "content": "Answer"},
+		map[string]any{"role": "tool", "content": "Tool output"},
+		map[string]any{"role": "user", "content": "Follow-up"},
+	}
+	err = p.ProcessRequest(context.Background(), framework.NewCycleState(), req)
+	require.NoError(t, err)
+
+	messages, ok := capturedReq["messages"].([]any)
+	require.True(t, ok, "messages should be an array")
+	require.Len(t, messages, 4, "system message must be filtered, 4 remaining forwarded")
+
+	roles := make([]string, len(messages))
+	for i, m := range messages {
+		roles[i] = m.(map[string]any)["role"].(string)
+	}
+	assert.Equal(t, []string{"user", "assistant", "tool", "user"}, roles)
+}
+
 // TestNemoRequestGuardBaseURLTrailingSlash ensures a trailing slash in baseURL doesn't double up.
 func TestNemoRequestGuardBaseURLTrailingSlash(t *testing.T) {
 	var calledPath string
@@ -427,7 +464,7 @@ func TestExtractMessages(t *testing.T) {
 			want: []map[string]string{{"role": "user", "content": "Hello"}},
 		},
 		{
-			name: "conversation — only last user message extracted",
+			name: "multi-turn conversation — all messages forwarded",
 			body: map[string]any{
 				"messages": []any{
 					map[string]any{"role": "user", "content": "First question"},
@@ -435,16 +472,47 @@ func TestExtractMessages(t *testing.T) {
 					map[string]any{"role": "user", "content": "Follow-up"},
 				},
 			},
-			want: []map[string]string{{"role": "user", "content": "Follow-up"}},
+			want: []map[string]string{
+				{"role": "user", "content": "First question"},
+				{"role": "assistant", "content": "Answer"},
+				{"role": "user", "content": "Follow-up"},
+			},
 		},
 		{
-			name: "no user message — all messages returned as fallback",
+			name: "system message filtered out — /v1/guardrail/checks rejects system role",
+			body: map[string]any{
+				"messages": []any{
+					map[string]any{"role": "system", "content": "You are helpful"},
+					map[string]any{"role": "user", "content": "Hello"},
+				},
+			},
+			want: []map[string]string{
+				{"role": "user", "content": "Hello"},
+			},
+		},
+		{
+			name: "system-only conversation — all filtered, returns nil",
 			body: map[string]any{
 				"messages": []any{
 					map[string]any{"role": "system", "content": "You are helpful"},
 				},
 			},
-			want: []map[string]string{{"role": "system", "content": "You are helpful"}},
+			want: nil,
+		},
+		{
+			name: "tool message included — not filtered out",
+			body: map[string]any{
+				"messages": []any{
+					map[string]any{"role": "user", "content": "Use the tool"},
+					map[string]any{"role": "tool", "content": "Tool response data"},
+					map[string]any{"role": "user", "content": "What did it say?"},
+				},
+			},
+			want: []map[string]string{
+				{"role": "user", "content": "Use the tool"},
+				{"role": "tool", "content": "Tool response data"},
+				{"role": "user", "content": "What did it say?"},
+			},
 		},
 		{
 			name:    "messages is not an array — error (caller must fail closed)",


### PR DESCRIPTION
## Summary

Fixes #160 - the request guard previously only sent the **last user message** to NeMo for
input-rail evaluation. This allowed toxic content in earlier user turns, assistant messages,
and tool messages to bypass guardrails entirely.

### Changes

- **`extractMessages`** now forwards all messages (user, assistant, tool) to NeMo instead of
  only the last user message.
- **System messages are filtered out** because NeMo's `/v1/guardrail/checks` endpoint
  (TrustyAI fork) rejects them with `status: "error"` - confirmed with TrustyAI team (Christina).
  See: [server/api.py#L1041](https://github.com/trustyai-explainability/NeMo-Guardrails/blob/6a3cfd1e51fd978075adc4355846dcea5927d60c/nemoguardrails/server/api.py#L1041)
- Updated `ProcessRequest` doc comment.
- Updated and added unit tests:
  - `"multi-turn conversation — all messages forwarded"`
  - `"system message filtered out — /v1/guardrail/checks rejects system role"`
  - `"system-only conversation — all filtered, returns nil"`
  - `"tool message included — not filtered out"`
  - `TestNemoRequestGuardForwardsAllNonSystemMessages` — integration test verifying system
    is excluded while user/assistant/tool are forwarded to NeMo.

### Testing

- All unit tests pass (`go test ./pkg/plugins/nemo/...`)
- E2E verified on Kind cluster:
  - Safe request with system + user → **200 OK** (system filtered, user evaluated)
  - Toxic earlier user message with safe follow-up → **403 Forbidden** (previously passed)
  - Toxic user-only message → **403 Forbidden**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Forward all non-system messages (user, assistant, tool) in original order instead of only the last user message.
  * Filter out system messages from forwarded requests; system-only conversations now yield no forwarded messages.

* **Documentation**
  * Updated docs to reflect the new message extraction and system-message filtering behavior.

* **Tests**
  * Added/updated tests covering multi-turn ordering, system-message filtering, and inclusion of tool-role messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->