### PR TITLE
fix: convert image_url content blocks to Anthropic format

### DIFF
--- a/pkg/plugins/api-translation/translator/anthropic/anthropic.go
+++ b/pkg/plugins/api-translation/translator/anthropic/anthropic.go
@@ -193,10 +193,9 @@ func separateSystemMessages(messages []map[string]any) (string, []map[string]any
 			content := extractContentString(msg)
 			systemParts = append(systemParts, content)
 		case "user":
-			content := extractContentString(msg)
 			anthropicMessages = append(anthropicMessages, map[string]any{
 				"role":    "user",
-				"content": content,
+				"content": buildUserContent(msg),
 			})
 		case "assistant":
 			anthropicMessages = append(anthropicMessages, buildAssistantMessage(msg))
@@ -350,6 +349,94 @@ func extractMessages(body map[string]any) ([]map[string]any, error) {
 	}
 
 	return messages, nil
+}
+
+// buildUserContent converts an OpenAI user message content to Anthropic format.
+// For simple string content, returns the string directly.
+// For array content with image_url blocks, returns Anthropic content blocks
+// (text blocks + image blocks with base64 source).
+func buildUserContent(msg map[string]any) any {
+	content, ok := msg["content"]
+	if !ok {
+		return ""
+	}
+
+	if s, ok := content.(string); ok {
+		return s
+	}
+
+	parts, ok := content.([]any)
+	if !ok {
+		return ""
+	}
+
+	hasImages := false
+	for _, part := range parts {
+		if partMap, ok := part.(map[string]any); ok {
+			if partType, _ := partMap["type"].(string); partType == "image_url" {
+				hasImages = true
+				break
+			}
+		}
+	}
+
+	if !hasImages {
+		return extractContentString(msg)
+	}
+
+	var blocks []any
+	for _, part := range parts {
+		partMap, ok := part.(map[string]any)
+		if !ok {
+			continue
+		}
+		partType, _ := partMap["type"].(string)
+
+		switch partType {
+		case "text":
+			text, _ := partMap["text"].(string)
+			blocks = append(blocks, map[string]any{
+				"type": "text",
+				"text": text,
+			})
+		case "image_url":
+			imageURL, _ := partMap["image_url"].(map[string]any)
+			url, _ := imageURL["url"].(string)
+
+			mediaType, data := parseDataURL(url)
+			if data != "" {
+				blocks = append(blocks, map[string]any{
+					"type": "image",
+					"source": map[string]any{
+						"type":       "base64",
+						"media_type": mediaType,
+						"data":       data,
+					},
+				})
+			}
+		}
+	}
+
+	return blocks
+}
+
+// parseDataURL extracts media type and base64 data from a data URL.
+// e.g., "data:image/png;base64,iVBOR..." → ("image/png", "iVBOR...")
+func parseDataURL(url string) (string, string) {
+	if !strings.HasPrefix(url, "data:") {
+		return "", ""
+	}
+	url = url[5:]
+	semicolon := strings.Index(url, ";")
+	if semicolon < 0 {
+		return "", ""
+	}
+	mediaType := url[:semicolon]
+	rest := url[semicolon+1:]
+	if !strings.HasPrefix(rest, "base64,") {
+		return "", ""
+	}
+	return mediaType, rest[7:]
 }
 
 // extractContentString extracts text content from a message, handling both

--- a/pkg/plugins/api-translation/translator/anthropic/anthropic_test.go
+++ b/pkg/plugins/api-translation/translator/anthropic/anthropic_test.go
@@ -763,9 +763,7 @@ func TestTranslateRequest_EmptyMessages(t *testing.T) {
 	assert.Contains(t, err.Error(), "non-system message")
 }
 
