### PR TITLE
feat: add SigV4 auth generator for AWS Bedrock provider

### DIFF
--- a/deploy/payload-processing/values.yaml
+++ b/deploy/payload-processing/values.yaml
@@ -27,6 +27,8 @@ upstreamBbr:
         name: model-provider-resolver
       - type: api-translation
         name: api-translation
+      # Ordering: apikey-injection must be last. SigV4 signs request.Body —
+      # do not add body-mutating plugins after this point.
       - type: apikey-injection
         name: apikey-injection
 

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,8 @@ require (
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
+	github.com/aws/aws-sdk-go-v2 v1.41.7 // indirect
+	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,10 @@ github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYW
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
+github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
+github.com/aws/smithy-go v1.25.1 h1:J8ERsGSU7d+aCmdQur5Txg6bVoYelvQJgtZehD12GkI=
+github.com/aws/smithy-go v1.25.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/pkg/plugins/apikey-injection/auth-generator/auth_generator.go
+++ b/pkg/plugins/apikey-injection/auth-generator/auth_generator.go
@@ -16,8 +16,16 @@ limitations under the License.
 
 package authgenerator
 
+import "sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
+
 // AuthHeadersGenerator generates auth headers from credential fields.
 // Each implementation defines which fields it requires from the credentials map.
 type AuthHeadersGenerator interface {
+	// ExtractRequestData pulls provider-specific data from the request/CycleState
+	// that is needed for auth header generation (e.g., body, endpoint for SigV4).
+	// The returned map is merged into credentialsData before GenerateAuthHeaders is called.
+	// Implementations that don't need request data should return nil, nil.
+	ExtractRequestData(cycleState *framework.CycleState, request *framework.InferenceRequest) (map[string]string, error)
+
 	GenerateAuthHeaders(credentialsData map[string]string) (map[string]string, error)
 }

--- a/pkg/plugins/apikey-injection/auth-generator/sigv4_auth_generator.go
+++ b/pkg/plugins/apikey-injection/auth-generator/sigv4_auth_generator.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
+
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/state"
+)
+
+const (
+	awsAccessKeyField    = "aws-access-key-id"
+	awsSecretKeyField    = "aws-secret-access-key"
+	awsSessionTokenField = "aws-session-token"
+
+	bodyField     = "request_body"
+	endpointField = "endpoint"
+	pathField     = "path"
+	regionField   = "region"
+	serviceField  = "service"
+)
+
+// compile-time interface check
+var _ AuthHeadersGenerator = &SigV4AuthGenerator{}
+
+// SigV4AuthGenerator generates AWS Signature Version 4 authentication headers.
+type SigV4AuthGenerator struct{}
+
+// ExtractRequestData pulls the request body, endpoint, path, region, and service
+// from CycleState and the InferenceRequest. Region falls back to hostname extraction
+// if not set in config; endpoint, path and service are mandatory. The returned map is merged into
+// credentialsData before GenerateAuthHeaders is called.
+func (g *SigV4AuthGenerator) ExtractRequestData(cycleState *framework.CycleState, request *framework.InferenceRequest) (map[string]string, error) {
+	// json.Marshal produces deterministic output (sorted map keys), ensuring the
+	// signed body matches what the framework sends upstream. If the framework ever
+	// changes its serializer, this assumption must be revisited.
+	bodyBytes, err := json.Marshal(request.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request body: %w", err)
+	}
+
+	endpoint, err := framework.ReadCycleStateKey[string](cycleState, state.EndpointKey)
+	if err != nil || endpoint == "" {
+		return nil, fmt.Errorf("missing or empty endpoint in CycleState (key %q)", state.EndpointKey)
+	}
+
+	path := request.Headers[":path"]
+	if path == "" {
+		return nil, fmt.Errorf("missing :path pseudo-header in request")
+	}
+
+	config, _ := framework.ReadCycleStateKey[map[string]string](cycleState, state.ModelConfigKey)
+
+	region := config["region"]
+	if region == "" {
+		var err error
+		region, err = regionFromEndpoint(endpoint)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve region: %w", err)
+		}
+	}
+
+	service := config["service"]
+	if service == "" {
+		return nil, fmt.Errorf("missing \"service\" in ExternalProvider.spec.config -- set the AWS service name (e.g. \"bedrock\", \"sagemaker\")")
+	}
+
+	return map[string]string{
+		bodyField:     string(bodyBytes),
+		endpointField: endpoint,
+		pathField:     path,
+		regionField:   region,
+		serviceField:  service,
+	}, nil
+}
+
+// GenerateAuthHeaders computes a SigV4 signature and returns the required AWS auth headers.
+// All runtime fields (body, endpoint, path, region, service) are guaranteed by ExtractRequestData.
+// Only "aws-access-key-id" and "aws-secret-access-key" come from the Secret and need validation here.
+func (g *SigV4AuthGenerator) GenerateAuthHeaders(credentialsData map[string]string) (map[string]string, error) {
+	accessKey := credentialsData[awsAccessKeyField]
+	if accessKey == "" {
+		return nil, fmt.Errorf("credentials missing required field %s", awsAccessKeyField)
+	}
+	secretKey := credentialsData[awsSecretKeyField]
+	if secretKey == "" {
+		return nil, fmt.Errorf("credentials missing required field %s", awsSecretKeyField)
+	}
+
+	creds := aws.Credentials{
+		AccessKeyID:     accessKey,
+		SecretAccessKey: secretKey,
+		SessionToken:    credentialsData[awsSessionTokenField],
+		Source:          "ExternalModelSecret",
+	}
+
+	body := credentialsData[bodyField]
+	bodyHash := sha256Hex([]byte(body))
+
+	endpoint := credentialsData[endpointField]
+	path := credentialsData[pathField]
+	region := credentialsData[regionField]
+	service := credentialsData[serviceField]
+
+	req, err := http.NewRequest(http.MethodPost, "https://"+endpoint+path, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build HTTP request for signing: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	signer := v4.NewSigner()
+	if err := signer.SignHTTP(context.Background(), creds, req, bodyHash, service, region, time.Now()); err != nil {
+		return nil, fmt.Errorf("SigV4 signing failed: %w", err)
+	}
+
+	headers := map[string]string{
+		"Authorization":        req.Header.Get("Authorization"),
+		"X-Amz-Date":           req.Header.Get("X-Amz-Date"),
+		"X-Amz-Content-Sha256": bodyHash,
+	}
+	if creds.SessionToken != "" {
+		headers["X-Amz-Security-Token"] = creds.SessionToken
+	}
+
+	return headers, nil
+}
+
+// regionFromEndpoint extracts the AWS region from a standard Bedrock endpoint hostname.
+// Only accepts the canonical format: service.region.amazonaws.com (exactly 4 labels).
+// VPC endpoints, custom endpoints, or any non-standard format will return an error
+// instructing the user to set "region" explicitly in ExternalProvider.spec.config.
+func regionFromEndpoint(endpoint string) (string, error) {
+	if strings.Contains(endpoint, "://") {
+		return "", fmt.Errorf("endpoint must be a bare hostname without scheme: %q", endpoint)
+	}
+	parts := strings.Split(endpoint, ".")
+	if len(parts) != 4 || parts[2] != "amazonaws" || parts[3] != "com" {
+		return "", fmt.Errorf(
+			"cannot extract region from non-standard endpoint %q -- set \"region\" explicitly in ExternalProvider.spec.config",
+			endpoint,
+		)
+	}
+	return parts[1], nil
+}
+
+func sha256Hex(data []byte) string {
+	h := sha256.Sum256(data)
+	return fmt.Sprintf("%x", h)
+}

--- a/pkg/plugins/apikey-injection/auth-generator/sigv4_auth_generator.go
+++ b/pkg/plugins/apikey-injection/auth-generator/sigv4_auth_generator.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package auth
+package authgenerator
 
 import (
 	"context"

--- a/pkg/plugins/apikey-injection/auth-generator/sigv4_auth_generator_test.go
+++ b/pkg/plugins/apikey-injection/auth-generator/sigv4_auth_generator_test.go
@@ -1,0 +1,280 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestSigV4AuthHeadersGenerator(t *testing.T) {
+	validCredentials := map[string]string{
+		"aws-access-key-id":     "AKIAIOSFODNN7EXAMPLE",
+		"aws-secret-access-key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		"request_body":          `{"model":"anthropic.claude-v2","prompt":"hello"}`,
+		"endpoint":              "bedrock-runtime.us-east-1.amazonaws.com",
+		"path":                  "/default/bedrock-model/v1/chat/completions",
+		"region":                "us-east-1",
+		"service":               "bedrock",
+	}
+
+	validCredentialsWithToken := map[string]string{
+		"aws-access-key-id":     "AKIAIOSFODNN7EXAMPLE",
+		"aws-secret-access-key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		"aws-session-token":     "FwoGZXIvYXdzEBYaDH7example-session-token",
+		"request_body":          `{"model":"anthropic.claude-v2","prompt":"hello"}`,
+		"endpoint":              "bedrock-runtime.us-east-1.amazonaws.com",
+		"path":                  "/default/bedrock-model/v1/chat/completions",
+		"region":                "us-east-1",
+		"service":               "bedrock",
+	}
+
+	tests := []struct {
+		name             string
+		credentials      map[string]string
+		wantHeaders      []string
+		wantAuthPrefix   string
+		wantNoHeader     string
+		wantBodyHash     bool
+		wantRegionInAuth string
+		wantErrContains  string
+	}{
+		{
+			name:           "valid credentials without session token",
+			credentials:    validCredentials,
+			wantHeaders:    []string{"Authorization", "X-Amz-Date", "X-Amz-Content-Sha256"},
+			wantAuthPrefix: "AWS4-HMAC-SHA256",
+			wantNoHeader:   "X-Amz-Security-Token",
+			wantBodyHash:   true,
+		},
+		{
+			name:           "valid credentials with session token",
+			credentials:    validCredentialsWithToken,
+			wantHeaders:    []string{"Authorization", "X-Amz-Date", "X-Amz-Content-Sha256", "X-Amz-Security-Token"},
+			wantAuthPrefix: "AWS4-HMAC-SHA256",
+			wantBodyHash:   true,
+		},
+		{
+			name: "missing access key returns error",
+			credentials: map[string]string{
+				"aws-secret-access-key": "secret",
+				"request_body":          "{}",
+				"endpoint":              "bedrock-runtime.us-east-1.amazonaws.com",
+				"region":                "us-east-1",
+				"service":               "bedrock",
+			},
+			wantErrContains: "aws-access-key-id",
+		},
+		{
+			name: "missing secret key returns error",
+			credentials: map[string]string{
+				"aws-access-key-id": "AKIA...",
+				"request_body":      "{}",
+				"endpoint":          "bedrock-runtime.us-east-1.amazonaws.com",
+				"region":            "us-east-1",
+				"service":           "bedrock",
+			},
+			wantErrContains: "aws-secret-access-key",
+		},
+		{
+			name: "explicit region overrides hostname extraction",
+			credentials: map[string]string{
+				"aws-access-key-id":     "AKIAIOSFODNN7EXAMPLE",
+				"aws-secret-access-key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+				"request_body":          `{"model":"anthropic.claude-v2","prompt":"hello"}`,
+				"endpoint":              "bedrock-runtime.us-east-1.amazonaws.com",
+				"path":                  "/default/bedrock-model/v1/chat/completions",
+				"region":                "eu-west-2",
+				"service":               "bedrock",
+			},
+			wantHeaders:      []string{"Authorization", "X-Amz-Date", "X-Amz-Content-Sha256"},
+			wantAuthPrefix:   "AWS4-HMAC-SHA256",
+			wantRegionInAuth: "eu-west-2",
+			wantBodyHash:     true,
+		},
+		{
+			name: "explicit region with VPC endpoint that would fail hostname parsing",
+			credentials: map[string]string{
+				"aws-access-key-id":     "AKIAIOSFODNN7EXAMPLE",
+				"aws-secret-access-key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+				"request_body":          `{"model":"anthropic.claude-v2","prompt":"hello"}`,
+				"endpoint":              "vpce-0123456789.bedrock-runtime.us-west-2.vpce.amazonaws.com",
+				"path":                  "/default/bedrock-model/v1/chat/completions",
+				"region":                "us-west-2",
+				"service":               "bedrock",
+			},
+			wantHeaders:      []string{"Authorization", "X-Amz-Date", "X-Amz-Content-Sha256"},
+			wantAuthPrefix:   "AWS4-HMAC-SHA256",
+			wantRegionInAuth: "us-west-2",
+			wantBodyHash:     true,
+		},
+		{
+			name: "empty access key returns error",
+			credentials: map[string]string{
+				"aws-access-key-id":     "",
+				"aws-secret-access-key": "secret",
+				"request_body":          "{}",
+				"endpoint":              "bedrock-runtime.us-east-1.amazonaws.com",
+				"region":                "us-east-1",
+				"service":               "bedrock",
+			},
+			wantErrContains: "aws-access-key-id",
+		},
+		{
+			name:            "empty credentials returns error",
+			credentials:     map[string]string{},
+			wantErrContains: "aws-access-key-id",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			generator := &SigV4AuthGenerator{}
+			authHeaders, err := generator.GenerateAuthHeaders(test.credentials)
+
+			if test.wantErrContains != "" {
+				if err == nil {
+					t.Errorf("expected error containing %q but got nil", test.wantErrContains)
+				} else if !strings.Contains(err.Error(), test.wantErrContains) {
+					t.Errorf("expected error containing %q, got: %v", test.wantErrContains, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			for _, header := range test.wantHeaders {
+				val, ok := authHeaders[header]
+				if !ok {
+					t.Errorf("expected header %q not found in result", header)
+					continue
+				}
+				if val == "" {
+					t.Errorf("header %q is empty", header)
+				}
+			}
+
+			if test.wantAuthPrefix != "" {
+				auth := authHeaders["Authorization"]
+				if !strings.HasPrefix(auth, test.wantAuthPrefix) {
+					t.Errorf("Authorization header should start with %q, got: %q", test.wantAuthPrefix, auth)
+				}
+			}
+
+			if test.wantNoHeader != "" {
+				if _, ok := authHeaders[test.wantNoHeader]; ok {
+					t.Errorf("header %q should not be present", test.wantNoHeader)
+				}
+			}
+
+			if test.wantRegionInAuth != "" {
+				auth := authHeaders["Authorization"]
+				if !strings.Contains(auth, test.wantRegionInAuth) {
+					t.Errorf("Authorization header should contain region %q, got: %q", test.wantRegionInAuth, auth)
+				}
+			}
+
+			if test.wantBodyHash {
+				body := test.credentials["request_body"]
+				expectedHash := fmt.Sprintf("%x", sha256.Sum256([]byte(body)))
+				if got := authHeaders["X-Amz-Content-Sha256"]; got != expectedHash {
+					t.Errorf("content hash mismatch: want %q, got %q", expectedHash, got)
+				}
+			}
+		})
+	}
+}
+
+func TestRegionFromEndpoint(t *testing.T) {
+	tests := []struct {
+		name       string
+		endpoint   string
+		wantRegion string
+		wantErr    bool
+	}{
+		{
+			name:       "standard bedrock endpoint",
+			endpoint:   "bedrock-runtime.us-east-1.amazonaws.com",
+			wantRegion: "us-east-1",
+		},
+		{
+			name:       "eu-west-1 region",
+			endpoint:   "bedrock-runtime.eu-west-1.amazonaws.com",
+			wantRegion: "eu-west-1",
+		},
+		{
+			name:       "ap-southeast-1 region",
+			endpoint:   "bedrock-runtime.ap-southeast-1.amazonaws.com",
+			wantRegion: "ap-southeast-1",
+		},
+		{
+			name:     "too few parts - localhost",
+			endpoint: "localhost",
+			wantErr:  true,
+		},
+		{
+			name:     "only three parts",
+			endpoint: "bedrock.us-east-1.com",
+			wantErr:  true,
+		},
+		{
+			name:     "VPC endpoint - non-standard format requires explicit region",
+			endpoint: "vpce-0123456789.bedrock-runtime.us-west-2.vpce.amazonaws.com",
+			wantErr:  true,
+		},
+		{
+			name:     "endpoint with scheme rejected",
+			endpoint: "https://bedrock-runtime.us-east-1.amazonaws.com",
+			wantErr:  true,
+		},
+		{
+			name:     "wrong domain suffix",
+			endpoint: "bedrock-runtime.us-east-1.attacker.tld",
+			wantErr:  true,
+		},
+		{
+			name:     "five parts - extra subdomain",
+			endpoint: "extra.bedrock-runtime.us-east-1.amazonaws.com",
+			wantErr:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			region, err := regionFromEndpoint(test.endpoint)
+
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("expected error but got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if region != test.wantRegion {
+				t.Errorf("region mismatch: want %q, got %q", test.wantRegion, region)
+			}
+		})
+	}
+}

--- a/pkg/plugins/apikey-injection/auth-generator/sigv4_auth_generator_test.go
+++ b/pkg/plugins/apikey-injection/auth-generator/sigv4_auth_generator_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package auth
+package authgenerator
 
 import (
 	"crypto/sha256"

--- a/pkg/plugins/apikey-injection/auth-generator/simple_auth_generator.go
+++ b/pkg/plugins/apikey-injection/auth-generator/simple_auth_generator.go
@@ -18,6 +18,8 @@ package authgenerator
 
 import (
 	"fmt"
+
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
 )
 
 // apiKeyField is the field name in the credentials map that holds the API key.
@@ -33,6 +35,11 @@ var _ AuthHeadersGenerator = &SimpleAuthGenerator{}
 type SimpleAuthGenerator struct {
 	HeaderName        string
 	HeaderValuePrefix string
+}
+
+// ExtractRequestData is a no-op for SimpleAuthGenerator — API key auth doesn't need request data.
+func (g *SimpleAuthGenerator) ExtractRequestData(_ *framework.CycleState, _ *framework.InferenceRequest) (map[string]string, error) {
+	return nil, nil
 }
 
 // GenerateAuthHeaders extracts the "api-key" field from credentials and returns

--- a/pkg/plugins/apikey-injection/plugin.go
+++ b/pkg/plugins/apikey-injection/plugin.go
@@ -70,6 +70,8 @@ func NewAPIKeyInjectionPlugin(reconcilerBuilder func() *builder.Builder, clientR
 			Type: APIKeyInjectionPluginType,
 			Name: APIKeyInjectionPluginType,
 		},
+		// TODO(#310): Replace static provider→generator mapping with dynamic selection
+		// based on ExternalProvider.spec.auth.type once reconciler wiring lands.
 		authHeadersGenerators: map[string]authgenerator.AuthHeadersGenerator{
 			provider.OpenAI:      &authgenerator.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
 			provider.Anthropic:   &authgenerator.SimpleAuthGenerator{HeaderName: "x-api-key"},
@@ -78,6 +80,7 @@ func NewAPIKeyInjectionPlugin(reconcilerBuilder func() *builder.Builder, clientR
 			// provider.Vertex:     &auth.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
 			provider.VertexOpenAI:  &authgenerator.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
 			provider.BedrockOpenAI: &authgenerator.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
+			provider.AWSBedrock:    &authgenerator.SigV4AuthGenerator{},
 		},
 		store: store,
 	}), nil
@@ -136,6 +139,21 @@ func (p *ApiKeyInjectionPlugin) ProcessRequest(ctx context.Context, cycleState *
 	if !ok {
 		logger.Error(nil, "unsupported provider for auth generation", "provider", providerName)
 		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("unsupported provider - '%s'", providerName)}
+	}
+
+	extraData, err := generator.ExtractRequestData(cycleState, request)
+	if err != nil {
+		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("failed to extract request data for provider '%s': %v", providerName, err)}
+	}
+	if len(extraData) > 0 {
+		merged := make(map[string]string, len(credentials)+len(extraData))
+		for k, v := range credentials {
+			merged[k] = v
+		}
+		for k, v := range extraData {
+			merged[k] = v
+		}
+		credentials = merged
 	}
 
 	authHeaders, err := generator.GenerateAuthHeaders(credentials)

--- a/pkg/plugins/apikey-injection/plugin_test.go
+++ b/pkg/plugins/apikey-injection/plugin_test.go
@@ -18,6 +18,7 @@ package apikey_injection
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -31,17 +32,43 @@ import (
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/state"
 )
 
+const (
+	// Synthetic provider names for unit tests.
+	testProviderWithPrefix    = "provider-with-prefix"
+	testProviderWithoutPrefix = "provider-without-prefix"
+	testProviderSigV4         = "provider-sigv4"
+)
+
 // newTestPlugin creates an apiKeyInjectionPlugin for unit tests, bypassing the
 // Handle-based Factory (which requires a real manager).
 func newTestPlugin(store *secretStore) *ApiKeyInjectionPlugin {
 	return &ApiKeyInjectionPlugin{
 		typedName: plugin.TypedName{Type: APIKeyInjectionPluginType, Name: APIKeyInjectionPluginType},
 		authHeadersGenerators: map[string]authgenerator.AuthHeadersGenerator{
-			"provider-with-prefix":    &authgenerator.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "prefix "},
-			"provider-without-prefix": &authgenerator.SimpleAuthGenerator{HeaderName: "x-api-key"},
+			testProviderWithPrefix:    &authgenerator.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "prefix "},
+			testProviderWithoutPrefix: &authgenerator.SimpleAuthGenerator{HeaderName: "x-api-key"},
+			testProviderSigV4:         &authgenerator.SigV4AuthGenerator{},
 		},
 		store: store,
 	}
+}
+
+// newBedrockRequest creates an InferenceRequest pre-populated with a model body
+// field and :path, simulating a real client request routed to Bedrock.
+func newBedrockRequest() *framework.InferenceRequest {
+	req := framework.NewInferenceRequest()
+	req.Body["model"] = "anthropic.claude-v2"
+	req.Body["prompt"] = "hello"
+	req.Headers[":path"] = "/default/bedrock-model/v1/chat/completions"
+	return req
+}
+
+// newSigV4CycleState builds a CycleState with credential ref, sigv4 test provider, endpoint, and config.
+func newSigV4CycleState(credsNamespace, credsName string) *framework.CycleState {
+	cs := newCycleState(credsNamespace, credsName, testProviderSigV4)
+	cs.Write(state.EndpointKey, "bedrock-runtime.us-east-1.amazonaws.com")
+	cs.Write(state.ModelConfigKey, map[string]string{"service": "bedrock"})
+	return cs
 }
 
 // newCycleState builds a CycleState with credential ref and optional provider.
