### PR TITLE
chore: update simulator endpoint to new AWS instance

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  E2E_SIMULATOR_ENDPOINT: "3.13.21.181"
+  E2E_SIMULATOR_ENDPOINT: "3.147.232.199"
 
 jobs:
   check-changes:

--- a/api/inference/v1alpha1/types_test.go
+++ b/api/inference/v1alpha1/types_test.go
@@ -102,7 +102,7 @@ func TestNameReferencePattern(t *testing.T) {
 func TestEndpointPattern(t *testing.T) {
 	pattern := regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?)+$`)
 
-	valid := []string{"api.openai.com", "bedrock.us-east-1.amazonaws.com", "3-13-21-181.sslip.io", "a.b"}
+	valid := []string{"api.openai.com", "bedrock.us-east-1.amazonaws.com", "3-147-232-199.sslip.io", "a.b"}
 	for _, ep := range valid {
 		assert.True(t, pattern.MatchString(ep), "should accept %q", ep)
 	}

--- a/pkg/plugins/api-translation/translator/azure/azure_openai_test.go
+++ b/pkg/plugins/api-translation/translator/azure/azure_openai_test.go
@@ -369,7 +369,7 @@ func TestTranslateResponse_StreamingChunkStripsAzureFields(t *testing.T) {
 
 // TestTranslateResponse_LiveMockIntegration fetches a real Azure OpenAI response from
 // the llm-katan mock server and verifies that TranslateResponse strips Azure-specific fields.
-// Set LLM_KATAN_URL to enable (e.g. LLM_KATAN_URL=http://3.13.21.181:8000).
+// Set LLM_KATAN_URL to enable (e.g. LLM_KATAN_URL=http://3.147.232.199:8000).
 func TestTranslateResponse_LiveMockIntegration(t *testing.T) {
 	baseURL := os.Getenv("LLM_KATAN_URL")
 	if baseURL == "" {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	defaultNs                = "bbr-e2e"
-	defaultSimulatorEndpoint = "3.13.21.181"
+	defaultSimulatorEndpoint = "3.147.232.199"
 	defaultGatewayName       = "e2e-gateway"
 	defaultGatewayNamespace  = "default"
 )

--- a/test/e2e/scripts/e2e-ci.sh
+++ b/test/e2e/scripts/e2e-ci.sh
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-E2E_SIMULATOR_ENDPOINT="${E2E_SIMULATOR_ENDPOINT:-3-13-21-181.sslip.io}"
+E2E_SIMULATOR_ENDPOINT="${E2E_SIMULATOR_ENDPOINT:-3-147-232-199.sslip.io}"
 PAYLOAD_PROCESSING_IMAGE="${PAYLOAD_PROCESSING_IMAGE:-quay.io/opendatahub/ai-gateway-payload-processing:odh-stable}"
 PAYLOAD_PROCESSING_E2E_IMAGE="${PAYLOAD_PROCESSING_E2E_IMAGE:-quay.io/opendatahub/ai-gateway-payload-processing-e2e:odh-stable}"
 

--- a/test/e2e/scripts/entrypoint.sh
+++ b/test/e2e/scripts/entrypoint.sh
@@ -9,7 +9,7 @@
 #   E2E_NS                   - Test namespace (default: bbr-e2e)
 #   E2E_GATEWAY_NAMESPACE    - Gateway namespace (default: default)
 #   E2E_GATEWAY_NAME         - Gateway name (default: e2e-gateway)
-#   E2E_SIMULATOR_ENDPOINT   - Simulator IP/host (default: 3.13.21.181)
+#   E2E_SIMULATOR_ENDPOINT   - Simulator IP/host (default: 3.147.232.199)
 #   E2E_GATEWAY_SVC_NAME     - Gateway k8s service name (default: <gateway-name>-istio)
 #   E2E_SIMULATOR_VALIDATE_KEYS - Enable key validation tests (true/false)
 

--- a/test/e2e/scripts/setup-kind.sh
+++ b/test/e2e/scripts/setup-kind.sh
@@ -9,7 +9,7 @@
 # Environment variables:
 #   KIND_CLUSTER_NAME    - Kind cluster name (default: bbr-e2e)
 #   ISTIO_VERSION        - Istio version (default: 1.27.0-alpha.0)
-#   E2E_SIMULATOR_ENDPOINT - Simulator IP (default: 3.13.21.181)
+#   E2E_SIMULATOR_ENDPOINT - Simulator IP (default: 3.147.232.199)
 
 set -euo pipefail
 
@@ -18,7 +18,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-bbr-e2e}"
 ISTIO_VERSION="${ISTIO_VERSION:-1.29.2}"
-SIMULATOR_ENDPOINT="${E2E_SIMULATOR_ENDPOINT:-3.13.21.181}"
+SIMULATOR_ENDPOINT="${E2E_SIMULATOR_ENDPOINT:-3.147.232.199}"
 GATEWAY_NAMESPACE="default"
 GATEWAY_NAME="e2e-gateway"
 


### PR DESCRIPTION
## Summary
- Migrate llm-katan simulator endpoint from `3.13.21.181` to `3.147.232.199` (new AWS account)
- Same llm-katan version (0.15.3), same configuration, lifetime stats preserved

## Files changed
- CI workflow env var
- E2E test suite default constant
- E2E scripts (setup-kind, entrypoint) default values
- Test data (types_test.go sslip.io example, azure integration test comment)

## Test plan
- [x] New endpoint verified: health, all 5 providers, tool calling, streaming, auth, stats, dashboard
- [x] TLS cert valid (Let's Encrypt via sslip.io)