### PR TITLE
feat: BBR plugin integration for new ExternalProvider CRDs (3/3)

### DIFF
--- a/deploy/payload-processing/templates/rbac.yaml
+++ b/deploy/payload-processing/templates/rbac.yaml
@@ -1,4 +1,3 @@
----
 {{- $bbr := .Values.upstreamBbr.bbr }}
 {{- if $bbr.multiNamespace }}
 ---
@@ -11,10 +10,26 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
-  # model-provider-resolver plugin: watches ExternalModel CRD
-  - apiGroups: ["maas.opendatahub.io"]
-    resources: ["externalmodels"]
+  # model-provider-resolver + controller plugin: watches ExternalProvider and ExternalModel CRDs
+  - apiGroups: ["inference.opendatahub.io"]
+    resources: ["externalproviders", "externalmodels"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["inference.opendatahub.io"]
+    resources: ["externalproviders/status", "externalmodels/status"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["inference.opendatahub.io"]
+    resources: ["externalproviders/finalizers", "externalmodels/finalizers"]
+    verbs: ["update"]
+  # controller plugin: creates networking resources
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: ["networking.istio.io"]
+    resources: ["serviceentries", "destinationrules"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -40,10 +55,26 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
-  # model-provider-resolver plugin: watches ExternalModel CRD
-  - apiGroups: ["maas.opendatahub.io"]
-    resources: ["externalmodels"]
+  # model-provider-resolver + controller plugin: watches ExternalProvider and ExternalModel CRDs
+  - apiGroups: ["inference.opendatahub.io"]
+    resources: ["externalproviders", "externalmodels"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["inference.opendatahub.io"]
+    resources: ["externalproviders/status", "externalmodels/status"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["inference.opendatahub.io"]
+    resources: ["externalproviders/finalizers", "externalmodels/finalizers"]
+    verbs: ["update"]
+  # controller plugin: creates networking resources
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: ["networking.istio.io"]
+    resources: ["serviceentries", "destinationrules"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/deploy/payload-processing/values.yaml
+++ b/deploy/payload-processing/values.yaml
@@ -18,6 +18,11 @@ upstreamBbr:
     # BBR plugins configuration.
     # Format: type (registered plugin type), name (instance name), json (optional config object)
     plugins:
+      - type: external-model-controller
+        name: external-model-controller
+        json:
+          gatewayName: maas-default-gateway
+          gatewayNamespace: istio-system
       - type: body-field-to-header
         name: model-extractor
         json:

--- a/pkg/plugins/common/state/state-keys.go
+++ b/pkg/plugins/common/state/state-keys.go
@@ -22,4 +22,5 @@ const (
 	ModelKey          = "model"
 	CredsRefName      = "credential-ref-name"
 	CredsRefNamespace = "credential-ref-namespace"
+	ProviderConfigKey = "provider-config"
 )

--- a/pkg/plugins/model-provider-resolver/external_model_reconciler.go
+++ b/pkg/plugins/model-provider-resolver/external_model_reconciler.go
@@ -19,36 +19,32 @@ package model_provider_resolver
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 )
 
-// externalModelGVK is the GroupVersionKind for ExternalModel CRD.
 var externalModelGVK = schema.GroupVersionKind{
-	Group:   "maas.opendatahub.io",
+	Group:   "inference.opendatahub.io",
 	Version: "v1alpha1",
 	Kind:    "ExternalModel",
 }
 
-// externalModelReconciler watches ExternalModel CRDs (via unstructured client)
-// and updates the model store with provider and credential information.
 type externalModelReconciler struct {
 	client.Reader
-	store *modelInfoStore
+	modelStore    *modelInfoStore
+	providerStore *providerInfoStore
 }
 
-// Reconcile handles create/update/delete events for ExternalModel resources.
-// The ExternalModel CR name is used as the model key in the store, matching
-// the model name in inference request bodies.
 func (r *externalModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx).V(logutil.DEFAULT)
-	logger.Info("reconciling ExternalModel", "name", req.Name, "namespace", req.Namespace)
+	logger := log.FromContext(ctx)
+	logger.Info("Reconciling ExternalModel", "name", req.Name, "namespace", req.Namespace)
 
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(externalModelGVK)
@@ -59,24 +55,63 @@ func (r *externalModelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	if errors.IsNotFound(err) || !obj.GetDeletionTimestamp().IsZero() {
-		r.store.deleteExternalModel(req.NamespacedName)
-		logger.Info("ExternalModel removed from store", "name", req.Name, "namespace", req.Namespace)
+		r.modelStore.deleteExternalModel(req.NamespacedName)
 		return ctrl.Result{}, nil
 	}
 
-	provider, _, _ := unstructured.NestedString(obj.Object, "spec", "provider")
-	targetModel, _, _ := unstructured.NestedString(obj.Object, "spec", "targetModel")
-	credsName, _, _ := unstructured.NestedString(obj.Object, "spec", "credentialRef", "name")
-
-	// targetModel is the model that will be used in the request body when getting inference requests.
-	info := &externalModelInfo{
-		provider:        provider,
-		targetModel:     targetModel,
-		secretName:      credsName,
-		secretNamespace: req.Namespace, // secret namespace is always the namespace of the ExternalModel
+	refs, _, _ := unstructured.NestedSlice(obj.Object, "spec", "externalProviderRefs")
+	if len(refs) == 0 {
+		r.modelStore.deleteExternalModel(req.NamespacedName)
+		return ctrl.Result{}, nil
 	}
-	r.store.addOrUpdateExternalModel(req.NamespacedName, info)
 
-	logger.Info("updated model store", "provider", provider, "targetModel", targetModel)
+	refMap, ok := refs[0].(map[string]any)
+	if !ok {
+		r.modelStore.deleteExternalModel(req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+
+	providerRefName := nestedString(refMap, "ref", "name")
+	targetModel := nestedString(refMap, "targetModel")
+
+	if providerRefName == "" {
+		r.modelStore.deleteExternalModel(req.NamespacedName)
+		logger.Info("ExternalModel missing provider ref name, skipping")
+		return ctrl.Result{}, nil
+	}
+
+	providerKey := types.NamespacedName{Namespace: req.Namespace, Name: providerRefName}
+	provInfo, found := r.providerStore.get(providerKey)
+	if !found {
+		logger.Info("ExternalProvider not yet available, requeueing", "provider", providerRefName)
+		return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
+	}
+
+	info := &externalModelInfo{
+		provider:        provInfo.provider,
+		targetModel:     targetModel,
+		secretName:      provInfo.secretName,
+		secretNamespace: provInfo.secretNamespace,
+		config:          provInfo.config,
+	}
+	r.modelStore.addOrUpdateExternalModel(req.NamespacedName, info)
+
+	logger.Info("Updated model store", "provider", provInfo.provider, "targetModel", targetModel)
 	return ctrl.Result{}, nil
+}
+
+func nestedString(obj map[string]any, fields ...string) string {
+	current := obj
+	for i, f := range fields {
+		if i == len(fields)-1 {
+			s, _ := current[f].(string)
+			return s
+		}
+		next, ok := current[f].(map[string]any)
+		if !ok {
+			return ""
+		}
+		current = next
+	}
+	return ""
 }

--- a/pkg/plugins/model-provider-resolver/external_model_reconciler_test.go
+++ b/pkg/plugins/model-provider-resolver/external_model_reconciler_test.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model_provider_resolver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func newModelUnstructured(name, namespace, providerRefName, targetModel string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(externalModelGVK)
+	obj.SetName(name)
+	obj.SetNamespace(namespace)
+	obj.Object["spec"] = map[string]any{
+		"externalProviderRefs": []any{
+			map[string]any{
+				"ref":         map[string]any{"name": providerRefName},
+				"targetModel": targetModel,
+			},
+		},
+	}
+	return obj
+}
+
+func TestModelReconciler_ValidCR(t *testing.T) {
+	modelKey := types.NamespacedName{Namespace: "models", Name: "gpt4"}
+	providerKey := types.NamespacedName{Namespace: "models", Name: "my-openai"}
+
+	reader := &mockReader{objects: map[types.NamespacedName]*unstructured.Unstructured{
+		modelKey: newModelUnstructured("gpt4", "models", "my-openai", "gpt-4o"),
+	}}
+
+	provStore := newProviderInfoStore()
+	provStore.addOrUpdate(providerKey, &providerInfo{
+		provider: "openai", endpoint: "api.openai.com",
+		secretName: "openai-key", secretNamespace: "models",
+	})
+
+	modelStore := newModelInfoStore()
+	r := &externalModelReconciler{Reader: reader, modelStore: modelStore, providerStore: provStore}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: modelKey})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	info, found := modelStore.getModelInfo(modelKey)
+	require.True(t, found)
+	assert.Equal(t, "openai", info.provider)
+	assert.Equal(t, "gpt-4o", info.targetModel)
+	assert.Equal(t, "openai-key", info.secretName)
+	assert.Equal(t, "models", info.secretNamespace)
+}
+
+func TestModelReconciler_MissingProvider_Requeues(t *testing.T) {
+	modelKey := types.NamespacedName{Namespace: "models", Name: "gpt4"}
+
+	reader := &mockReader{objects: map[types.NamespacedName]*unstructured.Unstructured{
+		modelKey: newModelUnstructured("gpt4", "models", "my-openai", "gpt-4o"),
+	}}
+
+	provStore := newProviderInfoStore() // empty — provider not yet reconciled
+	modelStore := newModelInfoStore()
+	r := &externalModelReconciler{Reader: reader, modelStore: modelStore, providerStore: provStore}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: modelKey})
+	require.NoError(t, err)
+	assert.Equal(t, 2*time.Second, result.RequeueAfter, "should requeue when provider not available")
+
+	_, found := modelStore.getModelInfo(modelKey)
+	assert.False(t, found, "should not populate model store without provider")
+}
+
+func TestModelReconciler_EmptyProviderRef_NoRequeue(t *testing.T) {
+	modelKey := types.NamespacedName{Namespace: "models", Name: "bad"}
+
+	reader := &mockReader{objects: map[types.NamespacedName]*unstructured.Unstructured{
+		modelKey: newModelUnstructured("bad", "models", "", "gpt-4o"),
+	}}
+
+	provStore := newProviderInfoStore()
+	modelStore := newModelInfoStore()
+	r := &externalModelReconciler{Reader: reader, modelStore: modelStore, providerStore: provStore}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: modelKey})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result, "should NOT requeue for empty provider ref")
+	assert.Zero(t, result.RequeueAfter)
+
+	_, found := modelStore.getModelInfo(modelKey)
+	assert.False(t, found)
+}
+
+func TestModelReconciler_DeletedCR(t *testing.T) {
+	modelKey := types.NamespacedName{Namespace: "models", Name: "deleted"}
+
+	reader := &mockReader{objects: map[types.NamespacedName]*unstructured.Unstructured{}} // not found
+
+	modelStore := newModelInfoStore()
+	modelStore.addOrUpdateExternalModel(modelKey, &externalModelInfo{provider: "openai", targetModel: "gpt-4o"})
+
+	provStore := newProviderInfoStore()
+	r := &externalModelReconciler{Reader: reader, modelStore: modelStore, providerStore: provStore}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: modelKey})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	_, found := modelStore.getModelInfo(modelKey)
+	assert.False(t, found, "model store entry should be removed on delete")
+}
+
+func TestModelReconciler_ProviderUpdatePropagates(t *testing.T) {
+	modelKey := types.NamespacedName{Namespace: "models", Name: "gpt4-update"}
+	providerKey := types.NamespacedName{Namespace: "models", Name: "my-openai"}
+
+	reader := &mockReader{objects: map[types.NamespacedName]*unstructured.Unstructured{
+		modelKey: newModelUnstructured("gpt4-update", "models", "my-openai", "gpt-4o"),
+	}}
+
+	provStore := newProviderInfoStore()
+	provStore.addOrUpdate(providerKey, &providerInfo{
+		provider: "openai", endpoint: "api.openai.com",
+		secretName: "old-key", secretNamespace: "models",
+	})
+
+	modelStore := newModelInfoStore()
+	r := &externalModelReconciler{Reader: reader, modelStore: modelStore, providerStore: provStore}
+
+	// First reconcile — model gets old-key
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: modelKey})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	info, found := modelStore.getModelInfo(modelKey)
+	require.True(t, found)
+	assert.Equal(t, "old-key", info.secretName)
+
+	// Simulate provider update (credential rotation)
+	provStore.addOrUpdate(providerKey, &providerInfo{
+		provider: "openai", endpoint: "api.openai.com",
+		secretName: "new-key", secretNamespace: "models",
+	})
+
+	// Re-reconcile (triggered by cross-watch in production) — model picks up new-key
+	result, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: modelKey})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	info, found = modelStore.getModelInfo(modelKey)
+	require.True(t, found)
+	assert.Equal(t, "new-key", info.secretName, "model store should reflect updated provider credentials")
+}
+
+func TestModelReconciler_NoProviderRefs(t *testing.T) {
+	modelKey := types.NamespacedName{Namespace: "models", Name: "empty"}
+
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(externalModelGVK)
+	obj.SetName("empty")
+	obj.SetNamespace("models")
+	obj.Object["spec"] = map[string]any{}
+
+	reader := &mockReader{objects: map[types.NamespacedName]*unstructured.Unstructured{modelKey: obj}}
+
+	modelStore := newModelInfoStore()
+	provStore := newProviderInfoStore()
+	r := &externalModelReconciler{Reader: reader, modelStore: modelStore, providerStore: provStore}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: modelKey})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	_, found := modelStore.getModelInfo(modelKey)
+	assert.False(t, found)
+}