@@ -68,7 +95,7 @@ func TestProcessRequest(t *testing.T) {
 			name:              "provider that has simple generator with prefix",
 			secrets:           []*corev1.Secret{testSecret("default", "openai-key", map[string]string{"api-key": "sk-test-key"})},
 			request:           framework.NewInferenceRequest(),
-			prepareCycleState: func() *framework.CycleState { return newCycleState("default", "openai-key", "provider-with-prefix") },
+			prepareCycleState: func() *framework.CycleState { return newCycleState("default", "openai-key", testProviderWithPrefix) },
 			wantHeaders: map[string]string{
 				"Authorization": "prefix sk-test-key",
 			},
@@ -78,7 +105,7 @@ func TestProcessRequest(t *testing.T) {
 			secrets: []*corev1.Secret{testSecret("default", "anthropic-key", map[string]string{"api-key": "ant-key-123"})},
 			request: framework.NewInferenceRequest(),
 			prepareCycleState: func() *framework.CycleState {
-				return newCycleState("default", "anthropic-key", "provider-without-prefix")
+				return newCycleState("default", "anthropic-key", testProviderWithoutPrefix)
 			},
 			wantHeaders: map[string]string{
 				"x-api-key": "ant-key-123",
@@ -104,7 +131,7 @@ func TestProcessRequest(t *testing.T) {
 			request: framework.NewInferenceRequest(),
 			prepareCycleState: func() *framework.CycleState {
 				cs := framework.NewCycleState()
-				cs.Write(state.ProviderKey, "provider-with-prefix") // external model has provider but no creds
+				cs.Write(state.ProviderKey, testProviderWithPrefix) // external model has provider but no creds
 				return cs
 			},
 			errorContains: "missing credentialRef",
@@ -114,7 +141,7 @@ func TestProcessRequest(t *testing.T) {
 			secrets: []*corev1.Secret{},
 			request: framework.NewInferenceRequest(),
 			prepareCycleState: func() *framework.CycleState {
-				return newCycleState("default", "unknown", "provider-with-prefix")
+				return newCycleState("default", "unknown", testProviderWithPrefix)
 			},
 			errorContains: "credentials not found",
 		},
@@ -123,7 +150,7 @@ func TestProcessRequest(t *testing.T) {
 			secrets: []*corev1.Secret{testSecret("default", "wrong-fields", map[string]string{"wrong-field": "value"})},
 			request: framework.NewInferenceRequest(),
 			prepareCycleState: func() *framework.CycleState {
-				return newCycleState("default", "wrong-fields", "provider-with-prefix")
+				return newCycleState("default", "wrong-fields", testProviderWithPrefix)
 			},
 			errorContains: "failed to generate auth headers",
 		},
@@ -145,6 +172,91 @@ func TestProcessRequest(t *testing.T) {
 			require.NoError(t, err)
 			if diff := cmp.Diff(test.wantHeaders, test.request.Headers, cmpopts.SortMaps(func(a, b string) bool { return a < b }), cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("headers mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestProcessRequest_AWSBedrock(t *testing.T) {
+	tests := []struct {
+		name              string
+		secrets           []*corev1.Secret
+		prepareCycleState func() *framework.CycleState
+		wantSecurityToken string // exact value; empty means the header must be absent
+		errorContains     string
+	}{
+		{
+			name: "produces SigV4 auth headers",
+			secrets: []*corev1.Secret{testSecret("default", "bedrock-creds", map[string]string{
+				"aws-access-key-id":     "AKIAIOSFODNN7EXAMPLE",
+				"aws-secret-access-key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			})},
+			prepareCycleState: func() *framework.CycleState { return newSigV4CycleState("default", "bedrock-creds") },
+		},
+		{
+			name: "includes security token when session token is present",
+			secrets: []*corev1.Secret{testSecret("default", "bedrock-creds", map[string]string{
+				"aws-access-key-id":     "AKIAIOSFODNN7EXAMPLE",
+				"aws-secret-access-key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+				"aws-session-token":     "FwoGZXIvYXdzEBYaDH7example-session-token",
+			})},
+			prepareCycleState: func() *framework.CycleState { return newSigV4CycleState("default", "bedrock-creds") },
+			wantSecurityToken: "FwoGZXIvYXdzEBYaDH7example-session-token",
+		},
+		{
+			name: "uses explicit region from provider config map",
+			secrets: []*corev1.Secret{testSecret("default", "bedrock-creds", map[string]string{
+				"aws-access-key-id":     "AKIAIOSFODNN7EXAMPLE",
+				"aws-secret-access-key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			})},
+			prepareCycleState: func() *framework.CycleState {
+				cs := newSigV4CycleState("default", "bedrock-creds")
+				cs.Write(state.ModelConfigKey, map[string]string{"region": "ap-northeast-1", "service": "bedrock"})
+				return cs
+			},
+		},
+		{
+			name: "missing endpoint in cycle state returns error",
+			secrets: []*corev1.Secret{testSecret("default", "bedrock-creds", map[string]string{
+				"aws-access-key-id":     "AKIAIOSFODNN7EXAMPLE",
+				"aws-secret-access-key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			})},
+			prepareCycleState: func() *framework.CycleState { return newCycleState("default", "bedrock-creds", testProviderSigV4) },
+			errorContains:     "failed to extract request data",
+		},
+		{
+			name:              "missing aws credentials returns error",
+			secrets:           []*corev1.Secret{testSecret("default", "bedrock-creds", map[string]string{"wrong-field": "value"})},
+			prepareCycleState: func() *framework.CycleState { return newSigV4CycleState("default", "bedrock-creds") },
+			errorContains:     "failed to generate auth headers",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := newSecretStore()
+			for _, secret := range test.secrets {
+				require.NoError(t, store.addOrUpdate(secret.GetNamespace(), secret.GetName(), secret))
+			}
+
+			plugin := newTestPlugin(store)
+			request := newBedrockRequest()
+			err := plugin.ProcessRequest(context.Background(), test.prepareCycleState(), request)
+
+			if test.errorContains != "" {
+				require.ErrorContains(t, err, test.errorContains)
+				return
+			}
+			require.NoError(t, err)
+
+			// SigV4 Authorization is dynamic (timestamp, signature), so we verify the scheme prefix only.
+			require.True(t, strings.HasPrefix(request.Headers["Authorization"], "AWS4-HMAC-SHA256"),
+				"Authorization header should start with AWS4-HMAC-SHA256, got: %s", request.Headers["Authorization"])
+			require.NotEmpty(t, request.Headers["X-Amz-Date"])
+			require.NotEmpty(t, request.Headers["X-Amz-Content-Sha256"])
+
+			if diff := cmp.Diff(test.wantSecurityToken, request.Headers["X-Amz-Security-Token"]); diff != "" {
+				t.Errorf("X-Amz-Security-Token mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/plugins/common/provider/provider.go
+++ b/pkg/plugins/common/provider/provider.go
@@ -26,4 +26,5 @@ const (
 	AzureOpenAI   = "azure-openai"
 	VertexOpenAI  = "vertex-openai"
 	BedrockOpenAI = "bedrock-openai"
+	AWSBedrock    = "aws-bedrock"
 )

--- a/pkg/plugins/common/state/state-keys.go
+++ b/pkg/plugins/common/state/state-keys.go
@@ -25,4 +25,5 @@ const (
 	ModelConfigKey    = "model-config"
 	APIFormatKey      = "api-format"
 	InputAPIFormatKey = "input-api-format"
+	EndpointKey       = "endpoint"
 )

--- a/pkg/plugins/model-provider-resolver/external_model_reconciler.go
+++ b/pkg/plugins/model-provider-resolver/external_model_reconciler.go
@@ -110,6 +110,7 @@ func (r *externalModelReconciler) resolveRef(namespace string, ref *inferencev1a
 		provider:        providerInfo.provider,
 		targetModel:     ref.TargetModel,
 		apiFormat:       apiformat.APIFormat(ref.APIFormat),
+		endpoint:        providerInfo.endpoint,
 		secretName:      secretName,
 		secretNamespace: secretNamespace,
 		config:          config,

--- a/pkg/plugins/model-provider-resolver/plugin.go
+++ b/pkg/plugins/model-provider-resolver/plugin.go
@@ -179,6 +179,7 @@ func (p *ModelProviderResolverPlugin) ProcessRequest(ctx context.Context, cycleS
 	cycleState.Write(state.ProviderKey, ref.provider)
 	cycleState.Write(state.ModelKey, ref.targetModel)
 	cycleState.Write(state.APIFormatKey, ref.apiFormat)
+	cycleState.Write(state.EndpointKey, ref.endpoint)
 	cycleState.Write(state.CredsRefName, ref.secretName)
 	cycleState.Write(state.CredsRefNamespace, ref.secretNamespace)
 	cycleState.Write(state.ModelConfigKey, ref.config)

--- a/pkg/plugins/model-provider-resolver/plugin_test.go
+++ b/pkg/plugins/model-provider-resolver/plugin_test.go
@@ -36,6 +36,7 @@ func TestProcessRequest_ModelResolved(t *testing.T) {
 		extName     = "claude-sonnet"
 		targetModel = "claude-sonnet-1234"
 		credName    = "anthropic-key"
+		endpoint    = "api.anthropic.com"
 	)
 	store.addOrUpdateModel(
 		types.NamespacedName{Namespace: extNS, Name: extName},
@@ -43,6 +44,7 @@ func TestProcessRequest_ModelResolved(t *testing.T) {
 			provider:        provider.Anthropic,
 			targetModel:     targetModel,
 			apiFormat:       apiformat.Messages,
+			endpoint:        endpoint,
 			secretName:      credName,
 			secretNamespace: extNS,
 			config:          map[string]string{},
@@ -78,6 +80,10 @@ func TestProcessRequest_ModelResolved(t *testing.T) {
 	actualAPIFormat, err := framework.ReadCycleStateKey[apiformat.APIFormat](cs, state.APIFormatKey)
 	require.NoError(t, err)
 	require.Equal(t, apiformat.Messages, actualAPIFormat)
+
+	actualEndpoint, err := framework.ReadCycleStateKey[string](cs, state.EndpointKey)
+	require.NoError(t, err)
+	require.Equal(t, endpoint, actualEndpoint)
 }
 
 func TestProcessRequest_ModelMismatch(t *testing.T) {

--- a/pkg/plugins/model-provider-resolver/store.go
+++ b/pkg/plugins/model-provider-resolver/store.go
@@ -37,6 +37,7 @@ type resolvedProviderRef struct {
 	provider        string
 	targetModel     string
 	apiFormat       apiformat.APIFormat
+	endpoint        string
 	secretName      string
 	secretNamespace string
 	config          map[string]string


### PR DESCRIPTION
## Summary

Adds AWS SigV4 authentication support to the `apikey-injection` plugin, enabling requests to AWS Bedrock endpoints that require Signature Version 4 signing.

Closes #59

## What this does

- **`SigV4AuthGenerator`** — implements `AuthHeadersGenerator`, uses AWS SDK v2 to sign requests and produce `Authorization`, `X-Amz-Date`, `X-Amz-Content-Sha256`, and (optionally) `X-Amz-Security-Token` headers
- **Credentials enricher pattern** — adds a `dataEnrichers` map to `ApiKeyInjectionPlugin` that injects per-request data (body, endpoint, path) into the credentials map before signing. 
the `AuthHeadersGenerator` interface stays unchanged and existing providers are unaffected
- **Endpoint threading** — reads `ExternalModel.spec.endpoint` via the reconciler → `modelInfoStore` → `CycleState`, and extracts the AWS region from the hostname (e.g. `bedrock-runtime.us-east-1.amazonaws.com` → `us-east-1`)

## Design notes

- SigV4 signing requires the request body and target endpoint, which aren't available from the Secret alone. The enricher injects these fields into the credentials map per-request, so the generator interface doesn't change.
- The enricher map is extensible — any future provider that needs request-scoped data for auth can register its own enricher.
- Aligned with Nir's feedback: 
this lives inside `apikey-injection` (not a separate plugin), 
sources endpoint from `ExternalModel.spec.endpoint` (not from `:authority` header), 
and will adapt naturally once `ExternalProvider` reconcilers land.

## Changed files

| File | What |
|------|------|
| `auth/sigv4_auth_generator.go` | SigV4 signing logic + region extraction |
| `plugin.go` | `dataEnrichers` map + `enrichBedrockCredentials` |
| `plugin_test.go` | Table-driven Bedrock tests (happy path, session token, missing endpoint, missing creds) |
| `auth/sigv4_auth_generator_test.go` | Unit tests for signing, region parsing, error cases |
| `common/provider/provider.go` | `AWSBedrock = "aws-bedrock"` constant |
| `common/state/state-keys.go` | `EndpointKey` constant |
| `model-provider-resolver/*` | Thread `endpoint` from CR → store → CycleState |

## How has this been tested

- Unit tests for `SigV4AuthGenerator`: verifies header format, body hash, session token, region extraction, and error paths
- Integration tests in `plugin_test.go`: full `ProcessRequest` flow with secret store, enricher, and SigV4 signing
- `model-provider-resolver` plugin test: validates endpoint is written to CycleState
- All existing tests pass (`go test ./...`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AWS Bedrock support as an external model provider with AWS SigV4 authentication for secure request signing
  * Introduced provider-specific credential enrichment that augments credentials with per-request context (body, endpoint, path, region/service) before signing
  * Resolver now records external model endpoints so requests can target the correct runtime

* **Tests**
  * Added unit tests covering SigV4 header generation, region extraction, and Bedrock request processing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->