### PR TITLE
ci(security): pin jlumbroso/free-disk-space action to commit SHA

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -39,7 +39,7 @@ jobs:
       contents: read
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           tool-cache: false
 


### PR DESCRIPTION
## Description

Pin the `jlumbroso/free-disk-space` GitHub Action from the mutable `@main` branch reference to its full commit SHA (`54081f138730dfa15788a46383842cd2f914a1be`).

Referencing an action by branch name means any push to that branch — including potentially compromised commits — will be executed in CI. Pinning to a specific commit SHA ensures an immutable, auditable reference that prevents supply-chain attacks.

## How Has This Been Tested?

- Ran `zizmor` locally — the `unpinned-uses` finding for `jlumbroso/free-disk-space` is no longer reported.
- Verified the pinned SHA resolves to a valid commit via `git ls-remote`.

Fixes #178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to use a pinned version of a dependency for improved build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->