### PR TITLE
ci(workflows): add PR size labeler

### DIFF
--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -1,0 +1,51 @@
+name: PR Size Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  size-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: size-label
+        id: size
+        uses: pascalgn/size-label-action@v0.5.7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IGNORED: |
+            go.sum
+            go.mod
+            *.generated.go
+            vendor/**
+        with:
+          sizes: >
+            {
+              "0": "XS",
+              "10": "S",
+              "30": "M",
+              "100": "L",
+              "500": "XL",
+              "1000": "XXL"
+            }
+
+      - name: Hold large PRs
+        if: contains(steps.size.outputs.sizeLabel, 'XL')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --add-label "do-not-merge/hold"
+          
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --body "⚠️ **Large PR detected**
+
+          Your PR is large. Please consider breaking it into multiple PRs.
+
+          The \`do-not-merge/hold\` label has been added and can be removed by the reviewers based on their judgement."


### PR DESCRIPTION

## Summary

Add automated PR size labeling to encourage smaller, reviewable PRs.

## Changes

- Add GitHub workflow using `pascalgn/size-label-action`
- Label PRs as XS/S/M/L/XL/XXL based on lines changed
- Auto-add `do-not-merge/hold` label for XL+ PRs with a comment
- Ignore generated files: `go.sum`, `go.mod`, `*.generated.go`, `vendor/**`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated pull request size assessment now categorizes submissions by size with labels and automatically blocks excessively large pull requests from merging until they are divided into smaller changesets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->