### PR TITLE
fix: validate required CRD fields in ExternalModel reconciler

### DIFF
--- a/pkg/plugins/model-provider-resolver/external_model_reconciler.go
+++ b/pkg/plugins/model-provider-resolver/external_model_reconciler.go
@@ -62,9 +62,23 @@ func (r *externalModelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 
-	provider, _, _ := unstructured.NestedString(obj.Object, "spec", "provider")
-	targetModel, _, _ := unstructured.NestedString(obj.Object, "spec", "targetModel")
-	credsName, _, _ := unstructured.NestedString(obj.Object, "spec", "credentialRef", "name")
+	provider, found, err := unstructured.NestedString(obj.Object, "spec", "provider")
+	if err != nil || !found || provider == "" {
+		r.store.deleteExternalModel(req.NamespacedName)
+		return ctrl.Result{}, fmt.Errorf("ExternalModel %s is missing required field spec.provider", req.NamespacedName)
+	}
+
+	targetModel, found, err := unstructured.NestedString(obj.Object, "spec", "targetModel")
+	if err != nil || !found || targetModel == "" {
+		r.store.deleteExternalModel(req.NamespacedName)
+		return ctrl.Result{}, fmt.Errorf("ExternalModel %s is missing required field spec.targetModel", req.NamespacedName)
+	}
+
+	credsName, found, err := unstructured.NestedString(obj.Object, "spec", "credentialRef", "name")
+	if err != nil || !found || credsName == "" {
+		r.store.deleteExternalModel(req.NamespacedName)
+		return ctrl.Result{}, fmt.Errorf("ExternalModel %s is missing required field spec.credentialRef.name", req.NamespacedName)
+	}
 
 	// targetModel is the model that will be used in the request body when getting inference requests.
 	info := &externalModelInfo{


### PR DESCRIPTION
## Summary

- Validate that required fields (`spec.provider`, `spec.targetModel`, `spec.credentialRef.name`) extracted from ExternalModel CRD are non-empty before storing them in the model info store
- Previously, `unstructured.NestedString` return values (`found`, `error`) were silently discarded with `_, _`, allowing empty/invalid data to be stored
- On validation failure, stale store entries are removed before returning the error to prevent serving incomplete data
- Returning the error causes controller-runtime to requeue with backoff, surfacing the misconfiguration in controller logs

## Test
- `go build ./...` passes

## Related
#close https://github.com/opendatahub-io/ai-gateway-payload-processing/issues/248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of external model configurations. Required fields are now verified before processing. Invalid or incomplete configurations are automatically removed with clear error messages identifying which fields are missing or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->