-func TestTranslateRequest_NonTextContentSkipped(t *testing.T) {
-	// Non-text content (images) is currently extracted as text-only.
-	// Full multimodal support is tracked in a separate issue.
+func TestTranslateRequest_ImageContent(t *testing.T) {
 	body := map[string]any{
 		"model": "claude-sonnet-4-20250514",
 		"messages": []any{
@@ -773,7 +771,9 @@ func TestTranslateRequest_NonTextContentSkipped(t *testing.T) {
 				"role": "user",
 				"content": []any{
 					map[string]any{"type": "text", "text": "Describe this"},
-					map[string]any{"type": "image_url", "image_url": map[string]any{"url": "https://example.com/img.png"}},
+					map[string]any{"type": "image_url", "image_url": map[string]any{
+						"url": "data:image/png;base64,iVBORw0KGgo=",
+					}},
 				},
 			},
 		},
@@ -783,5 +783,67 @@ func TestTranslateRequest_NonTextContentSkipped(t *testing.T) {
 	require.NoError(t, err)
 
 	msgs := translated["messages"].([]map[string]any)
-	assert.Equal(t, "Describe this", msgs[0]["content"])
+	blocks, ok := msgs[0]["content"].([]any)
+	require.True(t, ok, "content should be an array of blocks for multimodal")
+	require.Len(t, blocks, 2)
+
+	textBlock := blocks[0].(map[string]any)
+	assert.Equal(t, "text", textBlock["type"])
+	assert.Equal(t, "Describe this", textBlock["text"])
+
+	imageBlock := blocks[1].(map[string]any)
+	assert.Equal(t, "image", imageBlock["type"])
+	source := imageBlock["source"].(map[string]any)
+	assert.Equal(t, "base64", source["type"])
+	assert.Equal(t, "image/png", source["media_type"])
+	assert.Equal(t, "iVBORw0KGgo=", source["data"])
+}
+
+func TestTranslateRequest_ImageContent_NonDataURL(t *testing.T) {
+	body := map[string]any{
+		"model": "claude-sonnet-4-20250514",
+		"messages": []any{
+			map[string]any{
+				"role": "user",
+				"content": []any{
+					map[string]any{"type": "text", "text": "Describe this"},
+					map[string]any{"type": "image_url", "image_url": map[string]any{
+						"url": "https://example.com/img.png",
+					}},
+				},
+			},
+		},
+	}
+
+	translated, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	msgs := translated["messages"].([]map[string]any)
+	blocks, ok := msgs[0]["content"].([]any)
+	require.True(t, ok, "content should be blocks when image_url is present")
+	require.Len(t, blocks, 1, "non-data URL images should be skipped")
+	assert.Equal(t, "text", blocks[0].(map[string]any)["type"])
+}
+
+func TestTranslateRequest_TextOnlyArray(t *testing.T) {
+	body := map[string]any{
+		"model": "claude-sonnet-4-20250514",
+		"messages": []any{
+			map[string]any{
+				"role": "user",
+				"content": []any{
+					map[string]any{"type": "text", "text": "Hello"},
+					map[string]any{"type": "text", "text": "World"},
+				},
+			},
+		},
+	}
+
+	translated, _, _, err := NewAnthropicTranslator().TranslateRequest(body)
+	require.NoError(t, err)
+
+	msgs := translated["messages"].([]map[string]any)
+	content, ok := msgs[0]["content"].(string)
+	require.True(t, ok, "text-only array should be flattened to string")
+	assert.Equal(t, "Hello World", content)
 }


### PR DESCRIPTION
## Problem

The Anthropic api-translation plugin silently drops `image_url` content blocks from multimodal messages. Only text content is extracted and sent to the backend — images are lost entirely.

Fixes #185

## Fix

Add `buildUserContent()` that detects image_url blocks in the content array and converts them to Anthropic's native image format:

```
OpenAI:     {type: "image_url", image_url: {url: "data:image/png;base64,..."}}
Anthropic:  {type: "image", source: {type: "base64", media_type: "image/png", data: "..."}}
```

Text-only content arrays are still flattened to strings (no behavior change for non-multimodal requests). Non-data-URL images (e.g., `https://...`) are skipped since Anthropic requires base64 source.

## Test plan

- [x] `TestTranslateRequest_ImageContent` — base64 data URL converted to Anthropic image block
- [x] `TestTranslateRequest_ImageContent_NonDataURL` — non-data URLs skipped gracefully
- [x] `TestTranslateRequest_TextOnlyArray` — text-only arrays still flatten to string
- [x] All 43 existing Anthropic translator tests pass
- [x] E2E verified on `maas-local` (old MaaS CRDs) — `[image:image/png]` in response
- [x] E2E verified on `maas-experimental` (new ExternalProvider CRDs) — same result
- [x] Bug reproduced on both clusters BEFORE fix (image data lost)

Discovered via automated E2E tests using local Kind deployment + llm-katan v0.15.0 simulator.