### PR TITLE
ci(security): pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/check-typos.yaml
+++ b/.github/workflows/check-typos.yaml
@@ -14,4 +14,4 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Check typos
-        uses: crate-ci/typos@v1.46.0
+        uses: crate-ci/typos@bbaefadf97b0ec5fdc942684b647f1a6ab250274 # v1.46.0

--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Publish E2E test results
         if: always()
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6
         with:
           report_paths: "**/results_e2e_xunit.xml"
           check_name: E2E Test Results


### PR DESCRIPTION
## Summary

Addresses the remaining 2 HIGH severity findings from #172 by pinning third-party GitHub Actions to immutable commit SHAs, preventing supply chain attacks via mutable tags.

4 of the original 6 findings were already fixed by #227, #228, #229, #230. This PR covers the remaining 2:

### Changes

| File | Action | Before | After |
|------|--------|--------|-------|
| `check-typos.yaml` | `crate-ci/typos` | `@v1.46.0` | `@bbaefadf97b0ec5fdc942684b647f1a6ab250274 # v1.46.0` |
| `ci-e2e.yaml` | `mikepenz/action-junit-report` | `@v6` | `@bccf2e31636835cf0874589931c4116687171386 # v6` |

First-party actions (`actions/*`, `docker/*`) are excluded as they are covered by GitHub's own security guarantees.

Closes #172
Closes #173, #176

## Test plan

- [x] Both SHAs verified against their current tags via GitHub API
- [x] `yamllint -d relaxed` passes on both modified files (exit code 0)
- [x] Rebased on latest `main` (includes #227, #228, #229, #230)
- [x] No remaining unpinned third-party actions in any workflow file
- [x] Minimal diff: only `uses:` lines changed, no functional impact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations to use pinned commit references for improved workflow stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->