### PR TITLE
ci(release): add matrix strategy for ARM64 support

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -1,5 +1,5 @@
 name: Docker Build and Push
-description: Build multi-platform image and push to GitHub Container Registry
+description: Build image and push to GitHub Container Registry (supports push-by-digest for multi-arch)
 
 inputs:
   image-name:
@@ -11,9 +11,17 @@ inputs:
   registry:
     required: true
     description: Container registry (e.g., ghcr.io/opendatahub-io)
+  platform:
+    required: false
+    default: "linux/amd64"
+    description: Target platform (e.g., linux/amd64, linux/arm64)
   github-token:
     required: true
     description: GitHub token for registry authentication
+  push-by-digest:
+    required: false
+    default: "false"
+    description: If true, push by digest only (no tag). Use for multi-arch manifest builds.
   prerelease:
     required: false
     default: "false"
@@ -23,6 +31,11 @@ inputs:
     default: "Dockerfile"
     description: Path to Dockerfile
 
+outputs:
+  digest:
+    description: Image digest (sha256:...)
+    value: ${{ steps.build-digest.outputs.digest || steps.build-tag.outputs.digest }}
+
 runs:
   using: composite
   steps:
@@ -30,8 +43,11 @@ runs:
       uses: docker/setup-buildx-action@v4
 
     - name: Login to GitHub Container Registry
-      shell: bash
-      run: echo "${{ inputs.github-token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.github-token }}
 
     - name: Extract build metadata
       id: meta
@@ -40,29 +56,53 @@ runs:
         echo "commit_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
         echo "build_ref=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
 
-    - name: Build and push
+    - name: Build and push by digest
+      if: inputs.push-by-digest == 'true'
+      id: build-digest
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ${{ inputs.dockerfile }}
+        platforms: ${{ inputs.platform }}
+        outputs: type=image,name=${{ inputs.registry }}/${{ inputs.image-name }},push-by-digest=true,name-canonical=true,push=true
+        cache-from: type=gha,scope=${{ inputs.image-name }}-${{ inputs.platform }}
+        cache-to: type=gha,mode=max,scope=${{ inputs.image-name }}-${{ inputs.platform }}
+        build-args: |
+          COMMIT_SHA=${{ steps.meta.outputs.commit_sha }}
+          BUILD_REF=${{ steps.meta.outputs.build_ref }}
+
+    - name: Build and push with tag
+      if: inputs.push-by-digest != 'true'
+      id: build-tag
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ${{ inputs.dockerfile }}
+        platforms: ${{ inputs.platform }}
+        push: true
+        tags: ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.tag }}
+        cache-from: type=gha,scope=${{ inputs.image-name }}-${{ inputs.platform }}
+        cache-to: type=gha,mode=max,scope=${{ inputs.image-name }}-${{ inputs.platform }}
+        build-args: |
+          COMMIT_SHA=${{ steps.meta.outputs.commit_sha }}
+          BUILD_REF=${{ steps.meta.outputs.build_ref }}
+
+    - name: Tag as latest
+      if: inputs.push-by-digest != 'true' && inputs.prerelease != 'true'
       shell: bash
       run: |
-        TAGS="-t ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.tag }}"
-        
-        if [[ "${{ inputs.prerelease }}" != "true" ]]; then
-          TAGS="$TAGS -t ${{ inputs.registry }}/${{ inputs.image-name }}:latest"
-        fi
-        
-        docker buildx build \
-          --platform linux/amd64 \
-          --cache-from type=gha,scope=${{ inputs.image-name }} \
-          --cache-to type=gha,mode=max,scope=${{ inputs.image-name }} \
-          --build-arg COMMIT_SHA=${{ steps.meta.outputs.commit_sha }} \
-          --build-arg BUILD_REF=${{ steps.meta.outputs.build_ref }} \
-          $TAGS \
-          -f ${{ inputs.dockerfile }} \
-          --push .
+        docker buildx imagetools create \
+          -t ${{ inputs.registry }}/${{ inputs.image-name }}:latest \
+          ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.tag }}
 
     - name: Print image info
       shell: bash
       run: |
