### PR TITLE
ci DO-NOT-MERGE: add group test pipelinerun definition for ai-gateway

### DIFF
--- a/.tekton/ai-gateway-group-test.yaml
+++ b/.tekton/ai-gateway-group-test.yaml
@@ -1,0 +1,48 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/ai-gateway-payload-processing?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "group-test"
+    pipelinesascode.tekton.dev/on-comment: "^/group-test"
+  name: ai-gateway-group-test
+  namespace: open-data-hub-tenant
+  labels:
+    appstudio.openshift.io/application: group-testing
+    appstudio.openshift.io/component: ai-gateway-group
+    pipelines.appstudio.openshift.io/type: test
+spec:
+  params:
+  - name: group-components
+    value: '{ "odh-ai-gateway-payload-processing-ci": "opendatahub/odh-ai-gateway-payload-processing", "ai-gateway-payload-processing-e2e-ci": "opendatahub/ai-gateway-payload-processing-e2e" }'
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: integration-tests/ai-gateway-payload-processing/pr-group-testing-pipeline.yaml
+  taskRunTemplate:
+    podTemplate:
+      nodeSelector:
+        konflux-ci.dev/workload: konflux-tenants
+      tolerations:
+      - effect: NoSchedule
+        key: konflux-ci.dev/workload
+        operator: Equal
+        value: konflux-tenants
+    serviceAccountName: konflux-integration-runner
+  timeouts:
+    pipeline: 4h0m0s
+    tasks: 3h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/test/e2e/scripts/e2e-ci.sh
+++ b/test/e2e/scripts/e2e-ci.sh
@@ -18,9 +18,11 @@ echo "  Payload Processing E2E Image: $PAYLOAD_PROCESSING_E2E_IMAGE"
 echo "================================================"
 
 echo "Checking simulator connectivity..."
-if curl -sk --max-time 10 "https://${E2E_SIMULATOR_ENDPOINT}/health" >/dev/null 2>&1; then
+if curl --silent --fail --max-time 10 --output /dev/null --write-out "HTTP %{http_code} | time: %{time_total}s | ip: %{remote_ip}\n" "https://${E2E_SIMULATOR_ENDPOINT}/health"; then
+    reachable=true
     echo "Simulator is reachable"
 else
+    reachable=false
     echo "Simulator is NOT reachable at https://${E2E_SIMULATOR_ENDPOINT}/health"
     echo "Payload Processing E2E Testing Failed"
     exit 1

--- a/test/e2e/scripts/e2e-ci.sh
+++ b/test/e2e/scripts/e2e-ci.sh
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-E2E_SIMULATOR_ENDPOINT="${E2E_SIMULATOR_ENDPOINT:-3.13.21.181}"
+E2E_SIMULATOR_ENDPOINT="${E2E_SIMULATOR_ENDPOINT:-3-13-21-181.sslip.io}"
 PAYLOAD_PROCESSING_IMAGE="${PAYLOAD_PROCESSING_IMAGE:-quay.io/opendatahub/ai-gateway-payload-processing:odh-stable}"
 PAYLOAD_PROCESSING_E2E_IMAGE="${PAYLOAD_PROCESSING_E2E_IMAGE:-quay.io/opendatahub/ai-gateway-payload-processing-e2e:odh-stable}"
 
@@ -18,13 +18,11 @@ echo "  Payload Processing E2E Image: $PAYLOAD_PROCESSING_E2E_IMAGE"
 echo "================================================"
 
 echo "Checking simulator connectivity..."
-if nc -z -w 5 "$E2E_SIMULATOR_ENDPOINT" 443 2>/dev/null; then
-    reachable=true
+if curl -sk --max-time 10 "https://${E2E_SIMULATOR_ENDPOINT}/health" >/dev/null 2>&1; then
     echo "Simulator is reachable"
 else
-    reachable=false
-    echo "Simulator is NOT reachable"
-    echo "❌ Payload Processing E2E Testing Failed"
+    echo "Simulator is NOT reachable at https://${E2E_SIMULATOR_ENDPOINT}/health"
+    echo "Payload Processing E2E Testing Failed"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Adds a Tekton `PipelineRun` definition to enable Konflux group testing for the `ai-gateway-payload-processing` component.

## Description

- Introduces `.tekton/ai-gateway-group-test.yaml`, a new `PipelineRun` definition for group-level integration testing in Konflux.
- The pipeline is triggered via a `/group-test` comment on a pull request (`event == "group-test"`).
- References the `pr-group-testing-pipeline.yaml` pipeline from `opendatahub-io/odh-konflux-central`, keeping the orchestration logic centralized.
- Includes both `ai-gateway-payload-processing-e2e-ci` and `odh-ai-gateway-payload-processing-ci` components in the group test scope.
- Configured with a 4-hour pipeline timeout and runs on Konflux tenant nodes.

## Dependency

> **This PR depends on [#218](https://github.com/opendatahub-io/ai-gateway-payload-processing/pull/218) and must be merged after it.**
> PR #218 introduces the E2E CI orchestrator script (`test/e2e/scripts/e2e-ci.sh`) that the group test pipeline relies on.

## How it was tested

- Verified YAML structure is consistent with existing Tekton `PipelineRun` definitions in `.tekton/`.
- Manually reviewed annotations, labels, workspace, and pipeline resolver configuration against Konflux conventions.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new Tekton pipeline configuration to support group-testing workflows, including run retention, start conditions, timeouts, and workspace integration to streamline CI group tests.
  * Improved end-to-end test health checks by switching to HTTPS health endpoint probes and clearer failure reporting for more reliable simulator verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->