### PR TITLE
fix(security): enforce namespace boundary for external model resolution

### DIFF
--- a/pkg/plugins/model-provider-resolver/plugin.go
+++ b/pkg/plugins/model-provider-resolver/plugin.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -113,6 +114,22 @@ func (p *ModelProviderResolverPlugin) ProcessRequest(ctx context.Context, cycleS
 	modelKey := types.NamespacedName{Namespace: segments[0], Name: segments[1]}
 	log.FromContext(ctx).V(logutil.VERBOSE).Info("exported namespaced name from path", "key", modelKey)
 
+	// Authorize namespace boundary before any store lookup so callers cannot probe
+	// cross-namespace ExternalModel existence (same 403 regardless of whether the model exists).
+	requestNamespace, ok := extractRequestNamespace(request.Headers)
+	if !ok {
+		return errcommon.Error{
+			Code: errcommon.Forbidden,
+			Msg:  "unable to validate namespace boundary for external model request",
+		}
+	}
+	if requestNamespace != modelKey.Namespace {
+		return errcommon.Error{
+			Code: errcommon.Forbidden,
+			Msg:  fmt.Sprintf("cross-namespace access denied: request namespace '%s' cannot access model namespace '%s'", requestNamespace, modelKey.Namespace),
+		}
+	}
+
 	externalModelInfo, found := p.modelInfoStore.getModelInfo(modelKey)
 	if !found { // info is stored only for external models
 		return nil // this is not considered an error, we just need to skip if it's internal model
@@ -145,4 +162,67 @@ func sanitizePath(relativeUrlPath string) string {
 	}
 
 	return strings.Trim(relativeUrlPath, "/")
+}
+
+var namespaceHintHeaders = []string{
+	"x-ai-gateway-request-namespace",
+	"x-kubernetes-namespace",
+	"x-namespace",
+}
+
+const spiffeNamespacePrefix = "/ns/"
+
+// namespaceFromXFCCSPIFFE returns the workload namespace from the first SPIFFE URI in
+// x-forwarded-client-cert that contains the standard .../ns/<namespace>/... path segment.
+func namespaceFromXFCCSPIFFE(xfccValue string) (string, bool) {
+	for _, part := range strings.Split(xfccValue, ";") {
+		part = strings.TrimSpace(part)
+		if !strings.HasPrefix(part, "URI=") {
+			continue
+		}
+		uriString := strings.Trim(strings.TrimPrefix(part, "URI="), "\"")
+		parsedURI, err := url.Parse(uriString)
+		if err != nil {
+			continue
+		}
+		path := parsedURI.EscapedPath()
+		prefixIndex := strings.Index(path, spiffeNamespacePrefix)
+		if prefixIndex < 0 {
+			continue
+		}
+
+		namespacePath := path[prefixIndex+len(spiffeNamespacePrefix):]
+		namespaceSegments := strings.SplitN(namespacePath, "/", 2)
+		namespace := strings.TrimSpace(namespaceSegments[0])
+		if namespace != "" {
+			return namespace, true
+		}
+	}
+	return "", false
+}
+
+// extractRequestNamespace resolves the authenticated requester namespace.
+// When x-forwarded-client-cert contains a SPIFFE identity with a namespace segment, that
+// value is authoritative; if any hint header disagrees, the request is rejected.
+// If no SPIFFE namespace is found, hint headers are used (e.g. injected by gateway/MaaS).
+func extractRequestNamespace(headers map[string]string) (string, bool) {
+	xfccValue := strings.TrimSpace(headers["x-forwarded-client-cert"])
+	if xfccValue != "" {
+		if ns, ok := namespaceFromXFCCSPIFFE(xfccValue); ok {
+			for _, headerName := range namespaceHintHeaders {
+				if hinted := strings.TrimSpace(headers[headerName]); hinted != "" && hinted != ns {
+					return "", false
+				}
+			}
+			return ns, true
+		}
+	}
+
+	for _, headerName := range namespaceHintHeaders {
+		if namespace := strings.TrimSpace(headers[headerName]); namespace != "" {
+			return namespace, true
+		}
+	}
+
+	return "", false
 }

--- a/pkg/plugins/model-provider-resolver/plugin_test.go
+++ b/pkg/plugins/model-provider-resolver/plugin_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
+	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
 
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/provider"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/state"
@@ -50,6 +51,7 @@ func TestProcessRequest_ModelResolved(t *testing.T) {
 	cs := framework.NewCycleState()
 	req := framework.NewInferenceRequest()
 	req.Headers[":path"] = "/" + extNS + "/" + extName + "/v1/chat/completions"
+	req.Headers["x-ai-gateway-request-namespace"] = extNS
 	// Body "model" must match targetModel on the ExternalModel (ProcessRequest validates this).
 	req.Body["model"] = targetModel
 
@@ -79,6 +81,7 @@ func TestProcessRequest_ModelNotFound(t *testing.T) {
 	cs := framework.NewCycleState()
 	req := framework.NewInferenceRequest()
 	req.Headers[":path"] = "/model-ns/model-name/v1/chat/completions"
+	req.Headers["x-ai-gateway-request-namespace"] = "model-ns"
 	req.Body["model"] = "unknown-model"
 
 	err := p.ProcessRequest(context.Background(), cs, req)
@@ -113,6 +116,7 @@ func TestProcessRequest_BadPath(t *testing.T) {
 	cs := framework.NewCycleState()
 	req := framework.NewInferenceRequest()
 	req.Headers[":path"] = "/incomplete"
+	req.Headers["x-ai-gateway-request-namespace"] = "llm"
 	req.Body["model"] = "gpt-4o"
 
 	err := p.ProcessRequest(context.Background(), cs, req)
@@ -120,4 +124,128 @@ func TestProcessRequest_BadPath(t *testing.T) {
 
 	_, err = framework.ReadCycleStateKey[string](cs, state.ProviderKey)
 	require.Error(t, err)
+}
+
+func TestProcessRequest_RejectsCrossNamespaceAccess(t *testing.T) {
+	store := newModelInfoStore()
+	store.addOrUpdateExternalModel(
+		types.NamespacedName{Namespace: "team-a", Name: "gpt4"},
+		&externalModelInfo{
+			provider:        provider.OpenAI,
+			targetModel:     "gpt-4o",
+			secretName:      "openai-key",
+			secretNamespace: "team-a",
+		},
+	)
+
+	p := &ModelProviderResolverPlugin{modelInfoStore: store}
+	cs := framework.NewCycleState()
+	req := framework.NewInferenceRequest()
+	req.Headers[":path"] = "/team-a/gpt4/v1/chat/completions"
+	req.Headers["x-ai-gateway-request-namespace"] = "team-b"
+	req.Body["model"] = "gpt-4o"
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.Error(t, err)
+
+	commErr, ok := err.(errcommon.Error)
+	require.True(t, ok)
+	require.Equal(t, errcommon.Forbidden, commErr.Code)
+	require.Contains(t, commErr.Msg, "cross-namespace access denied")
+}
+
+func TestProcessRequest_RejectsWhenRequestNamespaceMissing(t *testing.T) {
+	store := newModelInfoStore()
+	store.addOrUpdateExternalModel(
+		types.NamespacedName{Namespace: "team-a", Name: "gpt4"},
+		&externalModelInfo{
+			provider:        provider.OpenAI,
+			targetModel:     "gpt-4o",
+			secretName:      "openai-key",
+			secretNamespace: "team-a",
+		},
+	)
+
+	p := &ModelProviderResolverPlugin{modelInfoStore: store}
+	cs := framework.NewCycleState()
+	req := framework.NewInferenceRequest()
+	req.Headers[":path"] = "/team-a/gpt4/v1/chat/completions"
+	req.Body["model"] = "gpt-4o"
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.Error(t, err)
+
+	commErr, ok := err.(errcommon.Error)
+	require.True(t, ok)
+	require.Equal(t, errcommon.Forbidden, commErr.Code)
+	require.Contains(t, commErr.Msg, "unable to validate namespace boundary")
+}
+
+func TestExtractRequestNamespace(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    string
+		ok      bool
+	}{
+		{
+			name: "direct namespace header",
+			headers: map[string]string{
+				"x-ai-gateway-request-namespace": "team-a",
+			},
+			want: "team-a",
+			ok:   true,
+		},
+		{
+			name: "spiffe namespace from xfcc",
+			headers: map[string]string{
+				"x-forwarded-client-cert": `By=spiffe://cluster.local/ns/istio-system/sa/ztunnel;Hash=abc;URI=spiffe://cluster.local/ns/team-b/sa/default`,
+			},
+			want: "team-b",
+			ok:   true,
+		},
+		{
+			name: "hint header ignored when same as spiffe namespace",
+			headers: map[string]string{
+				"x-forwarded-client-cert":        `URI=spiffe://cluster.local/ns/team-b/sa/default`,
+				"x-ai-gateway-request-namespace": "team-b",
+			},
+			want: "team-b",
+			ok:   true,
+		},
+		{
+			name: "reject when hint header disagrees with spiffe namespace",
+			headers: map[string]string{
+				"x-forwarded-client-cert":        `URI=spiffe://cluster.local/ns/team-b/sa/default`,
+				"x-ai-gateway-request-namespace": "team-a",
+			},
+			want: "",
+			ok:   false,
+		},
+		{
+			name: "fallback to hint headers when xfcc has no workload spiffe ns",
+			headers: map[string]string{
+				"x-forwarded-client-cert":        "By=spiffe://cluster.local/ns/istio-system/sa/ztunnel;Hash=abc",
+				"x-ai-gateway-request-namespace": "team-a",
+			},
+			want: "team-a",
+			ok:   true,
+		},
+		{
+			name: "no namespace data",
+			headers: map[string]string{
+				"x-forwarded-client-cert": "By=spiffe://cluster.local/ns/istio-system/sa/ztunnel",
+			},
+			want: "",
+			ok:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := extractRequestNamespace(tt.headers)
+			require.Equal(t, tt.ok, ok)
+			require.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -147,6 +147,7 @@ func getCurlCommand(modelName string) []string {
 		"curl", "-si", "--max-time", strconv.Itoa(int(curlTimeout.Seconds())),
 		gatewayURL,
 		"-H", "Content-Type: application/json",
+		"-H", "x-ai-gateway-request-namespace: " + nsName,
 		"-H", "Connection: close",
 		"-d", string(bodyBytes),
 	}


### PR DESCRIPTION
## Summary

Adds **namespace boundary enforcement** in `model-provider-resolver` before resolving
`ExternalModel` and wiring credential references downstream. This closes a
tenant-isolation gap where a client could target another namespace’s model path
to trigger use of secrets in that namespace.

Fixes #242

## Root cause

Request path parsing derives `namespace/name` from `:path` (`/<ns>/<model>/v1/...`)
without verifying the **requester’s authorized namespace** matches the target
model namespace.

## Fix

- Resolve requester namespace from (in order):
  - `x-ai-gateway-request-namespace`
  - `x-kubernetes-namespace`
  - `x-namespace`
  - `x-forwarded-client-cert` SPIFFE URI (`.../ns/<namespace>/...`)
- If requester namespace cannot be determined → **`403 Forbidden`**
- If requester namespace differs from model namespace parsed from path → **`403 Forbidden`**
- Same-namespace requests continue through the existing plugin chain.

## Tests

- Updated/added unit coverage in:
  - `pkg/plugins/model-provider-resolver/plugin_test.go`
- Updated e2e request builder to send:
  - `x-ai-gateway-request-namespace: <test namespace>`
  in `test/e2e/e2e_test.go` so existing e2e curls match the new policy.

## Manual verification (local)

Validated on kind/istio deploy that:
- cross-namespace request is blocked with `403`
- missing requester namespace context is blocked with `403`

## Notes / follow-ups

- This assumes the mesh/gateway injects a trusted requester namespace signal
  (header or XFCC). If deployments need a different canonical header, we can
  extend the extractor list in one place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added namespace-boundary validation for external model requests. The system now verifies that request namespaces match the external model's namespace configuration. Requests with namespace mismatches are rejected to prevent unauthorized access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->