-        echo "Pushed: ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.tag }}"
-        if [[ "${{ inputs.prerelease }}" != "true" ]]; then
-          echo "Pushed: ${{ inputs.registry }}/${{ inputs.image-name }}:latest"
+        if [[ "${{ inputs.push-by-digest }}" == "true" ]]; then
+          echo "Pushed by digest: ${{ steps.build-digest.outputs.digest }}"
+        else
+          echo "Pushed: ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.tag }}"
+          if [[ "${{ inputs.prerelease }}" != "true" ]]; then
+            echo "Pushed: ${{ inputs.registry }}/${{ inputs.image-name }}:latest"
+          fi
         fi

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -13,16 +13,25 @@ permissions:
 
 jobs:
   docker-build-and-push:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    outputs:
+      project_name: ${{ steps.meta.outputs.project_name }}
+      tag: ${{ steps.tag.outputs.tag }}
+      prerelease: ${{ steps.tag.outputs.prerelease }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: Set project name from repository
+      - name: Set project name
         id: meta
-        run: |
-          repo="${GITHUB_REPOSITORY##*/}"
-          echo "project_name=$repo" >> "$GITHUB_OUTPUT"
+        run: echo "project_name=${GITHUB_REPOSITORY##*/}" >> "$GITHUB_OUTPUT"
 
       - name: Determine tag
         id: tag
@@ -37,18 +46,72 @@ jobs:
             echo "tag=latest" >> "$GITHUB_OUTPUT"
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
-        shell: bash
 
       - name: Build and push
+        id: build
         uses: ./.github/actions/docker-build-and-push
         with:
           image-name: ${{ steps.meta.outputs.project_name }}
           tag: ${{ steps.tag.outputs.tag }}
           registry: ghcr.io/opendatahub-io
+          platform: ${{ matrix.platform }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          prerelease: ${{ steps.tag.outputs.prerelease }}
+          push-by-digest: "true"
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ strategy.job-index }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  create-manifest-and-scan:
+    needs: docker-build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Download all digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          IMAGE="ghcr.io/opendatahub-io/${{ needs.docker-build-and-push.outputs.project_name }}"
+          TAG="${{ needs.docker-build-and-push.outputs.tag }}"
+          PRERELEASE="${{ needs.docker-build-and-push.outputs.prerelease }}"
+          
+          DIGESTS=$(printf "${IMAGE}@sha256:%s " *)
+          
+          docker buildx imagetools create -t ${IMAGE}:${TAG} ${DIGESTS}
+          
+          if [[ "${PRERELEASE}" != "true" ]]; then
+            docker buildx imagetools create -t ${IMAGE}:latest ${DIGESTS}
+          fi
 
       - name: Trivy security scan
         uses: ./.github/actions/trivy-scan
         with:
-          image: ghcr.io/opendatahub-io/${{ steps.meta.outputs.project_name }}:${{ steps.tag.outputs.tag }}
+          image: ghcr.io/opendatahub-io/${{ needs.docker-build-and-push.outputs.project_name }}:${{ needs.docker-build-and-push.outputs.tag }}


### PR DESCRIPTION
## Description

Add ARM64 platform support to CI release workflow using native GitHub Actions ARM64 runners.

**Changes:**
- Add matrix strategy to build on `ubuntu-latest` (AMD64) and `ubuntu-24.04-arm` (ARM64) in parallel
- Use push-by-digest pattern to avoid tag conflicts between parallel builds
- Add `create-manifest-and-scan` job to combine digests into a single multi-arch manifest
- Refactor `docker-build-and-push` action with `platform`, `push-by-digest` inputs and `digest` output
- Run Trivy scan once on final manifest image

**Why native runners?** The project uses `CGO_ENABLED=1` with `GOEXPERIMENT=strictfipsruntime` for FIPS compliance, which prevents cross-compilation.

**Note:** Trivy may fail on `libcap` CVE-2026-4878 from `ubi9/ubi-minimal` base image - this is not project code.

## How Has This Been Tested?

Tested on fork by pushing test tags - both architectures build successfully, manifest created correctly, Trivy scan runs once on final image.

Resolves #203 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI/CD pipeline now supports multi-platform Docker image builds for both amd64 and arm64 architectures, enabling broader compatibility across systems.
  * Improved container image release workflow with multi-architecture manifest list generation and enhanced digest-based artifact handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->