### PR TITLE
fix(ci): pin mikepenz/action-junit-report to SHA (v6)

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Publish E2E test results
         if: always()
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6
         with:
           report_paths: "**/results_e2e_xunit.xml"
           check_name: E2E Test Results


### PR DESCRIPTION
## Description

Pins `mikepenz/action-junit-report` in `.github/workflows/ci-e2e.yaml` from the mutable tag `@v6` to the immutable commit SHA for that tag (`bccf2e31636835cf0874589931c4116687171386`), with an inline `# v6` comment for readability.

This addresses the supply-chain / unpinned third-party action finding (`zizmor/unpinned-uses`) reported for the E2E workflow.

Fixes #176

## How Has This Been Tested?

- Confirmed the workflow still references a valid `uses:` line (full 40-char SHA + comment).
- CI: rely on the existing `ci-e2e` workflow run for this PR to validate the pinned action executes in the **Publish E2E test results** step.

## Merge criteria:

- [ ] The commits are squashed into one commit (or reasonably few logical commits).
- [ ] Commit messages include testing instructions and/or manual verification steps, if not evident from the PR description.
- [ ] Changes were manually verified to work as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration for improved test report handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->