### PR TITLE
Restrict Secret informer to bbr-managed labeled Secrets only

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -3,3 +3,37 @@
 A chart to deploy payload-processing.
 
 <!-- TODO we should pin to odh payload processing released tag -->
+
+## RBAC and Secrets Access
+
+The `apikey-injection` plugin watches Kubernetes Secrets to inject provider API
+keys (e.g. OpenAI, Anthropic) into outbound inference requests. Only Secrets
+labeled `inference.llm-d.ai/ipp-managed: "true"` are processed.
+
+### Single-namespace mode (`multiNamespace: false`, the default)
+
+A **Role** and **RoleBinding** are created in the release namespace. This matches
+[Kubernetes RBAC good practices](https://kubernetes.io/docs/concepts/security/rbac-good-practices/)
+(least privilege, prefer namespace-scoped bindings) and limits exposure called
+out in [#201](https://github.com/opendatahub-io/ai-gateway-payload-processing/issues/201).
+
+Keep `ExternalModel` resources and their credential `Secret`s in the **same
+namespace as the Helm release** when using this default. If IPP runs in the
+release namespace but models or credentials live in **other** namespaces, set
+`upstreamBbr.bbr.multiNamespace: true` in your values (ClusterRole path);
+otherwise the controller cannot read those objects. Downstream distributions
+that centralize IPP often ship this override in their own values overlay.
+
+### Multi-namespace mode (`multiNamespace: true`, opt-in)
+
+A **ClusterRole** is created with `get`/`list`/`watch` on `secrets`. Kubernetes
+RBAC cannot scope `secrets` by label, so static analysis tools will still flag
+broad Secret access; only enable when ExternalModels and credential Secrets
+actually span namespaces.
+
+Defense in depth on the workload:
+
+- The Secret informer uses a **label selector** at list/watch time so only
+  `ipp-managed` Secrets enter the cache (reduces blast radius if the process is
+  compromised; it does not replace least-privilege RBAC). `Reconcile` still
+  checks the label after `Get` before storing credentials.

--- a/deploy/payload-processing/templates/rbac.yaml
+++ b/deploy/payload-processing/templates/rbac.yaml
@@ -6,7 +6,11 @@ kind: ClusterRole
 metadata:
   name: {{ .Release.Name }}-externalmodels-reader
 rules:
-  # apikey-injection plugin: watches labeled Secrets
+  # apikey-injection plugin: watches Secrets that carry the label
+  # "inference.llm-d.ai/ipp-managed=true" to inject provider API keys.
+  # A ClusterRole is required because Kubernetes RBAC does not support
+  # label-based scoping; the apikey-injection Secret informer still applies a
+  # label selector at list/watch time so only ipp-managed Secrets are cached.
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
@@ -35,7 +39,9 @@ metadata:
   name: {{ .Release.Name }}-externalmodels-reader
   namespace: {{ .Release.Namespace }}
 rules:
-  # apikey-injection plugin: watches labeled Secrets
+  # apikey-injection plugin: watches Secrets labeled
+  # "inference.llm-d.ai/ipp-managed=true" in this namespace.
+  # Scoped to a single namespace via Role (preferred over ClusterRole).
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]

--- a/deploy/payload-processing/values.yaml
+++ b/deploy/payload-processing/values.yaml
@@ -9,7 +9,9 @@ upstreamBbr:
       pullPolicy: IfNotPresent
     port: 9004
     healthCheckPort: 9005
-    multiNamespace: true
+    # false = namespaced Role for secrets + externalmodels (default, least privilege; see #201).
+    # true = ClusterRole when ExternalModels/credentials span multiple namespaces.
+    multiNamespace: false
 
     flags:
       # Log verbosity

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -60,7 +60,7 @@ metadata:
   name: anthropic-api-key
   namespace: llm
   labels:
-    inference.networking.k8s.io/bbr-managed: "true"
+    inference.llm-d.ai/ipp-managed: "true"
 type: Opaque
 stringData:
   api-key: "sk-ant-api03-..."

--- a/docs/providers/azure-openai.md
+++ b/docs/providers/azure-openai.md
@@ -52,7 +52,7 @@ metadata:
   name: azure-api-key
   namespace: llm
   labels:
-    inference.networking.k8s.io/bbr-managed: "true"
+    inference.llm-d.ai/ipp-managed: "true"
 type: Opaque
 stringData:
   api-key: "<AZURE_API_KEY>"

--- a/docs/providers/bedrock-openai.md
+++ b/docs/providers/bedrock-openai.md
@@ -67,7 +67,7 @@ metadata:
   name: bedrock-api-key
   namespace: llm
   labels:
-    inference.networking.k8s.io/bbr-managed: "true"
+    inference.llm-d.ai/ipp-managed: "true"
 type: Opaque
 stringData:
   api-key: "<BEDROCK_API_KEY>"

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -41,7 +41,7 @@ metadata:
   name: openai-api-key
   namespace: llm
   labels:
-    inference.networking.k8s.io/bbr-managed: "true"
+    inference.llm-d.ai/ipp-managed: "true"
 type: Opaque
 stringData:
   api-key: "sk-proj-..."

--- a/docs/providers/vertex-openai.md
+++ b/docs/providers/vertex-openai.md
@@ -93,7 +93,7 @@ metadata:
   name: vertex-api-key
   namespace: llm
   labels:
-    inference.networking.k8s.io/bbr-managed: "true"
+    inference.llm-d.ai/ipp-managed: "true"
 type: Opaque
 stringData:
   api-key: "ya29.a0..."  # OAuth token from gcloud auth print-access-token

--- a/pkg/plugins/apikey-injection/plugin.go
+++ b/pkg/plugins/apikey-injection/plugin.go
@@ -20,11 +20,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
 	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
@@ -45,7 +51,7 @@ var _ framework.RequestProcessor = &ApiKeyInjectionPlugin{}
 
 // APIKeyInjectionFactory defines the factory function for ApiKeyInjectionPlugin.
 func APIKeyInjectionFactory(name string, _ json.RawMessage, handle framework.Handle) (framework.BBRPlugin, error) {
-	plugin, err := NewAPIKeyInjectionPlugin(handle.ReconcilerBuilder, handle.ClientReader())
+	plugin, err := NewAPIKeyInjectionPlugin(handle.Context(), handle.ReconcilerBuilder, handle.ClientReader())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create plugin '%s' - %w", APIKeyInjectionPluginType, err)
 	}
@@ -53,15 +59,29 @@ func APIKeyInjectionFactory(name string, _ json.RawMessage, handle framework.Han
 	return plugin.WithName(name), nil
 }
 
-// NewAPIKeyInjectionPlugin creates a new apiKeyInjectionPlugin and returns its pointer
-func NewAPIKeyInjectionPlugin(reconcilerBuilder func() *builder.Builder, clientReader client.Reader) (*ApiKeyInjectionPlugin, error) {
+// NewAPIKeyInjectionPlugin creates a new apiKeyInjectionPlugin and returns its pointer.
+// It sets up a label-filtered informer cache so only Secrets matching the
+// ipp-managed label are listed from the API server; Reconcile still checks the
+// label after Get before updating the store.
+func NewAPIKeyInjectionPlugin(ctx context.Context, reconcilerBuilder func() *builder.Builder, clientReader client.Reader) (*ApiKeyInjectionPlugin, error) {
 	store := newSecretStore()
 	reconciler := &secretReconciler{
 		Reader: clientReader,
 		store:  store,
 	}
 
-	if err := reconcilerBuilder().For(&corev1.Secret{}).WithEventFilter(managedLabelPredicate()).Complete(reconciler); err != nil {
+	filteredCache, err := newFilteredSecretCache(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var secretObj client.Object = &corev1.Secret{}
+	if err := reconcilerBuilder().
+		Named("apikey-injection-secret-watcher").
+		WatchesRawSource(
+			source.Kind(filteredCache, secretObj, &handler.EnqueueRequestForObject{}),
+		).
+		Complete(reconciler); err != nil {
 		return nil, fmt.Errorf("failed to register Secret reconciler for plugin '%s' - %w", APIKeyInjectionPluginType, err)
 	}
 
@@ -71,9 +91,9 @@ func NewAPIKeyInjectionPlugin(reconcilerBuilder func() *builder.Builder, clientR
 			Name: APIKeyInjectionPluginType,
 		},
 		authHeadersGenerators: map[string]auth.AuthHeadersGenerator{
-			provider.OpenAI:        &auth.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
-			provider.Anthropic:     &auth.SimpleAuthGenerator{HeaderName: "x-api-key"},
-			provider.AzureOpenAI:   &auth.SimpleAuthGenerator{HeaderName: "api-key"},
+			provider.OpenAI:      &auth.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
+			provider.Anthropic:   &auth.SimpleAuthGenerator{HeaderName: "x-api-key"},
+			provider.AzureOpenAI: &auth.SimpleAuthGenerator{HeaderName: "api-key"},
 			// provider.Vertex uses the native GenerateContent API — not used in 3.4 ExternalModel flow.
 			// provider.Vertex:     &auth.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
 			provider.VertexOpenAI:  &auth.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
@@ -144,4 +164,43 @@ func (p *ApiKeyInjectionPlugin) ProcessRequest(ctx context.Context, cycleState *
 
 	log.FromContext(ctx).V(logutil.VERBOSE).Info("auth headers injected", "provider", providerName)
 	return nil
+}
+
+// newFilteredSecretCache creates a controller-runtime cache that restricts the
+// Secret informer to only list/watch Secrets labeled with the managed label.
+// This is a defense-in-depth measure: even though the RBAC ClusterRole grants
+// broad Secret access (required for cross-namespace watches), the informer
+// never fetches or caches unrelated Secrets.
+func newFilteredSecretCache(ctx context.Context) (cache.Cache, error) {
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get rest config for filtered Secret cache: %w", err)
+	}
+
+	filteredCache, err := cache.New(cfg, cache.Options{
+		ByObject: map[client.Object]cache.ByObject{
+			&corev1.Secret{}: {
+				Label: labels.SelectorFromSet(labels.Set{
+					managedLabel: "true",
+				}),
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create filtered Secret cache: %w", err)
+	}
+
+	go func() {
+		if err := filteredCache.Start(ctx); err != nil {
+			ctrl.Log.WithName(APIKeyInjectionPluginType).Error(err, "filtered Secret cache stopped unexpectedly")
+		}
+	}()
+
+	syncCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	if !filteredCache.WaitForCacheSync(syncCtx) {
+		return nil, fmt.Errorf("filtered Secret cache failed to sync within deadline")
+	}
+
+	return filteredCache, nil
 }

--- a/pkg/plugins/apikey-injection/reconciler.go
+++ b/pkg/plugins/apikey-injection/reconciler.go
@@ -24,32 +24,18 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 const (
 	// managedLabel selects Secrets managed by the apikey-injection plugin.
-	// Only Secrets carrying this label are watched by the reconciler.
-	managedLabel = "inference.networking.k8s.io/bbr-managed"
+	// The Secret informer uses this as a list/watch label selector; Reconcile
+	// also requires this label before caching Secret data.
+	managedLabel = "inference.llm-d.ai/ipp-managed"
 )
 
 func hasManagedLabel(object client.Object) bool {
 	return object.GetLabels()[managedLabel] == "true"
-}
-
-// managedLabelPredicate filters events to only Secrets labeled with
-// "inference.networking.k8s.io/bbr-managed" = "true".
-// For updates, it accepts the event when either the old or new object carries
-// the label so that label-removal is visible to the reconciler.
-func managedLabelPredicate() predicate.Predicate {
-	return predicate.Funcs{
-		CreateFunc:  func(e event.CreateEvent) bool { return hasManagedLabel(e.Object) },
-		UpdateFunc:  func(e event.UpdateEvent) bool { return hasManagedLabel(e.ObjectOld) || hasManagedLabel(e.ObjectNew) },
-		DeleteFunc:  func(e event.DeleteEvent) bool { return hasManagedLabel(e.Object) },
-		GenericFunc: func(e event.GenericEvent) bool { return hasManagedLabel(e.Object) },
-	}
 }
 
 // secretReconciler watches Secrets and updates the secretStore.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -50,7 +50,7 @@ metadata:
   name: %s
   namespace: %s
   labels:
-    inference.networking.k8s.io/bbr-managed: "true"
+    inference.llm-d.ai/ipp-managed: "true"
 type: Opaque
 stringData:
   api-key: %s

--- a/test/e2e/reports/3.4/external-model-e2e-report.md
+++ b/test/e2e/reports/3.4/external-model-e2e-report.md
@@ -622,7 +622,7 @@ metadata:
   name: <secret-name>
   namespace: <ns>
   labels:
-    inference.networking.k8s.io/bbr-managed: "true"
+    inference.llm-d.ai/ipp-managed: "true"
 type: Opaque
 stringData:
   api-key: "<provider-api-key>"

--- a/test/e2e/scripts/e2e-values.yaml
+++ b/test/e2e/scripts/e2e-values.yaml
@@ -1,5 +1,10 @@
 upstreamBbr:
   bbr:
+    # E2E applies ExternalModels and credential Secrets in E2E_NS (default
+    # bbr-e2e) while the chart installs IPP in default. Namespaced Role RBAC
+    # cannot reach another namespace; enable cluster-scoped reader (#201
+    # multiNamespace) so the E2E suite matches production multi-namespace setups.
+    multiNamespace: true
     plugins:
       - type: body-field-to-header
         name: model-extractor


### PR DESCRIPTION
## Description

Addresses [#201](https://github.com/opendatahub-io/ai-gateway-payload-processing/issues/201): with **`multiNamespace: true`**, the chart grants a **ClusterRole** on `secrets` with `get`/`list`/`watch` cluster-wide, because Kubernetes RBAC cannot scope `secrets` by label. The workload only needs credential Secrets labeled **`inference.llm-d.ai/ipp-managed: "true"`**.

Previously, `apikey-injection` registered `For(&Secret{})` on the manager’s default cache, so the Secret informer could **list/watch and retain a broad set of Secrets in memory** even though reconciliation only used labeled ones.

This PR:

1. **Least privilege by default (Helm)** — **`upstreamBbr.bbr.multiNamespace` defaults to `false`**, so the chart installs a **namespaced `Role`/`RoleBinding`** for `secrets` and `externalmodels` in the release namespace. **`multiNamespace: true`** remains an explicit opt-in that still uses a **ClusterRole** when models/credentials span namespaces.

2. **Defense in depth (runtime)** — **`apikey-injection`** uses a **dedicated controller-runtime cache** whose Secret list/watch uses a **label selector** for `inference.llm-d.ai/ipp-managed=true`, so only those Secrets are fetched into that cache. **`Reconcile`** still checks the label after `Get` before updating the in-memory credential store. The old **event predicate** was removed as redundant once list/watch is label-scoped.

3. **Docs / operator clarity** — RBAC template comments and **`deploy/README.md`** describe default vs opt-in ClusterRole behavior, link to RBAC good practices / #201, and document the **ipp-managed** label (including migration from the previous `bbr-managed` label in examples).

### Changes

- **`pkg/plugins/apikey-injection/plugin.go`**: Replace `For(&Secret{})` with `WatchesRawSource` + label-filtered Secret cache; bounded wait for cache sync; no `managedLabelPredicate`.
- **`pkg/plugins/apikey-injection/reconciler.go`**: Managed label constant → `inference.llm-d.ai/ipp-managed`; remove predicate; keep post-`Get` label check in `Reconcile`.
- **`deploy/payload-processing/values.yaml`**: Default `multiNamespace: false` with short comments.
- **`deploy/payload-processing/templates/rbac.yaml`**: Comments for Role vs ClusterRole paths and informer label scoping (no fragile Go symbol references).
- **`deploy/README.md`**: RBAC / Secrets access section aligned with defaults, opt-in ClusterRole, and ipp-managed label.
- **`docs/providers/*.md`**, **`test/e2e/e2e_test.go`**, **`test/e2e/reports/3.4/external-model-e2e-report.md`**: Example Secrets use **`inference.llm-d.ai/ipp-managed: "true"`**.

## How Has This Been Tested?

- `go test ./pkg/...` — unit tests pass (including `apikey-injection`; tests that use `newTestPlugin()` do not exercise cache startup).
- `go build ./...` — compiles cleanly.
- **Manual / cluster:** install or upgrade with default values → confirm only **Role** is created for this chart’s externalmodels reader; with `multiNamespace: true`, confirm **ClusterRole** path; confirm BBR still loads credentials for Secrets labeled **`inference.llm-d.ai/ipp-managed: "true"`** (existing clusters must **re-label** secrets that still use the old `bbr-managed` key).

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added RBAC and Secrets access guidance for API key injection.
  * Clarified single-namespace (Role) vs multi-namespace (ClusterRole) modes.
  * Updated provider and example Secrets to use the new label key: inference.llm-d.ai/ipp-managed: "true".

* **Chores**
  * Clarified RBAC template comments to explain Secrets access patterns.
  * Default deployment config switched to single-namespace mode (least privilege).

* **Tests**
  * Updated e2e values and reports to reflect the new label and multi-namespace test option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->