### PR TITLE
fix(yaml): resolve lint syntax errors

### DIFF
--- a/.github/workflows/check-typos.yaml
+++ b/.github/workflows/check-typos.yaml
@@ -1,8 +1,8 @@
 name: Check Typos
 
 on:
-  pull_request:
-  push:
+  pull_request: {}
+  push: {}
 
 jobs:
   typos:
@@ -15,4 +15,3 @@ jobs:
 
       - name: Check typos
         uses: crate-ci/typos@v1.45.1
-

--- a/deploy/payload-processing/templates/rbac.yaml
+++ b/deploy/payload-processing/templates/rbac.yaml
@@ -1,3 +1,4 @@
+---
 {{- $bbr := .Values.upstreamBbr.bbr }}
 {{- if $bbr.multiNamespace }}
 ---


### PR DESCRIPTION

## Description

Fix YAML lint errors flagged in security scan:
- Add explicit empty mappings (`{}`) for workflow triggers in `check-typos.yaml`
- Add document start marker (`---`) to `rbac.yaml` Helm template

## How Has This Been Tested?

Ran `yamllint` locally on `check-typos.yaml` — passes with no errors.

Fixes #197 #198 #199 #200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration syntax for consistency.
  * Minor formatting adjustment to deployment template.

These are internal infrastructure updates with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->