### PR TITLE
Partition secret and model stores by namespace

### DIFF
--- a/pkg/plugins/apikey-injection/plugin.go
+++ b/pkg/plugins/apikey-injection/plugin.go
@@ -71,9 +71,9 @@ func NewAPIKeyInjectionPlugin(reconcilerBuilder func() *builder.Builder, clientR
 			Name: APIKeyInjectionPluginType,
 		},
 		authHeadersGenerators: map[string]auth.AuthHeadersGenerator{
-			provider.OpenAI:        &auth.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
-			provider.Anthropic:     &auth.SimpleAuthGenerator{HeaderName: "x-api-key"},
-			provider.AzureOpenAI:   &auth.SimpleAuthGenerator{HeaderName: "api-key"},
+			provider.OpenAI:      &auth.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
+			provider.Anthropic:   &auth.SimpleAuthGenerator{HeaderName: "x-api-key"},
+			provider.AzureOpenAI: &auth.SimpleAuthGenerator{HeaderName: "api-key"},
 			// provider.Vertex uses the native GenerateContent API — not used in 3.4 ExternalModel flow.
 			// provider.Vertex:     &auth.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
 			provider.VertexOpenAI:  &auth.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
@@ -126,8 +126,7 @@ func (p *ApiKeyInjectionPlugin) ProcessRequest(ctx context.Context, cycleState *
 		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("provider '%s' is missing credentialRef namespace", providerName)}
 	}
 
-	secretKey := fmt.Sprintf("%s/%s", credsNamespace, credsName)
-	credentials, found := p.store.get(secretKey)
+	credentials, found := p.store.get(credsNamespace, credsName)
 	if !found {
 		logger.Error(nil, "credentials not found in store", "provider", providerName)
 		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("provider '%s' credentials not found", providerName)}

