### PR TITLE
feat: Extract and process MCP JSON-RPC response payloads

### DIFF
--- a/pkg/plugins/nemo/response_guard.go
+++ b/pkg/plugins/nemo/response_guard.go
@@ -123,14 +123,24 @@ func (p *NemoResponseGuardPlugin) ProcessResponse(ctx context.Context, _ *framew
 	return nil
 }
 
-// extractAssistantMessages pulls assistant content from every choice in an OpenAI-style
-// chat completion response. Returns an error if choices exists but has an unsupported
-// shape (fail closed), and nil when no choices are present.
+// extractAssistantMessages extracts assistant content from a response body.
+// It supports two payload formats:
+// 1. OpenAI chat (via "choices"): choices (fail closed), and nil when no content is found.
+// 2. MCP JSON-RPC: {"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"Hello"}]}}
+//
+// Returns (nil, nil) when no content is found.
 func extractAssistantMessages(body map[string]any) ([]map[string]string, error) {
-	raw, ok := body["choices"]
-	if !ok {
-		return nil, nil
+	if raw, ok := body["choices"]; ok {
+		return extractOpenAIAssistantMessagesFromChoices(raw)
 	}
+	if _, ok := body["jsonrpc"]; ok {
+		return extractMCPTextContent(body)
+	}
+	return nil, nil
+}
+
+// extractOpenAIAssistantMessagesFromChoices parses OpenAI-style choices into assistant messages.
+func extractOpenAIAssistantMessagesFromChoices(raw any) ([]map[string]string, error) {
 	choiceSlice, ok := raw.([]any)
 	if !ok {
 		return nil, fmt.Errorf("choices field has unsupported type")
@@ -164,6 +174,27 @@ func extractAssistantMessages(body map[string]any) ([]map[string]string, error) 
 			continue
 		}
 		messages = append(messages, map[string]string{"role": "assistant", "content": content})
+	}
+	return messages, nil
+}
+
+// extractMCPTextContent parses MCP text content into assistant messages.
+func extractMCPTextContent(body map[string]any) ([]map[string]string, error) {
+	result, _ := body["result"].(map[string]any)
+	contentSlice, _ := result["content"].([]any)
+	var messages []map[string]string
+	for _, item := range contentSlice {
+		entry, _ := item.(map[string]any)
+		if entry["type"] != "text" {
+			continue
+		}
+		text, ok := entry["text"].(string)
+		if !ok {
+			return nil, fmt.Errorf("mcp text content is not a string")
+		}
+		if text != "" {
+			messages = append(messages, map[string]string{"role": "assistant", "content": text})
+		}
 	}
 	return messages, nil
 }

--- a/pkg/plugins/nemo/response_guard_test.go
+++ b/pkg/plugins/nemo/response_guard_test.go
@@ -496,6 +496,38 @@ func TestExtractAssistantMessages(t *testing.T) {
 			body:    map[string]any{"choices": "not-an-array"},
 			wantErr: true,
 		},
+		{
+			name: "mcp text content",
+			body: map[string]any{
+				"jsonrpc": "2.0",
+				"result":  map[string]any{"content": []any{map[string]any{"type": "text", "text": "Hello"}}},
+			},
+			want: []map[string]string{{"role": "assistant", "content": "Hello"}},
+		},
+		{
+			name: "mcp text content — empty content array — nil",
+			body: map[string]any{
+				"jsonrpc": "2.0",
+				"result":  map[string]any{"content": []any{}},
+			},
+			want: nil,
+		},
+		{
+			name: "mcp text content — empty content entry — nil",
+			body: map[string]any{
+				"jsonrpc": "2.0",
+				"result":  map[string]any{"content": []any{map[string]any{"type": "text", "text": ""}}},
+			},
+			want: nil,
+		},
+		{
+			name: "mcp text content — text is not a string — fail closed",
+			body: map[string]any{
+				"jsonrpc": "2.0",
+				"result":  map[string]any{"content": []any{map[string]any{"type": "text", "text": 42}}},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR adds enables integration with the MCP Gateway by adding functionality to extract and process MCP JSON-RPC response payloads. Addresses #180 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I updated response_guard_test.go with unit tests. Additionally, I built a new image and deployed payload-processing on OpenShift cluster. I ran the following commands to test the nemo-response-guard plugin through the MCP gateway:

```
MCP_URL="https://$(oc get routes -n gateway-system -o jsonpath='{.items[0].spec.host}')/mcp"
# Get a fresh MCP session
SESSION=$(curl -si --max-time 10 ${MCP_URL} \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' \
  2>/dev/null | grep -i mcp-session-id | tr -d '\r' | awk '{print $2}')
echo "Session: ${SESSION}"
echo ""

# Test 1: Clean response (should PASS - no PERSON entity, no forbidden words)

echo "=== Test 1: Clean response (should pass all output rails) ==="
curl -s --max-time 15 ${MCP_URL} \
  -H "Content-Type: application/json" \
  -H "Mcp-Session-Id: ${SESSION}" \
  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"cal_greet","arguments":{"name":"The weather is nice today"}}}'
echo -e "\n"

# Test 2: PERSON entity in output (should be BLOCKED by detect sensitive data on output)
echo "=== Test 2: PERSON entity in output (should be BLOCKED) ==="
curl -s --max-time 15 ${MCP_URL} \
  -H "Content-Type: application/json" \
  -H "Mcp-Session-Id: ${SESSION}" \
  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"cal_greet","arguments":{"name":"Dr. Sarah Johnson prescribed the medication"}}}'
echo -e "\n"

# Test 3: Multiple PERSON entities in output (should be BLOCKED)
echo "=== Test 3: Multiple PERSON entities in output (should be BLOCKED) ==="
curl -s --max-time 15 ${MCP_URL} \
  -H "Content-Type: application/json" \
  -H "Mcp-Session-Id: ${SESSION}" \
  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"cal_greet","arguments":{"name":"Meeting between Alice Cooper and Bob Williams at 3pm"}}}'
echo -e "\n"

=== Test 1: Clean response (should pass all output rails) ===
{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"Hi The weather is nice today"}]}}

=== Test 2: PERSON entity in output (should be BLOCKED) ===
inference error: Forbidden - response blocked by NeMo guardrails

=== Test 3: Multiple PERSON entities in output (should be BLOCKED) ===
inference error: Forbidden - response blocked by NeMo guardrails
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
