### PR TITLE
ci: pin size-label-action to SHA

### DIFF
--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: size-label
         id: size
-        uses: pascalgn/size-label-action@v0.5.7
+        uses: pascalgn/size-label-action@56b489b027932ec0cf60438a1a5f1a19c8fc71ff
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IGNORED: |


### PR DESCRIPTION

## Summary

Pin third-party GitHub Action to commit SHA for supply chain security.

## Changes

- Replace `pascalgn/size-label-action@v0.5.7` with full SHA `56b489b027932ec0cf60438a1a5f1a19c8fc71ff`

Fixes #241 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal infrastructure updates only. No user-facing features, bug fixes, or changes are included.

* **Chores**
  * Updated CI/CD workflow configuration for internal build pipeline management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->