### PR TITLE
ci: enable automatic group testing on pull requests

### DIFF
--- a/.tekton/ai-gateway-payload-processing-e2e-ci-on-pull-request.yaml
+++ b/.tekton/ai-gateway-payload-processing-e2e-ci-on-pull-request.yaml
@@ -33,6 +33,8 @@ spec:
     value: .
   - name: pipeline-type
     value: pull-request
+  - name: enable-group-testing
+    value: "true"
   - name: additional-tags
     value:
     - 'odh-pr-{{revision}}'

--- a/.tekton/odh-ai-gateway-payload-processing-ci-on-pull-request.yaml
+++ b/.tekton/odh-ai-gateway-payload-processing-ci-on-pull-request.yaml
@@ -33,6 +33,8 @@ spec:
     value: .
   - name: pipeline-type
     value: pull-request
+  - name: enable-group-testing
+    value: "true"
   - name: additional-tags
     value:
     - 'odh-pr-{{revision}}'


### PR DESCRIPTION
## Summary

Enable automatic group e2e test triggering for `ai-gateway-payload-processing` PR builds by adding the missing `enable-group-testing: "true"` parameter to both PR build PipelineRuns.

## Description

The group testing PipelineRun (`.tekton/ai-gateway-group-test.yaml`) and the integration test pipeline in `odh-konflux-central` were already in place, but the two PR build PipelineRuns were missing the opt-in parameter that activates the `trigger-group-testing` task in the shared `multi-arch-container-build` pipeline.

- Add `enable-group-testing: "true"` to `odh-ai-gateway-payload-processing-ci-on-pull-request.yaml`
- Add `enable-group-testing: "true"` to `ai-gateway-payload-processing-e2e-ci-on-pull-request.yaml`

Without this parameter, the `trigger-group-testing` task is skipped (its `when` condition requires `enable-group-testing == "true"`), meaning no group test is triggered automatically — leaving contributors to post `/group-test` comments manually. This matches the same pattern already used by MaaS and Kserve.

## Dependency

This PR is companion to [opendatahub-io/odh-konflux-central#344](https://github.com/opendatahub-io/odh-konflux-central/pull/344) which carries the equivalent change for the centralized pipelineruns in `odh-konflux-central`.

## How it was tested

- Reviewed the `trigger-group-testing` task `when` conditions in `pipeline/multi-arch-container-build.yaml` in `odh-konflux-central` to confirm `enable-group-testing` is the sole gate.
- Cross-referenced with working configurations for MaaS and Kserve where `enable-group-testing: "true"` is set on all PR builds.

Made with [Cursor](https://cursor.com)