### PR TITLE
fix: remove system role filtering, TrustyAI now supports system messages

### DIFF
--- a/pkg/plugins/nemo/request_guard.go
+++ b/pkg/plugins/nemo/request_guard.go
@@ -133,7 +133,7 @@ func (p *NemoRequestGuardPlugin) ProcessRequest(ctx context.Context, _ *framewor
 // extractMessages returns user-supplied text as a message slice suitable for NeMo's
 // OpenAI-compatible chat endpoint. It supports two payload formats:
 //
-//  1. OpenAI chat: top-level "messages" array → forwards all non-system messages.
+//  1. OpenAI chat: top-level "messages" array → forwards all messages.
 //  2. MCP JSON-RPC: {"jsonrpc":"2.0","params":{"arguments":{…}}} → concatenates
 //     all string argument values into a single user message.
 //
@@ -148,15 +148,17 @@ func extractMessages(body map[string]any) ([]map[string]string, error) {
 	return nil, nil // not an inference request (e.g. API key management, model listing)
 }
 
-// extractOpenAIMessages parses an OpenAI-style "messages" value. System messages are
-// filtered. TrustyAI does not support this role. All other roles are forwarded so NeMo can evaluate
-// the full conversation context.
+// extractOpenAIMessages parses an OpenAI-style "messages" value. All messages are forwarded
+// so NeMo can evaluate the full conversation context.
 func extractOpenAIMessages(raw any) ([]map[string]string, error) {
 	slice, ok := raw.([]any)
 	if !ok {
 		return nil, fmt.Errorf("messages is not an array")
 	}
-	var messages []map[string]string
+	if len(slice) == 0 {
+		return nil, nil
+	}
+	messages := make([]map[string]string, 0, len(slice))
 
 	for _, m := range slice {
 		msg, ok := m.(map[string]any)
@@ -164,9 +166,6 @@ func extractOpenAIMessages(raw any) ([]map[string]string, error) {
 			continue
 		}
 		role, _ := msg["role"].(string)
-		if role == "system" {
-			continue
-		}
 		content, _ := msg["content"].(string)
 		messages = append(messages, map[string]string{"role": role, "content": content})
 	}

--- a/pkg/plugins/nemo/request_guard_test.go
+++ b/pkg/plugins/nemo/request_guard_test.go
@@ -362,10 +362,9 @@ func TestNemoRequestGuardSendsCorrectPayloadMCP(t *testing.T) {
 	assert.Equal(t, "hello world", msg["content"])
 }
 
-// TestNemoRequestGuardForwardsAllNonSystemMessages verifies that user, assistant, and tool
-// messages are forwarded to NeMo while system messages are filtered out (the /v1/guardrail/checks
-// endpoint rejects the system role with status "error").
-func TestNemoRequestGuardForwardsAllNonSystemMessages(t *testing.T) {
+// TestNemoRequestGuardForwardsAllMessages verifies that all messages including system
+// are forwarded to NeMo for evaluation.
+func TestNemoRequestGuardForwardsAllMessages(t *testing.T) {
 	var capturedReq map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&capturedReq))
@@ -390,13 +389,13 @@ func TestNemoRequestGuardForwardsAllNonSystemMessages(t *testing.T) {
 
 	messages, ok := capturedReq["messages"].([]any)
 	require.True(t, ok, "messages should be an array")
-	require.Len(t, messages, 4, "system message must be filtered, 4 remaining forwarded")
+	require.Len(t, messages, 5, "all messages including system should be forwarded")
 
 	roles := make([]string, len(messages))
 	for i, m := range messages {
 		roles[i] = m.(map[string]any)["role"].(string)
 	}
-	assert.Equal(t, []string{"user", "assistant", "tool", "user"}, roles)
+	assert.Equal(t, []string{"system", "user", "assistant", "tool", "user"}, roles)
 }
 
 // TestNemoRequestGuardBaseURLTrailingSlash ensures a trailing slash in baseURL doesn't double up.
@@ -479,25 +478,15 @@ func TestExtractMessages(t *testing.T) {
 			},
 		},
 		{
-			name: "system message filtered out — /v1/guardrail/checks rejects system role",
+			name: "single system message",
 			body: map[string]any{
 				"messages": []any{
 					map[string]any{"role": "system", "content": "You are helpful"},
-					map[string]any{"role": "user", "content": "Hello"},
 				},
 			},
 			want: []map[string]string{
-				{"role": "user", "content": "Hello"},
+				{"role": "system", "content": "You are helpful"},
 			},
-		},
-		{
-			name: "system-only conversation — all filtered, returns nil",
-			body: map[string]any{
-				"messages": []any{
-					map[string]any{"role": "system", "content": "You are helpful"},
-				},
-			},
-			want: nil,
 		},
 		{
 			name: "tool message included — not filtered out",


### PR DESCRIPTION
## Summary

- Remove system message filtering from `nemo-request-guard`. Previously, messages with `role: "system"` were filtered out before sending to NeMo because the TrustyAI `/v1/guardrail/checks` endpoint rejected them with a hard error (`Unsupported message role: 'system'`).
- TrustyAI has since merged [feat(api): Support input guardrail checks when role: 'system' (#47)](https://github.com/trustyai-explainability/NeMo-Guardrails/pull/47).
- All messages (including system) are now forwarded to NeMo for full conversation context evaluation.

Closes #160. #205 

## Changes

- `request_guard.go`: Removed the `if role == "system" { continue }` filter in `extractOpenAIMessages`. Updated comments.
- `request_guard_test.go`: Updated tests to expect system messages in the forwarded payload.

## E2E verification
Verified end-to-end by building the TrustyAI NeMo image locally from the `develop` branch (`Dockerfile.server`) which includes PR #47, and deploying it on a Kind cluster with `detect sensitive data on input` rails:
| Test | Messages | Result |
|------|----------|--------|
| Safe system + user | `system: "You are a helpful assistant"` + `user: "Hello"` | **success** (both checked) |
| PII in system msg | `system: "card 4111-1111-1111-1111"` + `user: "Hello"` | **blocked** (system detected) |
| System-only with PII | `system: "Contact John Smith at john@example.com"` | **blocked** (system detected) |

cc @nirrozenbaum @christinaexyou 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * System messages are now included when forwarding conversations to NeMo, ensuring complete message history is transmitted.
* **Tests**
  * Unit tests updated to expect and validate all message roles (including system) and adjusted cases for single-system vs. system-only conversations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->