### PR TITLE
fix(e2e): remove curl install from Dockerfile.e2e — UBI9 conflict

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -35,9 +35,7 @@ ARG KUBECTL_VERSION
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
 
-RUN microdnf install -y curl && \
-    microdnf clean all && \
-    curl -sLo /usr/local/bin/kubectl \
+RUN curl -sLo /usr/local/bin/kubectl \
       "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl" && \
     chmod +x /usr/local/bin/kubectl
 


### PR DESCRIPTION
## Summary
- UBI9-minimal already ships `curl-minimal`, which conflicts with installing `curl` via `microdnf`
- This breaks Konflux builds of `Dockerfile.e2e` (see PR #165)
- Fix: remove `microdnf install -y curl` — `curl-minimal` already works for downloading kubectl

## Test plan
- [ ] Konflux build passes (PR #165 can rebase on this)
- [ ] GitHub CI E2E tests still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the E2E test Docker build process by removing unnecessary package installations, streamlining the container setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->