### PR TITLE
ci(security): pin dorny/paths-filter action to commit SHA

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
         with:
           filters: |


### PR DESCRIPTION
## Description

Pin the `dorny/paths-filter` GitHub Action from the mutable `@v4` tag reference to its full commit SHA (`fbd0ab8f3e69293af611ebaee6363fc25e6d187d`).

Mutable version tags can be moved to arbitrary commits by the upstream maintainer (or an attacker who compromises the repository), making them a supply-chain attack vector. Pinning to a specific commit SHA ensures an immutable, auditable reference.

## How Has This Been Tested?

- Ran `zizmor` locally — the `unpinned-uses` finding for `dorny/paths-filter` is no longer reported.
- Verified the pinned SHA resolves to a valid commit via `git ls-remote`.

Fixes #177