### PR TITLE
test(e2e): add e2e ci orchestrator script

### DIFF
--- a/test/e2e/scripts/e2e-ci.sh
+++ b/test/e2e/scripts/e2e-ci.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# E2E testing orchestrator script for AI Gateway Payload Processing.
+
+set -euo pipefail
+
+E2E_SIMULATOR_ENDPOINT="${E2E_SIMULATOR_ENDPOINT:-3.13.21.181}"
+PAYLOAD_PROCESSING_IMAGE="${PAYLOAD_PROCESSING_IMAGE:-quay.io/opendatahub/ai-gateway-payload-processing:odh-stable}"
+PAYLOAD_PROCESSING_E2E_IMAGE="${PAYLOAD_PROCESSING_E2E_IMAGE:-quay.io/opendatahub/ai-gateway-payload-processing-e2e:odh-stable}"
+
+
+echo "================================================"
+echo "Payload Processing E2E Testing"
+echo "================================================"
+echo "Test Configuration:"
+echo "  E2E Simulator Endpoint: $E2E_SIMULATOR_ENDPOINT"
+echo "  Payload Processing Image: $PAYLOAD_PROCESSING_IMAGE"
+echo "  Payload Processing E2E Image: $PAYLOAD_PROCESSING_E2E_IMAGE"
+echo "================================================"
+
+echo "Checking simulator connectivity..."
+if nc -z -w 5 "$E2E_SIMULATOR_ENDPOINT" 443 2>/dev/null; then
+    reachable=true
+    echo "Simulator is reachable"
+else
+    reachable=false
+    echo "Simulator is NOT reachable"
+    echo "❌ Payload Processing E2E Testing Failed"
+    exit 1
+fi
+
+#  TODO: Add Deployment and E2E tests


### PR DESCRIPTION
## Summary
Adds `test/e2e/scripts/e2e-ci.sh` as the E2E CI orchestrator script for AI Gateway Payload Processing.

## Description
This is a **scaffolding PR** that introduces a template orchestrator script to test and validate the E2E CI pipeline setup with Konflux. The script itself serves as the entry point that will orchestrate the full E2E test lifecycle — the component team is expected to implement the `TODO` section with the actual deployment and testing logic specific to this project.

Actual deployment and E2E test invocation will be wired in a follow-up once the Konflux CI setup is confirmed stable. The existing GitHub Actions workflow continues to handle E2E execution in the meantime.

Current scope:
- Introduces `e2e-ci.sh` with bash strict mode (`set -euo pipefail`) for fail-fast execution.
- Key environment variables are configurable with defaults:
  - `E2E_SIMULATOR_ENDPOINT` (default: `3.13.21.181`)
  - `PAYLOAD_PROCESSING_IMAGE` (default: `quay.io/opendatahub/ai-gateway-payload-processing:odh-stable`)
  - `PAYLOAD_PROCESSING_E2E_IMAGE` (default: `quay.io/opendatahub/ai-gateway-payload-processing-e2e:odh-stable`)
- Checks simulator reachability via `nc` on port 443; fails the pipeline with a clear message if unreachable.
- The `TODO` section at the end is intentionally left for the component team to implement the deployment setup and E2E test execution logic.

## How it was tested
- Script syntax verified locally (`bash -n`).
- Reachability check logic manually validated.