### PR TITLE
ci(security): pin jlumbroso/free-disk-space action to commit SHA in ci-e2e.yaml

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -67,7 +67,7 @@ jobs:
       checks: write
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           tool-cache: false
 


### PR DESCRIPTION
## Description

Pin the `jlumbroso/free-disk-space` GitHub Action in `ci-e2e.yaml` from the mutable `@main` branch reference to its full commit SHA (`54081f138730dfa15788a46383842cd2f914a1be`).

Branch references always point to the latest commit, meaning any push to `main` (including compromised commits) will be executed in CI. Pinning to a specific commit SHA ensures an immutable, auditable reference that prevents supply-chain attacks.

## How Has This Been Tested?

- Ran `zizmor` locally — the `unpinned-uses` finding for `jlumbroso/free-disk-space` in `ci-e2e.yaml` is no longer reported.
- Verified the pinned SHA resolves to a valid commit via `git ls-remote`.

Fixes #175