--- a/pkg/plugins/apikey-injection/plugin_test.go
+++ b/pkg/plugins/apikey-injection/plugin_test.go
@@ -18,7 +18,6 @@ package apikey_injection
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -134,8 +133,7 @@ func TestProcessRequest(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			store := newSecretStore()
 			for _, secret := range test.secrets {
-				secretKey := fmt.Sprintf("%s/%s", secret.GetNamespace(), secret.GetName())
-				require.NoError(t, store.addOrUpdate(secretKey, secret))
+				require.NoError(t, store.addOrUpdate(secret.GetNamespace(), secret.GetName(), secret))
 			}
 
 			plugin := newTestPlugin(store)

--- a/pkg/plugins/apikey-injection/reconciler.go
+++ b/pkg/plugins/apikey-injection/reconciler.go
@@ -72,12 +72,12 @@ func (r *secretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	if errors.IsNotFound(err) || !secret.DeletionTimestamp.IsZero() || !hasManagedLabel(secret) {
-		r.store.delete(key)
+		r.store.delete(req.Namespace, req.Name)
 		logger.Info("Secret removed from store", "key", key)
 		return ctrl.Result{}, nil
 	}
 
-	if err := r.store.addOrUpdate(key, secret); err != nil {
+	if err := r.store.addOrUpdate(req.Namespace, req.Name, secret); err != nil {
 		return ctrl.Result{}, fmt.Errorf("unable to add or update Secret %s: %w", key, err)
 	}
 

--- a/pkg/plugins/apikey-injection/reconciler_test.go
+++ b/pkg/plugins/apikey-injection/reconciler_test.go
@@ -18,7 +18,6 @@ package apikey_injection
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -125,7 +124,7 @@ func TestReconcile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			store := newSecretStore()
 			for _, sec := range tt.initSecrets {
-				_ = store.addOrUpdate(fmt.Sprintf("%s/%s", sec.Namespace, sec.Name), sec)
+				_ = store.addOrUpdate(sec.Namespace, sec.Name, sec)
 			}
 
 			builder := fake.NewClientBuilder()
@@ -155,7 +154,8 @@ func TestReconcile(t *testing.T) {
 			require.NoError(t, err)
 
 			if tt.wantKey != "" {
-				creds, found := store.get(tt.wantKey)
+				parts := strings.Split(tt.wantKey, "/")
+				creds, found := store.get(parts[0], parts[1])
 				assert.Equal(t, tt.wantFound, found)
 				if tt.wantFound {
 					if diff := cmp.Diff(tt.wantCreds, creds); diff != "" {

--- a/pkg/plugins/apikey-injection/store.go
+++ b/pkg/plugins/apikey-injection/store.go
@@ -27,30 +27,32 @@ import (
 // namespaced name ("namespace/name") to its credential data.
 // The secretReconciler writes to it; the apiKeyInjectionPlugin reads from it.
 type secretStore struct {
-	mu   sync.RWMutex
-	data map[string]map[string]string
+	mu sync.RWMutex
+	// namespace -> secret name -> credentials
+	data map[string]map[string]map[string]string
 }
 
 // newSecretStore creates an empty secretStore.
 func newSecretStore() *secretStore {
 	return &secretStore{
-		data: make(map[string]map[string]string),
+		data: make(map[string]map[string]map[string]string),
 	}
 }
 
 // addOrUpdate extracts all fields from the Secret's data and stores them under
 // the given key. Returns an error if the Secret has no data fields or if any
 // field is empty.
-func (s *secretStore) addOrUpdate(key string, secret *corev1.Secret) error {
+func (s *secretStore) addOrUpdate(namespace, name string, secret *corev1.Secret) error {
+	key := fmt.Sprintf("%s/%s", namespace, name)
 	if len(secret.Data) == 0 {
-		s.delete(key)
+		s.delete(namespace, name)
 		return fmt.Errorf("secret '%s' has no data fields", key)
 	}
 
 	credentials := make(map[string]string)
 	for field, value := range secret.Data {
 		if len(value) == 0 {
-			s.delete(key)
+			s.delete(namespace, name)
 			return fmt.Errorf("secret '%s' has empty field '%s'", key, field)
 		}
 		credentials[field] = string(value)
@@ -58,21 +60,37 @@ func (s *secretStore) addOrUpdate(key string, secret *corev1.Secret) error {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.data[key] = credentials
+	if _, exists := s.data[namespace]; !exists {
+		s.data[namespace] = make(map[string]map[string]string)
+	}
+	s.data[namespace][name] = credentials
 	return nil
 }
 
 // delete removes the entry for the given Secret namespaced name.
-func (s *secretStore) delete(secretKey string) {
+func (s *secretStore) delete(namespace, name string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	delete(s.data, secretKey)
+	secretsByName, found := s.data[namespace]
+	if !found {
+		return
+	}
+	delete(secretsByName, name)
+	if len(secretsByName) == 0 {
+		delete(s.data, namespace)
+	}
 }
 
 // get returns the credentials for the given namespaced name and whether it was found.
-func (s *secretStore) get(secretKey string) (map[string]string, bool) {
+func (s *secretStore) get(namespace, name string) (map[string]string, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	credentials, ok := s.data[secretKey]
+
+	secretsByName, found := s.data[namespace]
+	if !found {
+		return nil, false
+	}
+
+	credentials, ok := secretsByName[name]
 	return credentials, ok
 }

--- a/pkg/plugins/apikey-injection/store_test.go
+++ b/pkg/plugins/apikey-injection/store_test.go
@@ -18,6 +18,7 @@ package apikey_injection
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 
@@ -60,7 +61,7 @@ func TestSecretStore(t *testing.T) {
 		{
 			name: "AddOrUpdate and Get returns stored credentials",
 			initStoreFunc: func(s *secretStore) {
-				_ = s.addOrUpdate("default/openai-key", testSecret("default", "openai-key", map[string]string{"api-key": "sk-key-1"}))
+				_ = s.addOrUpdate("default", "openai-key", testSecret("default", "openai-key", map[string]string{"api-key": "sk-key-1"}))
 			},
 			secretKey: "default/openai-key",
 			wantFound: true,
@@ -75,8 +76,8 @@ func TestSecretStore(t *testing.T) {
 		{
 			name: "AddOrUpdate overwrites existing entry",
 			initStoreFunc: func(s *secretStore) {
-				_ = s.addOrUpdate("default/key", testSecret("default", "key", map[string]string{"api-key": "old-key"}))
-				_ = s.addOrUpdate("default/key", testSecret("default", "key", map[string]string{"api-key": "new-key"}))
+				_ = s.addOrUpdate("default", "key", testSecret("default", "key", map[string]string{"api-key": "old-key"}))
+				_ = s.addOrUpdate("default", "key", testSecret("default", "key", map[string]string{"api-key": "new-key"}))
 			},
 			secretKey: "default/key",
 			wantFound: true,
@@ -85,8 +86,8 @@ func TestSecretStore(t *testing.T) {
 		{
 			name: "delete removes entry",
 			initStoreFunc: func(s *secretStore) {
-				_ = s.addOrUpdate("default/key", testSecret("default", "key", map[string]string{"api-key": "sk-key-1"}))
-				s.delete("default/key")
+				_ = s.addOrUpdate("default", "key", testSecret("default", "key", map[string]string{"api-key": "sk-key-1"}))
+				s.delete("default", "key")
 			},
 			secretKey: "default/key",
 			wantFound: false,
@@ -94,7 +95,7 @@ func TestSecretStore(t *testing.T) {
 		{
 			name: "delete nonexistent key is a no-op",
 			initStoreFunc: func(s *secretStore) {
-				s.delete("default/nonexistent")
+				s.delete("default", "nonexistent")
 			},
 			secretKey: "default/nonexistent",
 			wantFound: false,
@@ -102,7 +103,7 @@ func TestSecretStore(t *testing.T) {
 		{
 			name: "stores multiple fields from secret",
 			initStoreFunc: func(s *secretStore) {
-				_ = s.addOrUpdate("default/bedrock-creds", testSecret("default", "bedrock-creds", map[string]string{
+				_ = s.addOrUpdate("default", "bedrock-creds", testSecret("default", "bedrock-creds", map[string]string{
 					"aws-access-key-id":     "AKIAIOSFODNN7EXAMPLE",
 					"aws-secret-access-key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
 				}))
@@ -114,6 +115,14 @@ func TestSecretStore(t *testing.T) {
 				"aws-secret-access-key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
 			},
 		},
+		{
+			name: "cross-namespace lookup with same name returns not found",
+			initStoreFunc: func(s *secretStore) {
+				_ = s.addOrUpdate("namespace-a", "shared-name", testSecret("namespace-a", "shared-name", map[string]string{"api-key": "ns-a-key"}))
+			},
+			secretKey: "namespace-b/shared-name",
+			wantFound: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -121,7 +130,8 @@ func TestSecretStore(t *testing.T) {
 			s := newSecretStore()
 			tt.initStoreFunc(s)
 
-			creds, found := s.get(tt.secretKey)
+			parts := strings.SplitN(tt.secretKey, "/", 2)
+			creds, found := s.get(parts[0], parts[1])
 			require.Equal(t, tt.wantFound, found)
 			if tt.wantFound {
 				if diff := cmp.Diff(tt.wantCreds, creds, cmpopts.SortMaps(func(a, b string) bool { return a < b })); diff != "" {
@@ -172,10 +182,11 @@ func TestAddOrUpdateErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := newSecretStore()
 
-			err := s.addOrUpdate(tt.key, tt.secret)
+			parts := strings.SplitN(tt.key, "/", 2)
+			err := s.addOrUpdate(parts[0], parts[1], tt.secret)
 
 			require.Error(t, err)
-			_, found := s.get(tt.key)
+			_, found := s.get(parts[0], parts[1])
 			assert.False(t, found, "store should not contain entry when addOrUpdate fails")
 		})
 	}
@@ -190,11 +201,11 @@ func TestSecretStoreConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
-			key := fmt.Sprintf("default/secret-%d", n)
-			sec := testSecret("default", fmt.Sprintf("secret-%d", n), map[string]string{"api-key": "key"})
-			_ = s.addOrUpdate(key, sec)
-			s.get(key)
-			s.delete(key)
+			secretName := fmt.Sprintf("secret-%d", n)
+			sec := testSecret("default", secretName, map[string]string{"api-key": "key"})
+			_ = s.addOrUpdate("default", secretName, sec)
+			s.get("default", secretName)
+			s.delete("default", secretName)
 		}(i)
 	}
 	wg.Wait()

--- a/pkg/plugins/model-provider-resolver/model_store.go
+++ b/pkg/plugins/model-provider-resolver/model_store.go
@@ -33,15 +33,15 @@ type externalModelInfo struct {
 // modelInfoStore is a thread-safe in-memory store that maps model names to their provider info.
 // The reconciler writes to it; the plugin reads from it during request processing.
 type modelInfoStore struct {
-	//externalModelToModelInfo maps externalModel CR namespaced name to externalModelInfo
-	externalModelToModelInfo map[string]*externalModelInfo
+	// externalModelToModelInfo maps namespace -> external model name -> externalModelInfo.
+	externalModelToModelInfo map[string]map[string]*externalModelInfo
 
 	lock sync.RWMutex
 }
 
 func newModelInfoStore() *modelInfoStore {
 	return &modelInfoStore{
-		externalModelToModelInfo: make(map[string]*externalModelInfo),
+		externalModelToModelInfo: make(map[string]map[string]*externalModelInfo),
 	}
 }
 
@@ -49,14 +49,24 @@ func newModelInfoStore() *modelInfoStore {
 func (s *modelInfoStore) addOrUpdateExternalModel(externalModelKey types.NamespacedName, modelInfo *externalModelInfo) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	s.externalModelToModelInfo[externalModelKey.String()] = modelInfo
+	if _, found := s.externalModelToModelInfo[externalModelKey.Namespace]; !found {
+		s.externalModelToModelInfo[externalModelKey.Namespace] = make(map[string]*externalModelInfo)
+	}
+	s.externalModelToModelInfo[externalModelKey.Namespace][externalModelKey.Name] = modelInfo
 }
 
 // deleteExternalModel deletes ExternalModel information.
 func (s *modelInfoStore) deleteExternalModel(externalModelKey types.NamespacedName) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	delete(s.externalModelToModelInfo, externalModelKey.String())
+	modelsByNamespace, found := s.externalModelToModelInfo[externalModelKey.Namespace]
+	if !found {
+		return
+	}
+	delete(modelsByNamespace, externalModelKey.Name)
+	if len(modelsByNamespace) == 0 {
+		delete(s.externalModelToModelInfo, externalModelKey.Namespace)
+	}
 }
 
 // getModelInfo returns the modelInfo stored in ExternalModel and bool if found or not.
@@ -65,7 +75,12 @@ func (s *modelInfoStore) getModelInfo(externalModelKey types.NamespacedName) (*e
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
-	externalModelInfo, ok := s.externalModelToModelInfo[externalModelKey.String()]
+	modelsByNamespace, found := s.externalModelToModelInfo[externalModelKey.Namespace]
+	if !found {
+		return nil, false // ExternalModel namespace not found
+	}
+
+	externalModelInfo, ok := modelsByNamespace[externalModelKey.Name]
 	if !ok {
 		return nil, false // ExternalModel not found
 	}

--- a/pkg/plugins/model-provider-resolver/model_store_test.go
+++ b/pkg/plugins/model-provider-resolver/model_store_test.go
@@ -60,3 +60,14 @@ func TestModelStore_DeleteExternalModel(t *testing.T) {
 	_, foundAfter := store.getModelInfo(key)
 	assert.False(t, foundAfter)
 }
+
+func TestModelStore_CrossNamespaceIsolation(t *testing.T) {
+	store := newModelInfoStore()
+	store.addOrUpdateExternalModel(
+		types.NamespacedName{Namespace: "ns-a", Name: "shared-model"},
+		&externalModelInfo{provider: provider.OpenAI},
+	)
+
+	_, found := store.getModelInfo(types.NamespacedName{Namespace: "ns-b", Name: "shared-model"})
+	assert.False(t, found)
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This change addresses multi-tenant isolation concerns for in-memory caches used by the **apikey-injection** and **model-provider-resolver** plugins ([issue #250](https://github.com/opendatahub-io/ai-gateway-payload-processing/issues/250)).

**`secretStore` (`pkg/plugins/apikey-injection`)**  
Previously, credentials were held in a single flat `map[string]…` keyed by a composite `"namespace/name"` string. The store now uses a **two-level map**: `namespace → secret name → credential fields`. Public behavior is unchanged for reconciler and request flow, but reads/writes/deletes use **explicit `(namespace, name)`** so the data layout matches Kubernetes namespacing and avoids a single global string keyspace. Empty namespace buckets are removed when the last secret in that namespace is deleted.

**`modelInfoStore` (`pkg/plugins/model-provider-resolver`)**  
External model metadata was stored in a flat `map[string]*externalModelInfo` keyed by `NamespacedName.String()`. The store now partitions internally as **`namespace → external model name → info`**, while keeping the same method signatures that take `types.NamespacedName`. Deletes clear the inner entry and drop the namespace map when it becomes empty.

**Tests**  
Unit tests were updated for the new `secretStore` API. Cross-namespace isolation cases were added for both stores so a row in namespace A is not visible when querying with namespace B and the same resource name.

**Note:** This hardens cache structure and API clarity; **authorization** (who may choose which namespace on the request path) remains governed by deployment, routing, and Kubernetes RBAC outside these stores.

## How Has This Been Tested?

- **Local / CI-style unit tests:**  
  `go test ./pkg/plugins/apikey-injection ./pkg/plugins/model-provider-resolver`  
  (all tests in those packages passed.)

- **Build:**  
  `go build ./...`  
  (succeeded.)

- **Full `go test ./...`:**  
  Fails in `test/e2e` when no Kubernetes API server is available at `127.0.0.1:6443` (expected in environments without a cluster); plugin unit tests were run explicitly as above.

- **Environment:** Windows, Go toolchain as used by the repo (no e2e cluster in this run).

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked internal stores to use explicit namespace + name addressing, improving namespace isolation and lifecycle handling.

* **Tests**
  * Updated and added tests to validate namespace-level isolation, concurrent access, and correct add/update/delete behavior for credentials and model info.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->