--- a/pkg/plugins/model-provider-resolver/external_provider_reconciler.go
+++ b/pkg/plugins/model-provider-resolver/external_provider_reconciler.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model_provider_resolver
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var externalProviderGVK = schema.GroupVersionKind{
+	Group:   "inference.opendatahub.io",
+	Version: "v1alpha1",
+	Kind:    "ExternalProvider",
+}
+
+type externalProviderReconciler struct {
+	client.Reader
+	store *providerInfoStore
+}
+
+func (r *externalProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("Reconciling ExternalProvider", "name", req.Name, "namespace", req.Namespace)
+
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(externalProviderGVK)
+
+	err := r.Get(ctx, req.NamespacedName, obj)
+	if err != nil && !errors.IsNotFound(err) {
+		return ctrl.Result{}, fmt.Errorf("unable to get ExternalProvider: %w", err)
+	}
+
+	if errors.IsNotFound(err) || !obj.GetDeletionTimestamp().IsZero() {
+		r.store.delete(req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+
+	providerType, _, _ := unstructured.NestedString(obj.Object, "spec", "provider")
+	endpoint, _, _ := unstructured.NestedString(obj.Object, "spec", "endpoint")
+	secretName, _, _ := unstructured.NestedString(obj.Object, "spec", "auth", "secretRef", "name")
+
+	if providerType == "" || endpoint == "" || secretName == "" {
+		r.store.delete(req.NamespacedName)
+		logger.Info("ExternalProvider missing required fields, removing from store",
+			"provider", providerType, "endpoint", endpoint, "secretName", secretName)
+		return ctrl.Result{}, nil
+	}
+
+	configRaw, _, _ := unstructured.NestedStringMap(obj.Object, "spec", "config")
+
+	r.store.addOrUpdate(req.NamespacedName, &providerInfo{
+		provider:        providerType,
+		endpoint:        endpoint,
+		secretName:      secretName,
+		secretNamespace: req.Namespace,
+		config:          configRaw,
+	})
+
+	logger.Info("Updated provider store", "provider", providerType, "endpoint", endpoint)
+	return ctrl.Result{}, nil
+}

--- a/pkg/plugins/model-provider-resolver/external_provider_reconciler_test.go
+++ b/pkg/plugins/model-provider-resolver/external_provider_reconciler_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model_provider_resolver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// mockReader implements client.Reader for unit testing reconcilers.
+type mockReader struct {
+	objects map[types.NamespacedName]*unstructured.Unstructured
+}
+
+func (m *mockReader) Get(_ context.Context, key types.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+	u, ok := m.objects[key]
+	if !ok {
+		return apierrors.NewNotFound(schema.GroupResource{Group: "inference.opendatahub.io", Resource: "externalproviders"}, key.Name)
+	}
+	u.DeepCopyInto(obj.(*unstructured.Unstructured))
+	return nil
+}
+
+func (m *mockReader) List(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
+	return nil
+}
+
+func newProviderUnstructured(name, namespace, provider, endpoint, secretName string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(externalProviderGVK)
+	obj.SetName(name)
+	obj.SetNamespace(namespace)
+	obj.Object["spec"] = map[string]any{
+		"provider": provider,
+		"endpoint": endpoint,
+		"auth": map[string]any{
+			"secretRef": map[string]any{
+				"name": secretName,
+			},
+		},
+	}
+	return obj
+}
+
+func TestProviderReconciler_ValidCR(t *testing.T) {
+	key := types.NamespacedName{Namespace: "models", Name: "my-openai"}
+	reader := &mockReader{objects: map[types.NamespacedName]*unstructured.Unstructured{
+		key: newProviderUnstructured("my-openai", "models", "openai", "api.openai.com", "openai-key"),
+	}}
+	store := newProviderInfoStore()
+	r := &externalProviderReconciler{Reader: reader, store: store}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	info, found := store.get(key)
+	require.True(t, found)
+	assert.Equal(t, "openai", info.provider)
+	assert.Equal(t, "api.openai.com", info.endpoint)
+	assert.Equal(t, "openai-key", info.secretName)
+	assert.Equal(t, "models", info.secretNamespace)
+}
+
+func TestProviderReconciler_DeletedCR(t *testing.T) {
+	key := types.NamespacedName{Namespace: "models", Name: "deleted"}
+	reader := &mockReader{objects: map[types.NamespacedName]*unstructured.Unstructured{}} // not found
+	store := newProviderInfoStore()
+	store.addOrUpdate(key, &providerInfo{provider: "openai"})
+
+	r := &externalProviderReconciler{Reader: reader, store: store}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	_, found := store.get(key)
+	assert.False(t, found, "store entry should be removed on delete")
+}
+
+func TestProviderReconciler_MissingProvider(t *testing.T) {
+	key := types.NamespacedName{Namespace: "models", Name: "bad"}
+	reader := &mockReader{objects: map[types.NamespacedName]*unstructured.Unstructured{
+		key: newProviderUnstructured("bad", "models", "", "api.openai.com", "key"),
+	}}
+	store := newProviderInfoStore()
+	r := &externalProviderReconciler{Reader: reader, store: store}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	_, found := store.get(key)
+	assert.False(t, found, "should not store provider with empty provider field")
+}
+
+func TestProviderReconciler_MissingEndpoint(t *testing.T) {
+	key := types.NamespacedName{Namespace: "models", Name: "bad"}
+	reader := &mockReader{objects: map[types.NamespacedName]*unstructured.Unstructured{
+		key: newProviderUnstructured("bad", "models", "openai", "", "key"),
+	}}
+	store := newProviderInfoStore()
+	r := &externalProviderReconciler{Reader: reader, store: store}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	_, found := store.get(key)
+	assert.False(t, found, "should not store provider with empty endpoint")
+}
+
+func TestProviderReconciler_MissingSecretName(t *testing.T) {
+	key := types.NamespacedName{Namespace: "models", Name: "bad"}
+	reader := &mockReader{objects: map[types.NamespacedName]*unstructured.Unstructured{
+		key: newProviderUnstructured("bad", "models", "openai", "api.openai.com", ""),
+	}}
+	store := newProviderInfoStore()
+	r := &externalProviderReconciler{Reader: reader, store: store}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	_, found := store.get(key)
+	assert.False(t, found, "should not store provider with empty secretName")
+}

--- a/pkg/plugins/model-provider-resolver/model_store.go
+++ b/pkg/plugins/model-provider-resolver/model_store.go
@@ -28,6 +28,7 @@ type externalModelInfo struct {
 	targetModel     string // this is the name of the model that will be used in the request
 	secretName      string
 	secretNamespace string
+	config          map[string]string
 }
 
 // modelInfoStore is a thread-safe in-memory store that maps model names to their provider info.

--- a/pkg/plugins/model-provider-resolver/plugin.go
+++ b/pkg/plugins/model-provider-resolver/plugin.go
@@ -22,16 +22,26 @@ import (
 	"fmt"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
 	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	inferencev1alpha1 "github.com/opendatahub-io/ai-gateway-payload-processing/api/inference/v1alpha1"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/controller/externalmodel"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/controller/externalprovider"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/state"
 )
 
@@ -42,9 +52,25 @@ const (
 // compile-time type validation
 var _ framework.RequestProcessor = &ModelProviderResolverPlugin{}
 
+type resolverConfig struct {
+	GatewayName      string `json:"gatewayName,omitempty"`
+	GatewayNamespace string `json:"gatewayNamespace,omitempty"`
+	RouteTimeout     string `json:"routeTimeout,omitempty"`
+}
+
 // ModelProviderResolverFactory defines the factory function for ModelProviderResolverPlugin
-func ModelProviderResolverFactory(name string, _ json.RawMessage, handle framework.Handle) (framework.BBRPlugin, error) {
-	plugin, err := NewModelProviderResolver(handle.ReconcilerBuilder, handle.Client())
+func ModelProviderResolverFactory(name string, rawConfig json.RawMessage, handle framework.Handle) (framework.BBRPlugin, error) {
+	utilruntime.Must(inferencev1alpha1.AddToScheme(handle.Client().Scheme()))
+	utilruntime.Must(gatewayapiv1.Install(handle.Client().Scheme()))
+
+	var config resolverConfig
+	if len(rawConfig) > 0 {
+		if err := json.Unmarshal(rawConfig, &config); err != nil {
+			return nil, fmt.Errorf("failed to parse model-provider-resolver config: %w", err)
+		}
+	}
+
+	plugin, err := NewModelProviderResolver(handle, config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create plugin '%s' - %w", ModelProviderResolverPluginType, err)
 	}
@@ -52,24 +78,112 @@ func ModelProviderResolverFactory(name string, _ json.RawMessage, handle framewo
 	return plugin.WithName(name), nil
 }
 
-func NewModelProviderResolver(reconcilerBuilder func() *builder.Builder, clientReader client.Reader) (*ModelProviderResolverPlugin, error) {
-	modelInfoStore := newModelInfoStore()
-	reconciler := &externalModelReconciler{
-		Reader: clientReader,
-		store:  modelInfoStore,
+func NewModelProviderResolver(handle framework.Handle, config resolverConfig) (*ModelProviderResolverPlugin, error) {
+	reconcilerBuilder := handle.ReconcilerBuilder
+	k8sClient := handle.Client()
+	providerStore := newProviderInfoStore()
+	modelStore := newModelInfoStore()
+
+	// Watch ExternalProvider CRDs (inference.opendatahub.io/v1alpha1)
+	providerObj := &unstructured.Unstructured{}
+	providerObj.SetGroupVersionKind(externalProviderGVK)
+	providerReconciler := &externalProviderReconciler{
+		Reader: k8sClient,
+		store:  providerStore,
+	}
+	if err := reconcilerBuilder().For(providerObj).Complete(providerReconciler); err != nil {
+		return nil, fmt.Errorf("failed to register ExternalProvider reconciler for plugin '%s' - %w", ModelProviderResolverPluginType, err)
 	}
 
-	// Watch ExternalModel CRDs directly (no MaaS dependency)
-	obj := &unstructured.Unstructured{}
-	obj.SetGroupVersionKind(externalModelGVK)
-
-	if err := reconcilerBuilder().For(obj).Complete(reconciler); err != nil {
+	// Watch ExternalModel CRDs (inference.opendatahub.io/v1alpha1)
+	// Cross-watch ExternalProviders so credential/endpoint changes propagate to modelStore
+	modelObj := &unstructured.Unstructured{}
+	modelObj.SetGroupVersionKind(externalModelGVK)
+	modelReconciler := &externalModelReconciler{
+		Reader:        k8sClient,
+		modelStore:    modelStore,
+		providerStore: providerStore,
+	}
+	mapProviderToModels := func(ctx context.Context, obj client.Object) []reconcile.Request {
+		providerName := obj.GetName()
+		providerNamespace := obj.GetNamespace()
+		modelList := &unstructured.UnstructuredList{}
+		modelList.SetGroupVersionKind(externalModelGVK)
+		if err := k8sClient.List(ctx, modelList, client.InNamespace(providerNamespace)); err != nil {
+			log.FromContext(ctx).Error(err, "failed to list ExternalModels for provider mapping",
+				"provider", providerName, "namespace", providerNamespace)
+			return nil
+		}
+		var requests []reconcile.Request
+		for i := range modelList.Items {
+			refs, _, _ := unstructured.NestedSlice(modelList.Items[i].Object, "spec", "externalProviderRefs")
+			if len(refs) == 0 {
+				continue
+			}
+			refMap, ok := refs[0].(map[string]any)
+			if !ok {
+				continue
+			}
+			if nestedString(refMap, "ref", "name") == providerName {
+				requests = append(requests, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      modelList.Items[i].GetName(),
+						Namespace: modelList.Items[i].GetNamespace(),
+					},
+				})
+			}
+		}
+		return requests
+	}
+	providerWatchObj := &unstructured.Unstructured{}
+	providerWatchObj.SetGroupVersionKind(externalProviderGVK)
+	if err := reconcilerBuilder().
+		For(modelObj).
+		Watches(providerWatchObj, handler.EnqueueRequestsFromMapFunc(mapProviderToModels)).
+		Complete(modelReconciler); err != nil {
 		return nil, fmt.Errorf("failed to register ExternalModel reconciler for plugin '%s' - %w", ModelProviderResolverPluginType, err)
+	}
+
+	// Controller reconcilers — create Istio networking resources and HTTPRoutes
+	managedByPredicate, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{
+		MatchLabels: map[string]string{"app.kubernetes.io/managed-by": "bbr-external-provider-reconciler"},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create label predicate: %w", err)
+	}
+
+	ctrlProviderReconciler := &externalprovider.Reconciler{
+		Client: k8sClient,
+		Scheme: k8sClient.Scheme(),
+	}
+	if err := reconcilerBuilder().
+		For(&inferencev1alpha1.ExternalProvider{}).
+		Owns(&corev1.Service{}, builder.WithPredicates(managedByPredicate)).
+		Named("external-provider-controller").
+		Complete(ctrlProviderReconciler); err != nil {
+		return nil, fmt.Errorf("failed to register ExternalProvider controller: %w", err)
+	}
+
+	ctrlModelReconciler := &externalmodel.Reconciler{
+		Client:           k8sClient,
+		Scheme:           k8sClient.Scheme(),
+		GatewayName:      config.GatewayName,
+		GatewayNamespace: config.GatewayNamespace,
+		RouteTimeout:     config.RouteTimeout,
+	}
+	if err := reconcilerBuilder().
+		For(&inferencev1alpha1.ExternalModel{}).
+		Owns(&gatewayapiv1.HTTPRoute{}).
+		Watches(&inferencev1alpha1.ExternalProvider{},
+			handler.EnqueueRequestsFromMapFunc(ctrlModelReconciler.MapProviderToModels)).
+		Named("external-model-controller").
+		Complete(ctrlModelReconciler); err != nil {
+		return nil, fmt.Errorf("failed to register ExternalModel controller: %w", err)
 	}
 
 	return &ModelProviderResolverPlugin{
 		typedName:      plugin.TypedName{Type: ModelProviderResolverPluginType, Name: ModelProviderResolverPluginType},
-		modelInfoStore: modelInfoStore,
+		modelInfoStore: modelStore,
 	}, nil
 }
 
@@ -96,8 +210,6 @@ func (p *ModelProviderResolverPlugin) WithName(name string) *ModelProviderResolv
 // from the modelInfoStore (populated by ExternalModel reconciler), and writes model, provider
 // and credential reference info to CycleState.
 func (p *ModelProviderResolverPlugin) ProcessRequest(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceRequest) error {
-	logger := log.FromContext(ctx).V(logutil.DEFAULT)
-
 	model, ok := request.Body["model"].(string)
 	if !ok || model == "" {
 		return nil // not an inference request (e.g. API key management, model listing)
@@ -121,13 +233,12 @@ func (p *ModelProviderResolverPlugin) ProcessRequest(ctx context.Context, cycleS
 	}
 
 	if !strings.HasSuffix(relativePath, "chat/completions") { // no support for other input types
-		logger.Error(nil, "unsupported route for external model", "model", modelKey.String(), "path", relativePath)
 		return errcommon.Error{Code: errcommon.BadRequest, Msg: "only /chat/completions input type is supported"}
+
 	}
 
 	// if there's a mismatch it's an error, we don't want to proceed
 	if externalModelInfo.targetModel != model {
-		logger.Error(nil, "model mismatch between request body and ExternalModel", "requestModel", model, "externalModel", externalModelInfo.targetModel)
 		return errcommon.Error{Code: errcommon.NotFound, Msg: fmt.Sprintf("model in request body '%s' doesn't match ExternalModel", model)}
 	}
 
@@ -136,8 +247,10 @@ func (p *ModelProviderResolverPlugin) ProcessRequest(ctx context.Context, cycleS
 	cycleState.Write(state.ModelKey, externalModelInfo.targetModel)
 	cycleState.Write(state.CredsRefName, externalModelInfo.secretName)
 	cycleState.Write(state.CredsRefNamespace, externalModelInfo.secretNamespace)
+	if len(externalModelInfo.config) > 0 {
+		cycleState.Write(state.ProviderConfigKey, externalModelInfo.config)
+	}
 
-	logger.Info("external model resolved", "model", modelKey.String(), "provider", externalModelInfo.provider)
 	return nil
 }
 

--- a/pkg/plugins/model-provider-resolver/provider_store.go
+++ b/pkg/plugins/model-provider-resolver/provider_store.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model_provider_resolver
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type providerInfo struct {
+	provider        string
+	endpoint        string
+	secretName      string
+	secretNamespace string
+	config          map[string]string
+}
+
+type providerInfoStore struct {
+	providers map[string]*providerInfo
+	lock      sync.RWMutex
+}
+
+func newProviderInfoStore() *providerInfoStore {
+	return &providerInfoStore{
+		providers: make(map[string]*providerInfo),
+	}
+}
+
+func (s *providerInfoStore) addOrUpdate(key types.NamespacedName, info *providerInfo) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.providers[key.String()] = info
+}
+
+func (s *providerInfoStore) delete(key types.NamespacedName) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	delete(s.providers, key.String())
+}
+
+func (s *providerInfoStore) get(key types.NamespacedName) (*providerInfo, bool) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	info, ok := s.providers[key.String()]
+	return info, ok
+}

--- a/pkg/plugins/model-provider-resolver/provider_store_test.go
+++ b/pkg/plugins/model-provider-resolver/provider_store_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model_provider_resolver
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestProviderStore_AddAndGet(t *testing.T) {
+	store := newProviderInfoStore()
+	key := types.NamespacedName{Namespace: "models", Name: "my-openai"}
+
+	store.addOrUpdate(key, &providerInfo{
+		provider: "openai", endpoint: "api.openai.com",
+		secretName: "openai-key", secretNamespace: "models",
+	})
+
+	info, found := store.get(key)
+	require.True(t, found)
+	assert.Equal(t, "openai", info.provider)
+	assert.Equal(t, "api.openai.com", info.endpoint)
+	assert.Equal(t, "openai-key", info.secretName)
+	assert.Equal(t, "models", info.secretNamespace)
+}
+
+func TestProviderStore_GetNotFound(t *testing.T) {
+	store := newProviderInfoStore()
+	_, found := store.get(types.NamespacedName{Namespace: "ns", Name: "nope"})
+	assert.False(t, found)
+}
+
+func TestProviderStore_Delete(t *testing.T) {
+	store := newProviderInfoStore()
+	key := types.NamespacedName{Namespace: "ns", Name: "prov"}
+	store.addOrUpdate(key, &providerInfo{provider: "openai"})
+
+	store.delete(key)
+
+	_, found := store.get(key)
+	assert.False(t, found)
+}
+
+func TestProviderStore_Update(t *testing.T) {
+	store := newProviderInfoStore()
+	key := types.NamespacedName{Namespace: "ns", Name: "prov"}
+
+	store.addOrUpdate(key, &providerInfo{provider: "openai", endpoint: "api.openai.com"})
+	store.addOrUpdate(key, &providerInfo{provider: "openai", endpoint: "api-v2.openai.com"})
+
+	info, found := store.get(key)
+	require.True(t, found)
+	assert.Equal(t, "api-v2.openai.com", info.endpoint)
+}
+
+func TestProviderStore_ConcurrentAccess(t *testing.T) {
+	store := newProviderInfoStore()
+	var wg sync.WaitGroup
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			key := types.NamespacedName{Namespace: "ns", Name: fmt.Sprintf("prov-%d", n%10)}
+			store.addOrUpdate(key, &providerInfo{provider: fmt.Sprintf("type-%d", n)})
+			store.get(key)
+			if n%3 == 0 {
+				store.delete(key)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

- Updates model-provider-resolver plugin to watch `inference.opendatahub.io` CRDs instead of `maas.opendatahub.io`
- Third and final PR implementing [Nir's ExternalProvider proposal](https://docs.google.com/document/d/1jjSGxKtpUgU4qDPf90ReKJty8KrDjOWIURszIJUebvY/edit?usp=sharing). Depends on PR #182 (types) and PR #183 (reconcilers).
- Propagates provider Config (map[string]string) through CycleState for downstream plugins

## Breaking change

The BBR \`model-provider-resolver\` plugin now **only** watches \`inference.opendatahub.io\` ExternalProvider + ExternalModel CRDs. It no longer resolves \`maas.opendatahub.io\` ExternalModel CRs. Deployments using old CRDs must continue running the previous BBR image until migration tooling is available.

## What changed

**New files:**
- \`provider_store.go\` — thread-safe store for ExternalProvider data (provider type, endpoint, secretRef, config)
- \`external_provider_reconciler.go\` — watches ExternalProvider CRs, populates providerInfoStore
- Tests for both (\`provider_store_test.go\`, \`external_provider_reconciler_test.go\`, \`external_model_reconciler_test.go\`)

**Modified files:**
- \`external_model_reconciler.go\` — now watches \`inference.opendatahub.io\` ExternalModel, resolves provider ref from providerInfoStore, writes combined info to modelInfoStore. Requeues with 2s delay if provider not yet available.
- \`plugin.go\` — registers both ExternalProvider and ExternalModel reconcilers
- \`state-keys.go\` — adds \`ProviderConfigKey\` for Config propagation to CycleState
- \`deploy/payload-processing/templates/rbac.yaml\` — \`inference.opendatahub.io\` replaces \`maas.opendatahub.io\`

**Unchanged:**
- \`ProcessRequest\` — same CycleState keys, same downstream behavior for api-translation and apikey-injection plugins

## Config propagation

Provider-specific config (\`ExternalProvider.spec.config\`) flows: ExternalProvider CR → providerInfoStore → modelInfoStore → CycleState (\`ProviderConfigKey\`). Downstream plugins (api-translation) can read it from CycleState. This enables per-provider settings like Vertex AI project/location without hardcoding in plugin config.

## Test plan

- [x] \`make test-unit\` — all tests pass
  - 5 provider store tests (add/get/delete/update/concurrent)
  - 5 provider reconciler tests (valid CR, deleted, empty provider/endpoint/secret)
  - 5 model reconciler tests (valid, missing provider requeue, empty ref no-requeue, deleted, no refs)
  - 4 existing ProcessRequest tests still pass
- [x] Full E2E validated on Kind cluster (results in PR #163)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced external model and external provider reconciliation capabilities to enhance model provider resolution.
  * Added configuration support for gateway settings and route timeout in model provider resolution.

* **Security**
  * Updated RBAC permissions to support the inference API group with expanded resource access for service and gateway management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->