### PR TITLE
Fix issue #190, Using specccific tag instead of latest tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,10 @@ RUN VERSION_PKG="$(go list -f '{{.ImportPath}}' sigs.k8s.io/gateway-api-inferenc
 	CGO_ENABLED=${CGO_ENABLED} GOEXPERIMENT=strictfipsruntime GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
 	go build -a -trimpath -ldflags="-s -w -X ${VERSION_PKG}.CommitSHA=${COMMIT_SHA} -X ${VERSION_PKG}.BuildRef=${BUILD_REF}" -o /bbr ./cmd
 
+USER 1001
+
 # Multistage deploy
-FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:a50731d3397a4ee28583f1699842183d4d24fadcc565c4688487af9ee4e13a44
 
 WORKDIR /
 COPY --from=builder /bbr /bbr

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -36,7 +36,7 @@ RUN curl -sLo /usr/local/bin/kubectl \
     chmod +x /usr/local/bin/kubectl
 
 ## Stage 2: Runtime
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:a50731d3397a4ee28583f1699842183d4d24fadcc565c4688487af9ee4e13a44
 
 WORKDIR /e2e
 


### PR DESCRIPTION
Fix vulnerabilities that was found during the security scans in the Dockerfile, moving from latest to specific tag for ubi-minimal image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned container runtime base images to a fixed 9.5 release for immutable, reproducible deployments.
  * Adjusted container runtime user context to run under a non-root user for improved security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->