### PR TITLE
ci(release): add missing docker-build-and-push and trivy-scan actions

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -1,0 +1,68 @@
+name: Docker Build and Push
+description: Build multi-platform image and push to GitHub Container Registry
+
+inputs:
+  image-name:
+    required: true
+    description: Image name (without registry prefix)
+  tag:
+    required: true
+    description: Image tag
+  registry:
+    required: true
+    description: Container registry (e.g., ghcr.io/opendatahub-io)
+  github-token:
+    required: true
+    description: GitHub token for registry authentication
+  prerelease:
+    required: false
+    default: "false"
+    description: If true, skip tagging as 'latest'
+  dockerfile:
+    required: false
+    default: "Dockerfile"
+    description: Path to Dockerfile
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+
+    - name: Login to GitHub Container Registry
+      shell: bash
+      run: echo "${{ inputs.github-token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+    - name: Extract build metadata
+      id: meta
+      shell: bash
+      run: |
+        echo "commit_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+        echo "build_ref=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+
+    - name: Build and push
+      shell: bash
+      run: |
+        TAGS="-t ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.tag }}"
+        
+        if [[ "${{ inputs.prerelease }}" != "true" ]]; then
+          TAGS="$TAGS -t ${{ inputs.registry }}/${{ inputs.image-name }}:latest"
+        fi
+        
+        docker buildx build \
+          --platform linux/amd64 \
+          --cache-from type=gha,scope=${{ inputs.image-name }} \
+          --cache-to type=gha,mode=max,scope=${{ inputs.image-name }} \
+          --build-arg COMMIT_SHA=${{ steps.meta.outputs.commit_sha }} \
+          --build-arg BUILD_REF=${{ steps.meta.outputs.build_ref }} \
+          $TAGS \
+          -f ${{ inputs.dockerfile }} \
+          --push .
+
+    - name: Print image info
+      shell: bash
+      run: |
+        echo "Pushed: ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.tag }}"
+        if [[ "${{ inputs.prerelease }}" != "true" ]]; then
+          echo "Pushed: ${{ inputs.registry }}/${{ inputs.image-name }}:latest"
+        fi

--- a/.github/actions/trivy-scan/action.yaml
+++ b/.github/actions/trivy-scan/action.yaml
@@ -1,0 +1,18 @@
+name: Trivy Scan
+description: Scan container image with official Aqua Security Trivy action
+
+inputs:
+  image:
+    required: true
+    description: Image to scan (e.g., ghcr.io/org/image:tag)
+
+runs:
+  using: composite
+  steps:
+    - name: Run Trivy vulnerability scanner
+      uses: aquasecurity/trivy-action@0.35.0
+      with:
+        image-ref: ${{ inputs.image }}
+        format: table
+        severity: HIGH,CRITICAL
+        exit-code: '1'

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -44,6 +44,7 @@ jobs:
         with:
           image-name: ${{ steps.meta.outputs.project_name }}
           tag: ${{ steps.tag.outputs.tag }}
+          registry: ghcr.io/opendatahub-io
           github-token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: ${{ steps.tag.outputs.prerelease }}
 


### PR DESCRIPTION
## Description
Add missing composite actions for the CI release workflow:
- `docker-build-and-push`: Builds Docker image and pushes to ghcr.io
- `trivy-scan`: Scans the image for HIGH/CRITICAL vulnerabilities
The workflow triggers on `v*` tags and builds AMD64 images with version metadata embedded.
## How Has This Been Tested?
Tested on my fork by pushing `v*` test tags. Image built, pushed, and scanned successfully.
## Known Issues
**libcap vulnerability (CVE-2026-4878)**:
The Trivy scan finds a HIGH vulnerability in `libcap` from the `ubi9/ubi-minimal` base image. Options:
1. Wait for Red Hat to release a patched base image
2. Temporarily lower Trivy severity to CRITICAL only
3. Ignore if not a real risk for this project

**ARM64 platform support**:
Currently builds AMD64 only. ARM64 builds fail because FIPS compliance requires `CGO_ENABLED=1`, which doesn't work with cross-compilation on GitHub Actions runners. Will create a follow-up issue to address this.

Resolves #181 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added automated Docker image building and publishing to container registry.
  * Introduced automated security scanning for container vulnerabilities, flagging critical findings.
  * Configured container registry target for release deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->