### PR TITLE
fix(e2e): make gateway service name configurable for OpenShift

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -27,12 +27,13 @@ const (
 )
 
 var (
-	kubeClient  kubernetes.Interface
-	nsName      string
-	gatewayNs   string
-	gatewayName string
-	simulatorEP string
-	curlTimeout = 30 * time.Second
+	kubeClient     kubernetes.Interface
+	nsName         string
+	gatewayNs      string
+	gatewayName    string
+	gatewaySvcName string
+	simulatorEP    string
+	curlTimeout    = 30 * time.Second
 )
 
 func TestE2E(t *testing.T) {
@@ -44,6 +45,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	nsName = envOr("E2E_NS", defaultNs)
 	gatewayNs = envOr("E2E_GATEWAY_NAMESPACE", defaultGatewayNamespace)
 	gatewayName = envOr("E2E_GATEWAY_NAME", defaultGatewayName)
+	gatewaySvcName = envOr("E2E_GATEWAY_SVC_NAME", gatewayName+"-istio")
 	simulatorEP = envOr("E2E_SIMULATOR_ENDPOINT", defaultSimulatorEndpoint)
 
 	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -138,10 +138,10 @@ func getCurlCommand(modelName string) []string {
 	bodyBytes, _ := json.Marshal(body)
 
 	// Access gateway service from inside the cluster via DNS.
-	// Istio creates a service named <gateway-name>-istio for each Gateway.
-	svcName := gatewayName + "-istio"
+	// Kind uses <gateway-name>-istio, OpenShift uses <gateway-name>-<namespace>.
+	// Override with E2E_GATEWAY_SVC_NAME when the default doesn't match.
 	gatewayURL := fmt.Sprintf("http://%s.%s.svc:80/%s/%s/v1/chat/completions",
-		svcName, gatewayNs, nsName, modelName)
+		gatewaySvcName, gatewayNs, nsName, modelName)
 
 	return []string{
 		"curl", "-si", "--max-time", strconv.Itoa(int(curlTimeout.Seconds())),

--- a/test/e2e/scripts/entrypoint.sh
+++ b/test/e2e/scripts/entrypoint.sh
@@ -10,6 +10,7 @@
 #   E2E_GATEWAY_NAMESPACE    - Gateway namespace (default: default)
 #   E2E_GATEWAY_NAME         - Gateway name (default: e2e-gateway)
 #   E2E_SIMULATOR_ENDPOINT   - Simulator IP/host (default: 3.13.21.181)
+#   E2E_GATEWAY_SVC_NAME     - Gateway k8s service name (default: <gateway-name>-istio)
 #   E2E_SIMULATOR_VALIDATE_KEYS - Enable key validation tests (true/false)
 
 set -euo pipefail


### PR DESCRIPTION
## Summary
- Add `E2E_GATEWAY_SVC_NAME` env var to override the gateway k8s service name used for in-cluster DNS resolution
- Kind creates services as `<name>-istio`, OpenShift uses `<name>-<namespace>` — this difference caused all E2E tests to fail on Jenkins CI with DNS resolution errors (exit code 6)
- Default remains `<gateway-name>-istio` so Kind/GitHub CI is unaffected

## Test plan
- [ ] GitHub CI E2E tests pass (backwards compatible, default unchanged)
- [ ] Jenkins CI: set `E2E_GATEWAY_SVC_NAME=maas-default-gateway-openshift-default` in vault secret, verify tests resolve the gateway

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced end-to-end testing infrastructure with configurable gateway service naming via the `E2E_GATEWAY_SVC_NAME` environment variable, enabling tests to adapt to different deployment environments and Kubernetes setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->