### PR TITLE
fix: pass response_format through Anthropic translator

### DIFF
--- a/pkg/plugins/api-translation/translator/anthropic/anthropic.go
+++ b/pkg/plugins/api-translation/translator/anthropic/anthropic.go
@@ -98,6 +98,10 @@ func (t *AnthropicTranslator) TranslateRequest(body map[string]any) (map[string]
 		translated["stream"] = stream
 	}
 
+	if responseFormat, ok := body["response_format"]; ok {
+		translated["response_format"] = responseFormat
+	}
+
 	headers := map[string]string{
 		"anthropic-version": anthropicAPIVersion,
 		"content-type":      "application/json",

--- a/pkg/plugins/api-translation/translator/anthropic/anthropic_test.go
+++ b/pkg/plugins/api-translation/translator/anthropic/anthropic_test.go
@@ -785,3 +785,33 @@ func TestTranslateRequest_NonTextContentSkipped(t *testing.T) {
 	msgs := translated["messages"].([]map[string]any)
 	assert.Equal(t, "Describe this", msgs[0]["content"])
 }
+
+func TestTranslateRequest_ResponseFormat(t *testing.T) {
+	body := map[string]any{
+		"model":    "claude-3-opus",
+		"messages": []any{map[string]any{"role": "user", "content": "list 3 colors as JSON"}},
+		"response_format": map[string]any{
+			"type": "json_object",
+		},
+	}
+
+	translated, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	rf, ok := translated["response_format"].(map[string]any)
+	require.True(t, ok, "response_format should be passed through")
+	assert.Equal(t, "json_object", rf["type"])
+}
+
+func TestTranslateRequest_NoResponseFormat(t *testing.T) {
+	body := map[string]any{
+		"model":    "claude-3-opus",
+		"messages": []any{map[string]any{"role": "user", "content": "hello"}},
+	}
+
+	translated, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	_, ok := translated["response_format"]
+	assert.False(t, ok, "response_format should not be present when not in input")
+}


### PR DESCRIPTION
## Problem

The Anthropic api-translation plugin silently drops the `response_format` field when translating OpenAI → Anthropic requests. This means JSON mode (`response_format: {type: json_object}`) has no effect for Anthropic providers — the backend receives a request without the JSON constraint and returns plain text.

Fixes #186

## Fix

Pass `response_format` through to the translated request body (4 lines). Anthropic's Messages API supports this field, and backends that don't recognize it will ignore it.

## Test plan

- [x] Unit tests: `TestTranslateRequest_ResponseFormat` (passes through) + `TestTranslateRequest_NoResponseFormat` (not present when not in input)
- [x] `go test ./pkg/plugins/api-translation/translator/anthropic/` — all tests pass
- [x] E2E verified on `maas-local` (old MaaS CRDs) — Anthropic JSON mode returns valid JSON
- [x] E2E verified on `maas-experimental` (new ExternalProvider CRDs) — same result
- [x] Bug reproduced on both clusters BEFORE fix (plain text returned)

Discovered via automated E2E tests using local Kind deployment + llm-katan v0.15.0 simulator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for response format specification when translating API requests through the plugin layer.

* **Tests**
  * Added test coverage for response format parameter handling in request translation, including cases with and without the parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->