### PR TITLE
feat(nemo): migrate guard plugins from /v1/guardrail/checks endpoint to /v1/chat/completions endpoint

### DIFF
--- a/pkg/plugins/nemo/nemo_guard_base.go
+++ b/pkg/plugins/nemo/nemo_guard_base.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -33,34 +32,61 @@ import (
 )
 
 const (
-	nemoAllowedStatus    = "success"
 	defaultTimeoutSec    = 360
 	maxNemoResponseBytes = 1 << 20 // 1 MiB
+
+	defaultActionVar = "message_action"
+	defaultReasonVar = "block_reason"
+
+	ActionPass   = "pass"
+	ActionBlock  = "block"
+	ActionModify = "modify"
 )
 
 // nemoGuardConfig is the configuration for nemo guard plugins.
 type nemoGuardConfig struct {
 	NemoURL        string `json:"nemoURL"`
 	TimeoutSeconds int    `json:"timeoutSeconds"`
+	ActionVar      string `json:"actionVar"`
+	ReasonVar      string `json:"reasonVar"`
 }
 
-// nemoResponse is NeMo's JSON response from /v1/guardrail/checks.
-type nemoResponse struct {
-	Status      string                         `json:"status"`
-	RailsStatus map[string]nemoRailStatusEntry `json:"rails_status"`
+// nemoCompletionResponse is NeMo's JSON response from /v1/chat/completions.
+type nemoCompletionResponse struct {
+	Choices    []nemoChoice       `json:"choices"`
+	Guardrails nemoGuardrailsData `json:"guardrails"`
 }
 
-type nemoRailStatusEntry struct {
-	Status string `json:"status"`
+type nemoChoice struct {
+	Message nemoMessage `json:"message"`
+}
+
+type nemoMessage struct {
+	Content string `json:"content"`
+	Role    string `json:"role"`
+}
+
+type nemoGuardrailsData struct {
+	ConfigID   string         `json:"config_id"`
+	OutputData map[string]any `json:"output_data"`
+}
+
+// nemoGuardResult holds the parsed outcome from a /v1/chat/completions call.
+type nemoGuardResult struct {
+	Action  string // ActionPass, ActionBlock, or ActionModify
+	Reason  string // human-readable reason (empty for pass)
+	Content string // response content from choices[0].message.content
 }
 
 // nemoGuardBase holds the shared fields and HTTP logic for nemo guard plugins.
 type nemoGuardBase struct {
 	nemoURL    string
 	httpClient *http.Client
+	actionVar  string
+	reasonVar  string
 }
 
-func newNemoGuardBase(nemoURL string, timeoutSeconds int) (*nemoGuardBase, error) {
+func newNemoGuardBase(nemoURL string, timeoutSeconds int, actionVar, reasonVar string) (*nemoGuardBase, error) {
 	if nemoURL == "" {
 		return nil, errors.New("nemoURL is required")
 	}
@@ -68,66 +94,91 @@ func newNemoGuardBase(nemoURL string, timeoutSeconds int) (*nemoGuardBase, error
 	if timeout <= 0 {
 		timeout = defaultTimeoutSec * time.Second
 	}
+	if actionVar == "" {
+		actionVar = defaultActionVar
+	}
+	if reasonVar == "" {
+		reasonVar = defaultReasonVar
+	}
 
 	return &nemoGuardBase{
-		nemoURL: nemoURL,
-		httpClient: &http.Client{
-			Timeout: timeout,
-		},
+		nemoURL:    nemoURL,
+		httpClient: &http.Client{Timeout: timeout},
+		actionVar:  actionVar,
+		reasonVar:  reasonVar,
 	}, nil
 }
 
-// callNemoGuard POSTs the payload to the NeMo guardrail checks endpoint, parses the
-// response, and returns an error with the corresponding error code if the content is
-// blocked or NeMo is unreachable. The caller is responsible for constructing the
-// client-facing errcommon.Error from the returned values.
-func (b *nemoGuardBase) callNemoGuard(ctx context.Context, payload []byte) (string, error) {
+// callNemoGuard POSTs a chat-completions request to NeMo with output_vars,
+// parses the response, and returns a nemoGuardResult describing the action taken.
+// The caller provides the model and messages; this method adds the guardrails.options
+// wrapper with the configured output variable names.
+func (b *nemoGuardBase) callNemoGuard(ctx context.Context, model string, messages any) (*nemoGuardResult, error) {
 	logger := log.FromContext(ctx).V(logutil.DEFAULT)
-	log.FromContext(ctx).V(logutil.VERBOSE).Info("calling NeMo guardrails")
+	log.FromContext(ctx).V(logutil.VERBOSE).Info("calling NeMo guardrails", "url", b.nemoURL)
+
+	reqBody := map[string]any{
+		"model":    model,
+		"messages": messages,
+		"guardrails": map[string]any{
+			"options": map[string]any{
+				"output_vars": []string{b.actionVar, b.reasonVar},
+			},
+		},
+	}
+	payload, err := json.Marshal(reqBody)
+	if err != nil {
+		logger.Error(err, "failed to marshal NeMo request")
+		return nil, errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("failed to marshal nemo request: %v", err)}
+	}
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, b.nemoURL, bytes.NewReader(payload))
 	if err != nil {
 		logger.Error(err, "failed to create NeMo request")
-		return errcommon.Internal, fmt.Errorf("failed to create nemo request: %w", err)
+		return nil, errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("failed to create nemo request: %v", err)}
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	resp, err := b.httpClient.Do(httpReq)
 	if err != nil {
 		logger.Error(err, "NeMo guardrail call failed")
-		return errcommon.ServiceUnavailable, fmt.Errorf("nemo call failed: %w", err)
+		return nil, errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: fmt.Sprintf("nemo call failed: %v", err)}
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		logger.Error(nil, "NeMo guardrail unexpected status", "statusCode", resp.StatusCode)
-		return errcommon.ServiceUnavailable, fmt.Errorf("unexpected status %d", resp.StatusCode)
+		return nil, errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: fmt.Sprintf("unexpected status %d from NeMo", resp.StatusCode)}
 	}
 
 	limited := io.LimitReader(resp.Body, maxNemoResponseBytes)
 	body, err := io.ReadAll(limited)
 	if err != nil {
 		logger.Error(err, "failed to read NeMo response")
-		return errcommon.ServiceUnavailable, fmt.Errorf("failed to read nemo response: %w", err)
+		return nil, errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: fmt.Sprintf("failed to read nemo response: %v", err)}
 	}
 
-	var nemoResp nemoResponse
+	var nemoResp nemoCompletionResponse
 	if err := json.Unmarshal(body, &nemoResp); err != nil {
 		logger.Error(err, "failed to decode NeMo response")
-		return errcommon.ServiceUnavailable, fmt.Errorf("failed to decode nemo response: %w", err)
+		return nil, errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: fmt.Sprintf("failed to decode nemo response: %v", err)}
 	}
 
-	if strings.EqualFold(strings.TrimSpace(nemoResp.Status), nemoAllowedStatus) {
-		logger.Info("allowed by NeMo guardrails")
-		return "", nil
+	result := &nemoGuardResult{Action: ActionPass}
+
+	if len(nemoResp.Choices) > 0 {
+		result.Content = nemoResp.Choices[0].Message.Content
 	}
 
-	railsParts := make([]string, 0, len(nemoResp.RailsStatus))
-	for key, value := range nemoResp.RailsStatus {
-		railsParts = append(railsParts, fmt.Sprintf("%s: %s", key, value.Status))
+	if od := nemoResp.Guardrails.OutputData; od != nil {
+		if action, ok := od[b.actionVar].(string); ok && action != "" {
+			result.Action = action
+		}
+		if reason, ok := od[b.reasonVar].(string); ok {
+			result.Reason = reason
+		}
 	}
-	railsStatus := fmt.Sprintf("[ %s ]", strings.Join(railsParts, " "))
 
-	log.FromContext(ctx).Info("blocked by NeMo guardrails", "railsStatus", railsStatus)
-	return errcommon.Forbidden, fmt.Errorf("blocked by NeMo guardrails")
+	logger.Info("NeMo guardrails result", "action", result.Action, "reason", result.Reason)
+	return result, nil
 }

--- a/pkg/plugins/nemo/request_guard.go
+++ b/pkg/plugins/nemo/request_guard.go
@@ -55,7 +55,7 @@ func NemoRequestGuardFactory(name string, rawParameters json.RawMessage, _ frame
 		}
 	}
 
-	plugin, err := NewNemoRequestGuardPlugin(config.NemoURL, config.TimeoutSeconds)
+	plugin, err := NewNemoRequestGuardPlugin(config.NemoURL, config.TimeoutSeconds, config.ActionVar, config.ReasonVar)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create '%s' plugin - %w", NemoRequestGuardPluginType, err)
 	}
@@ -65,8 +65,9 @@ func NemoRequestGuardFactory(name string, rawParameters json.RawMessage, _ frame
 
 // NewNemoRequestGuardPlugin builds a NeMo request guard plugin from validated parameters.
 // The NeMo server is expected to have a default configuration (--default-config-id).
-func NewNemoRequestGuardPlugin(nemoURL string, timeoutSeconds int) (*NemoRequestGuardPlugin, error) {
-	base, err := newNemoGuardBase(nemoURL, timeoutSeconds)
+// actionVar and reasonVar configure which NeMo output_vars to request; empty strings use defaults.
+func NewNemoRequestGuardPlugin(nemoURL string, timeoutSeconds int, actionVar, reasonVar string) (*NemoRequestGuardPlugin, error) {
+	base, err := newNemoGuardBase(nemoURL, timeoutSeconds, actionVar, reasonVar)
 	if err != nil {
 		return nil, err
 	}
@@ -89,12 +90,13 @@ func (p *NemoRequestGuardPlugin) WithName(name string) *NemoRequestGuardPlugin {
 
 // ProcessRequest calls NeMo Guardrails to evaluate input rails on the incoming request.
 // It extracts user-supplied text from either an OpenAI-style chat body (via "messages")
-// or an MCP JSON-RPC body (via "params.arguments"), POSTs to NeMo url, and returns an
-// errcommon.Error with Forbidden (403) if NeMo flags the content.
+// or an MCP JSON-RPC body (via "params.arguments"), POSTs to NeMo's /v1/chat/completions
+// endpoint, and inspects the message_action output variable to decide the outcome:
 //
-// NeMo always returns HTTP 200 for both allowed and blocked requests. The block/allow
-// decision is conveyed through the response body "status" field.
-// "success" means the request passed all rails; "blocked" means the request is blocked.
+//   - "pass"   → allow the request through.
+//   - "block"  → return errcommon.Forbidden (403) with the block reason.
+//   - "modify" → pass through for now (TODO: support redaction).
+//   - unknown  → fail closed (500).
 func (p *NemoRequestGuardPlugin) ProcessRequest(ctx context.Context, _ *framework.CycleState, request *framework.InferenceRequest) error {
 	model, ok := request.Body["model"].(string)
 	if !ok {
@@ -109,25 +111,26 @@ func (p *NemoRequestGuardPlugin) ProcessRequest(ctx context.Context, _ *framewor
 		return nil // no messages to check (e.g. non-chat request) → allow
 	}
 
-	// "model" field is required by the NeMo OpenAI-compatible API schema but is not used.
-	// the guard model is defined in NeMo's config.yml.
-	reqBody := map[string]any{
-		"model":    model,
-		"messages": messages,
-	}
-	payload, err := json.Marshal(reqBody)
+	result, err := p.callNemoGuard(ctx, model, messages)
 	if err != nil {
-		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("marshal request: %v", err)}
+		return err
 	}
 
-	code, callErr := p.callNemoGuard(ctx, payload)
-	if callErr != nil {
-		if code == errcommon.Forbidden {
-			return errcommon.Error{Code: code, Msg: "request blocked by NeMo guardrails"}
+	switch result.Action {
+	case ActionPass:
+		return nil
+	case ActionModify:
+		// TODO: support redaction by rewriting the message content.
+		return nil
+	case ActionBlock:
+		msg := "request blocked by NeMo guardrails"
+		if result.Reason != "" {
+			msg = result.Reason
 		}
-		return errcommon.Error{Code: code, Msg: callErr.Error()}
+		return errcommon.Error{Code: errcommon.Forbidden, Msg: msg}
+	default:
+		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("unknown NeMo action %q", result.Action)}
 	}
-	return nil
 }
 
 // extractMessages returns user-supplied text as a message slice suitable for NeMo's

--- a/pkg/plugins/nemo/request_guard_test.go
+++ b/pkg/plugins/nemo/request_guard_test.go
@@ -31,9 +31,22 @@ import (
 	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
 )
 
-// nemoAllowedJSON is a minimal NeMo guard response that means “allow”.
+// nemoResponseJSON builds a NeMo guard response with the given action.
+func nemoResponseJSON(action, reason, content string) map[string]any {
+	outputData := map[string]any{"message_action": action}
+	if reason != "" {
+		outputData["block_reason"] = reason
+	}
+	return map[string]any{
+		"choices": []any{
+			map[string]any{"message": map[string]any{"content": content, "role": "assistant"}},
+		},
+		"guardrails": map[string]any{"output_data": outputData},
+	}
+}
+
 func nemoAllowedJSON() map[string]any {
-	return map[string]any{"status": "success"}
+	return nemoResponseJSON(ActionPass, "", "Hello!")
 }
 
 // --- NewNemoRequestGuardPlugin construction ---
@@ -61,7 +74,7 @@ func TestNewNemoRequestGuardPlugin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := NewNemoRequestGuardPlugin(tt.baseURL, tt.timeout)
+			p, err := NewNemoRequestGuardPlugin(tt.baseURL, tt.timeout, "", "")
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -74,7 +87,7 @@ func TestNewNemoRequestGuardPlugin(t *testing.T) {
 }
 
 func TestNemoRequestGuardTypedName(t *testing.T) {
-	p, err := NewNemoRequestGuardPlugin("http://nemo:8000", 30)
+	p, err := NewNemoRequestGuardPlugin("http://nemo:8000", 30, "", "")
 	require.NoError(t, err)
 
 	assert.Equal(t, NemoRequestGuardPluginType, p.TypedName().Name)
@@ -88,8 +101,6 @@ func TestNemoRequestGuardTypedName(t *testing.T) {
 // --- ProcessRequest: allow / block / error ---
 
 func TestNemoRequestGuardProcessRequest(t *testing.T) {
-	const forbiddenMsg = "request blocked by NeMo guardrails"
-
 	tests := []struct {
 		name            string
 		serverHandler   http.HandlerFunc
@@ -99,13 +110,55 @@ func TestNemoRequestGuardProcessRequest(t *testing.T) {
 		wantErrCode     string
 	}{
 		{
-			name: "allow: NeMo returns top-level status success",
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+			name: "pass: NeMo returns message_action pass",
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
+				if err := json.NewEncoder(w).Encode(nemoAllowedJSON()); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
+			},
+			body:    map[string]any{"model": "gpt-4", "messages": []any{map[string]any{"role": "user", "content": "Hello"}}},
+			wantErr: false,
+		},
+		{
+			name: "block: NeMo returns message_action block with reason",
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
+				if err := json.NewEncoder(w).Encode(nemoResponseJSON(ActionBlock, "Forbidden words found", "BLOCKED")); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
+			},
+			body:            map[string]any{"model": "gpt-4", "messages": []any{map[string]any{"role": "user", "content": "bad content"}}},
+			wantErr:         true,
+			wantErrContains: "Forbidden words found",
+			wantErrCode:     errcommon.Forbidden,
+		},
+		{
+			name: "block: NeMo returns message_action block without reason",
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
+				if err := json.NewEncoder(w).Encode(nemoResponseJSON(ActionBlock, "", "BLOCKED")); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
+			},
+			body:            map[string]any{"model": "gpt-4", "messages": []any{map[string]any{"role": "user", "content": "bad content"}}},
+			wantErr:         true,
+			wantErrContains: "request blocked by NeMo guardrails",
+			wantErrCode:     errcommon.Forbidden,
+		},
+		{
+			name: "modify: NeMo returns message_action modify — allowed (TODO: support redaction)",
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
+				if err := json.NewEncoder(w).Encode(nemoResponseJSON(ActionModify, "PII redacted", "Hello <PERSON>")); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
+			},
+			body:    map[string]any{"model": "gpt-4", "messages": []any{map[string]any{"role": "user", "content": "Hello Rob"}}},
+			wantErr: false,
+		},
+		{
+			name: "pass: NeMo returns empty output_data — defaults to pass",
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
 				if err := json.NewEncoder(w).Encode(map[string]any{
-					"status": "success",
-					"rails_status": map[string]any{
-						"rail-a": map[string]any{"status": "success"},
-					},
+					"choices":    []any{map[string]any{"message": map[string]any{"content": "Hello!", "role": "assistant"}}},
+					"guardrails": map[string]any{},
 				}); err != nil {
 					http.Error(w, err.Error(), http.StatusInternalServerError)
 				}
@@ -114,76 +167,8 @@ func TestNemoRequestGuardProcessRequest(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "block: only success allows — status allowed is rejected",
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
-				if err := json.NewEncoder(w).Encode(map[string]any{"status": "allowed"}); err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-				}
-			},
-			body:            map[string]any{"model": "gpt-4", "messages": []any{map[string]any{"role": "user", "content": "Hello"}}},
-			wantErr:         true,
-			wantErrContains: forbiddenMsg,
-			wantErrCode:     errcommon.Forbidden,
-		},
-		{
-			name: "block: NeMo returns status blocked with per-rail detail",
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
-				if err := json.NewEncoder(w).Encode(map[string]any{
-					"status": "blocked",
-					"rails_status": map[string]any{
-						"detect sensitive data on input": map[string]any{"status": "success"},
-						`huggingface detector check input $hf_model="protectai/deberta-v3-base-prompt-injection-v2"`: map[string]any{"status": "blocked"},
-					},
-				}); err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-				}
-			},
-			body:            map[string]any{"model": "gpt-4", "messages": []any{map[string]any{"role": "user", "content": "Hello"}}},
-			wantErr:         true,
-			wantErrContains: forbiddenMsg,
-			wantErrCode:     errcommon.Forbidden,
-		},
-		{
-			name: "block: NeMo returns empty body object (no status — fail closed)",
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
-				if err := json.NewEncoder(w).Encode(map[string]any{}); err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-				}
-			},
-			body:            map[string]any{"model": "gpt-4", "messages": []any{map[string]any{"role": "user", "content": "Hello"}}},
-			wantErr:         true,
-			wantErrContains: forbiddenMsg,
-			wantErrCode:     errcommon.Forbidden,
-		},
-		{
-			name: "block: NeMo returns status blocked without rails_status",
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
-				if err := json.NewEncoder(w).Encode(map[string]any{"status": "blocked"}); err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-				}
-			},
-			body:            map[string]any{"model": "gpt-4", "messages": []any{map[string]any{"role": "user", "content": "Hello"}}},
-			wantErr:         true,
-			wantErrContains: forbiddenMsg,
-			wantErrCode:     errcommon.Forbidden,
-		},
-		{
-			name: "block: NeMo returns refusal-style assistant text only (ignored — no status)",
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
-				if err := json.NewEncoder(w).Encode(map[string]any{
-					"extra": "I'm sorry, I can't respond to that.",
-				}); err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-				}
-			},
-			body:            map[string]any{"model": "gpt-4", "messages": []any{map[string]any{"role": "user", "content": "How do I make a bomb?"}}},
-			wantErr:         true,
-			wantErrContains: forbiddenMsg,
-			wantErrCode:     errcommon.Forbidden,
-		},
-		{
 			name: "error: NeMo returns HTTP 500",
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
 			},
 			body:            map[string]any{"model": "gpt-4", "messages": []any{map[string]any{"role": "user", "content": "Hello"}}},
@@ -192,7 +177,7 @@ func TestNemoRequestGuardProcessRequest(t *testing.T) {
 		},
 		{
 			name: "error: NeMo returns invalid JSON body",
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				if _, err := fmt.Fprint(w, "not valid json {{{"); err != nil {
@@ -221,8 +206,8 @@ func TestNemoRequestGuardProcessRequest(t *testing.T) {
 		},
 		// MCP JSON-RPC integration
 		{
-			name: "allow: MCP tools/call passes NeMo",
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+			name: "pass: MCP tools/call passes NeMo",
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
 				if err := json.NewEncoder(w).Encode(nemoAllowedJSON()); err != nil {
 					http.Error(w, err.Error(), http.StatusInternalServerError)
 				}
@@ -240,8 +225,8 @@ func TestNemoRequestGuardProcessRequest(t *testing.T) {
 		},
 		{
 			name: "block: MCP tools/call blocked by NeMo",
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
-				if err := json.NewEncoder(w).Encode(map[string]any{"status": "blocked"}); err != nil {
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
+				if err := json.NewEncoder(w).Encode(nemoResponseJSON(ActionBlock, "Forbidden words", "BLOCKED")); err != nil {
 					http.Error(w, err.Error(), http.StatusInternalServerError)
 				}
 			},
@@ -255,7 +240,7 @@ func TestNemoRequestGuardProcessRequest(t *testing.T) {
 				},
 			},
 			wantErr:         true,
-			wantErrContains: forbiddenMsg,
+			wantErrContains: "Forbidden words",
 			wantErrCode:     errcommon.Forbidden,
 		},
 		{
@@ -278,7 +263,7 @@ func TestNemoRequestGuardProcessRequest(t *testing.T) {
 				baseURL = srv.URL
 			}
 
-			p, err := NewNemoRequestGuardPlugin(baseURL, 30)
+			p, err := NewNemoRequestGuardPlugin(baseURL, 30, "", "")
 			require.NoError(t, err)
 
 			var req *framework.InferenceRequest
@@ -317,7 +302,7 @@ func TestNemoRequestGuardSendsCorrectPayload(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p, err := NewNemoRequestGuardPlugin(srv.URL, 30)
+	p, err := NewNemoRequestGuardPlugin(srv.URL, 30, "", "")
 	require.NoError(t, err)
 
 	req := framework.NewInferenceRequest()
@@ -327,8 +312,15 @@ func TestNemoRequestGuardSendsCorrectPayload(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "client-model", capturedReq["model"])
-	_, hasGuardrails := capturedReq["guardrails"]
-	assert.False(t, hasGuardrails, "guardrails block should not be sent — NeMo server uses --default-config-id")
+
+	guardrails, ok := capturedReq["guardrails"].(map[string]any)
+	require.True(t, ok, "guardrails field must be present")
+	options, ok := guardrails["options"].(map[string]any)
+	require.True(t, ok, "options field must be present")
+	outputVars, ok := options["output_vars"].([]any)
+	require.True(t, ok, "output_vars field must be present")
+	assert.Contains(t, outputVars, defaultActionVar)
+	assert.Contains(t, outputVars, defaultReasonVar)
 }
 
 // TestNemoRequestGuardSendsCorrectPayloadMCP verifies the request sent to NeMo for an MCP payload.
@@ -340,7 +332,7 @@ func TestNemoRequestGuardSendsCorrectPayloadMCP(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p, err := NewNemoRequestGuardPlugin(srv.URL, 30)
+	p, err := NewNemoRequestGuardPlugin(srv.URL, 30, "", "")
 	require.NoError(t, err)
 
 	req := framework.NewInferenceRequest()
@@ -372,7 +364,7 @@ func TestNemoRequestGuardForwardsAllMessages(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p, err := NewNemoRequestGuardPlugin(srv.URL, 30)
+	p, err := NewNemoRequestGuardPlugin(srv.URL, 30, "", "")
 	require.NoError(t, err)
 
 	req := framework.NewInferenceRequest()
@@ -407,7 +399,7 @@ func TestNemoRequestGuardBaseURLTrailingSlash(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p, err := NewNemoRequestGuardPlugin(srv.URL+"//", 30)
+	p, err := NewNemoRequestGuardPlugin(srv.URL+"//", 30, "", "")
 	require.NoError(t, err)
 
 	req := framework.NewInferenceRequest()

--- a/pkg/plugins/nemo/response_guard.go
+++ b/pkg/plugins/nemo/response_guard.go
@@ -54,7 +54,7 @@ func NemoResponseGuardFactory(name string, rawParameters json.RawMessage, _ fram
 		}
 	}
 
-	plugin, err := NewNemoResponseGuardPlugin(config.NemoURL, config.TimeoutSeconds)
+	plugin, err := NewNemoResponseGuardPlugin(config.NemoURL, config.TimeoutSeconds, config.ActionVar, config.ReasonVar)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create '%s' plugin - %w", NemoResponseGuardPluginType, err)
 	}
@@ -63,8 +63,9 @@ func NemoResponseGuardFactory(name string, rawParameters json.RawMessage, _ fram
 }
 
 // NewNemoResponseGuardPlugin builds a NeMo response guard plugin from validated parameters.
-func NewNemoResponseGuardPlugin(nemoURL string, timeoutSeconds int) (*NemoResponseGuardPlugin, error) {
-	base, err := newNemoGuardBase(nemoURL, timeoutSeconds)
+// actionVar and reasonVar configure which NeMo output_vars to request; empty strings use defaults.
+func NewNemoResponseGuardPlugin(nemoURL string, timeoutSeconds int, actionVar, reasonVar string) (*NemoResponseGuardPlugin, error) {
+	base, err := newNemoGuardBase(nemoURL, timeoutSeconds, actionVar, reasonVar)
 	if err != nil {
 		return nil, err
 	}
@@ -87,12 +88,12 @@ func (p *NemoResponseGuardPlugin) WithName(name string) *NemoResponseGuardPlugin
 
 // ProcessResponse calls NeMo Guardrails to evaluate output rails on the model response.
 // It extracts assistant messages from the OpenAI-style response body, POSTs them to
-// NeMo's /v1/guardrail/checks endpoint, and returns an errcommon.Error with Forbidden (403)
-// if NeMo flags the content.
+// NeMo's /v1/chat/completions endpoint, and inspects the message_action output variable:
 //
-// NeMo always returns HTTP 200 for both allowed and blocked responses. The block/allow
-// decision is conveyed through the response body "status" field.
-// "success" means the response passed all rails; "blocked" means it is blocked.
+//   - "pass"   → allow the response through.
+//   - "block"  → return errcommon.Forbidden (403) with the block reason.
+//   - "modify" → pass through for now (TODO: support redaction).
+//   - unknown  → fail closed (500).
 func (p *NemoResponseGuardPlugin) ProcessResponse(ctx context.Context, _ *framework.CycleState, response *framework.InferenceResponse) error {
 	messages, err := extractAssistantMessages(response.Body)
 	if err != nil {
@@ -104,23 +105,26 @@ func (p *NemoResponseGuardPlugin) ProcessResponse(ctx context.Context, _ *framew
 
 	model, _ := response.Body["model"].(string)
 
-	reqBody := map[string]any{
-		"model":    model,
-		"messages": messages,
-	}
-	payload, marshalErr := json.Marshal(reqBody)
-	if marshalErr != nil {
-		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("marshal request: %v", marshalErr)}
+	result, err := p.callNemoGuard(ctx, model, messages)
+	if err != nil {
+		return err
 	}
 
-	code, callErr := p.callNemoGuard(ctx, payload)
-	if callErr != nil {
-		if code == errcommon.Forbidden {
-			return errcommon.Error{Code: code, Msg: "response blocked by NeMo guardrails"}
+	switch result.Action {
+	case ActionPass:
+		return nil
+	case ActionModify:
+		// TODO: support redaction by rewriting the message content.
+		return nil
+	case ActionBlock:
+		msg := "response blocked by NeMo guardrails"
+		if result.Reason != "" {
+			msg = result.Reason
 		}
-		return errcommon.Error{Code: code, Msg: callErr.Error()}
+		return errcommon.Error{Code: errcommon.Forbidden, Msg: msg}
+	default:
+		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("unknown NeMo action %q", result.Action)}
 	}
-	return nil
 }
 
 // extractAssistantMessages extracts assistant content from a response body.

--- a/pkg/plugins/nemo/response_guard_test.go
+++ b/pkg/plugins/nemo/response_guard_test.go
@@ -43,9 +43,9 @@ func TestNewNemoResponseGuardPlugin(t *testing.T) {
 	}{
 		{
 			name:        "valid config",
-			nemoURL:     "http://nemo:8000/v1/guardrail/checks",
+			nemoURL:     "http://nemo:8000/v1/chat/completions",
 			timeout:     30,
-			wantNemoURL: "http://nemo:8000/v1/guardrail/checks",
+			wantNemoURL: "http://nemo:8000/v1/chat/completions",
 		},
 		{
 			name:    "missing nemoURL — error",
@@ -56,7 +56,7 @@ func TestNewNemoResponseGuardPlugin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := NewNemoResponseGuardPlugin(tt.nemoURL, tt.timeout)
+			p, err := NewNemoResponseGuardPlugin(tt.nemoURL, tt.timeout, "", "")
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -69,7 +69,7 @@ func TestNewNemoResponseGuardPlugin(t *testing.T) {
 }
 
 func TestNemoResponseGuardTypedName(t *testing.T) {
-	p, err := NewNemoResponseGuardPlugin("http://nemo:8000/v1/guardrail/checks", 30)
+	p, err := NewNemoResponseGuardPlugin("http://nemo:8000/v1/chat/completions", 30, "", "")
 	require.NoError(t, err)
 
 	assert.Equal(t, NemoResponseGuardPluginType, p.TypedName().Name)
@@ -83,8 +83,6 @@ func TestNemoResponseGuardTypedName(t *testing.T) {
 // --- ProcessResponse: allow / block / error ---
 
 func TestNemoResponseGuardProcessResponse(t *testing.T) {
-	const forbiddenMsg = "response blocked by NeMo guardrails"
-
 	validResponseBody := func(content string) map[string]any {
 		return map[string]any{
 			"choices": []any{
@@ -107,14 +105,9 @@ func TestNemoResponseGuardProcessResponse(t *testing.T) {
 		wantErrCode     string
 	}{
 		{
-			name: "allow: NeMo returns status success",
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
-				if err := json.NewEncoder(w).Encode(map[string]any{
-					"status": "success",
-					"rails_status": map[string]any{
-						"output-rail": map[string]any{"status": "success"},
-					},
-				}); err != nil {
+			name: "pass: NeMo returns message_action pass",
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
+				if err := json.NewEncoder(w).Encode(nemoAllowedJSON()); err != nil {
 					http.Error(w, err.Error(), http.StatusInternalServerError)
 				}
 			},
@@ -122,63 +115,55 @@ func TestNemoResponseGuardProcessResponse(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "block: NeMo returns status blocked with per-rail detail",
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
-				if err := json.NewEncoder(w).Encode(map[string]any{
-					"status": "blocked",
-					"rails_status": map[string]any{
-						`huggingface detector check output $hf_model="ibm-granite/granite-guardian-hap-38m"`: map[string]any{"status": "blocked"},
-					},
-				}); err != nil {
+			name: "block: NeMo returns message_action block with reason",
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
+				if err := json.NewEncoder(w).Encode(nemoResponseJSON(ActionBlock, "HAP content detected", "BLOCKED")); err != nil {
 					http.Error(w, err.Error(), http.StatusInternalServerError)
 				}
 			},
 			body:            validResponseBody("this message should be blocked."),
 			wantErr:         true,
-			wantErrContains: forbiddenMsg,
+			wantErrContains: "HAP content detected",
 			wantErrCode:     errcommon.Forbidden,
 		},
 		{
-			name: "block: NeMo returns empty body (fail closed)",
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
-				if err := json.NewEncoder(w).Encode(map[string]any{}); err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-				}
-			},
-			body:            validResponseBody("Some content"),
-			wantErr:         true,
-			wantErrContains: forbiddenMsg,
-			wantErrCode:     errcommon.Forbidden,
-		},
-		{
-			name: "block: NeMo returns status blocked without rails_status",
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
-				if err := json.NewEncoder(w).Encode(map[string]any{"status": "blocked"}); err != nil {
+			name: "block: NeMo returns message_action block without reason",
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
+				if err := json.NewEncoder(w).Encode(nemoResponseJSON(ActionBlock, "", "BLOCKED")); err != nil {
 					http.Error(w, err.Error(), http.StatusInternalServerError)
 				}
 			},
 			body:            validResponseBody("Toxic content here"),
 			wantErr:         true,
-			wantErrContains: forbiddenMsg,
+			wantErrContains: "response blocked by NeMo guardrails",
 			wantErrCode:     errcommon.Forbidden,
 		},
 		{
-			name: "block: NeMo returns refusal-style text only (no status — fail closed)",
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+			name: "modify: NeMo returns message_action modify — allowed (TODO: support redaction)",
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
+				if err := json.NewEncoder(w).Encode(nemoResponseJSON(ActionModify, "PII redacted", "Hello <PERSON>")); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
+			},
+			body:    validResponseBody("Hello Rob"),
+			wantErr: false,
+		},
+		{
+			name: "pass: NeMo returns empty output_data — defaults to pass",
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
 				if err := json.NewEncoder(w).Encode(map[string]any{
-					"extra": "I'm sorry, I can't respond to that.",
+					"choices":    []any{map[string]any{"message": map[string]any{"content": "Hello!", "role": "assistant"}}},
+					"guardrails": map[string]any{},
 				}); err != nil {
 					http.Error(w, err.Error(), http.StatusInternalServerError)
 				}
 			},
-			body:            validResponseBody("Some toxic output"),
-			wantErr:         true,
-			wantErrContains: forbiddenMsg,
-			wantErrCode:     errcommon.Forbidden,
+			body:    validResponseBody("Some content"),
+			wantErr: false,
 		},
 		{
 			name: "error: NeMo returns HTTP 500",
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
 			},
 			body:            validResponseBody("Hello"),
@@ -187,7 +172,7 @@ func TestNemoResponseGuardProcessResponse(t *testing.T) {
 		},
 		{
 			name: "error: NeMo returns invalid JSON",
-			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
 				if _, err := fmt.Fprint(w, "not valid json {{{"); err != nil {
@@ -264,7 +249,7 @@ func TestNemoResponseGuardProcessResponse(t *testing.T) {
 				baseURL = srv.URL
 			}
 
-			p, err := NewNemoResponseGuardPlugin(baseURL, 30)
+			p, err := NewNemoResponseGuardPlugin(baseURL, 30, "", "")
 			require.NoError(t, err)
 
 			resp := framework.NewInferenceResponse()
@@ -300,7 +285,7 @@ func TestNemoResponseGuardSendsCorrectPayload(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p, err := NewNemoResponseGuardPlugin(srv.URL, 30)
+	p, err := NewNemoResponseGuardPlugin(srv.URL, 30, "", "")
 	require.NoError(t, err)
 
 	resp := framework.NewInferenceResponse()
@@ -318,6 +303,15 @@ func TestNemoResponseGuardSendsCorrectPayload(t *testing.T) {
 	msg := messages[0].(map[string]any)
 	assert.Equal(t, "assistant", msg["role"])
 	assert.Equal(t, "Here is the answer.", msg["content"])
+
+	guardrails, ok := capturedReq["guardrails"].(map[string]any)
+	require.True(t, ok, "guardrails field must be present")
+	options, ok := guardrails["options"].(map[string]any)
+	require.True(t, ok, "options field must be present")
+	outputVars, ok := options["output_vars"].([]any)
+	require.True(t, ok, "output_vars field must be present")
+	assert.Contains(t, outputVars, defaultActionVar)
+	assert.Contains(t, outputVars, defaultReasonVar)
 }
 
 // TestNemoResponseGuardForwardsModel verifies the model field from the response body is forwarded to NeMo.
@@ -329,7 +323,7 @@ func TestNemoResponseGuardForwardsModel(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p, err := NewNemoResponseGuardPlugin(srv.URL, 30)
+	p, err := NewNemoResponseGuardPlugin(srv.URL, 30, "", "")
 	require.NoError(t, err)
 
 	resp := framework.NewInferenceResponse()
@@ -354,7 +348,7 @@ func TestNemoResponseGuardBaseURLTrailingSlash(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p, err := NewNemoResponseGuardPlugin(srv.URL+"//", 30)
+	p, err := NewNemoResponseGuardPlugin(srv.URL+"//", 30, "", "")
 	require.NoError(t, err)
 
 	resp := framework.NewInferenceResponse()
@@ -371,7 +365,7 @@ func TestNemoResponseGuardBaseURLTrailingSlash(t *testing.T) {
 
 // TestNemoResponseGuardFactory verifies the factory parses JSON and sets the instance name.
 func TestNemoResponseGuardFactory(t *testing.T) {
-	params := json.RawMessage(`{"nemoURL":"http://nemo:8000/v1/guardrail/checks"}`)
+	params := json.RawMessage(`{"nemoURL":"http://nemo:8000/v1/chat/completions"}`)
 	p, err := NemoResponseGuardFactory("my-output-guard", params, nil)
 	require.NoError(t, err)
 	require.NotNil(t, p)


### PR DESCRIPTION
## Summary

- Refactor `nemo-request-guard` and `nemo-response-guard` plugins to use the NeMo `/v1/chat/completions` endpoint instead of the legacy `/v1/guardrail/checks` endpoint
- Add `message_action` / `block_reason` support via NeMo's `guardrails.options.output_vars` mechanism to distinguish pass, block, and modify (redact) actions from the response
- Introduce configurable `actionVar` and `reasonVar` fields in plugin config (defaulting to `message_action` and `block_reason`) so admins can match their NeMo Colang variable names
- Replace the old `nemoResponse` / `nemoRailStatusEntry` types with new `nemoCompletionResponse` / `nemoGuardResult` types for the chat-completions response format
- Consolidate request marshaling into `callNemoGuard` - callers now pass `model` + `messages` instead of pre-marshaled bytes
- Return `errcommon.Error` directly from `callNemoGuard` with specific codes (`Internal` for marshaling errors, `ServiceUnavailable` for network/response errors) instead of separate error code + error returns
- Forward NeMo's `block_reason` to the client in the 403 response instead of a generic message
- Treat `modify` action as pass-through for now - full redaction (message rewriting) will be added as part of https://github.com/opendatahub-io/ai-gateway-payload-processing/issues/123

## Tested

- All existing unit tests updated to use the new `/v1/chat/completions` response format and pass
- New test cases added for `modify` action (pass-through) and block-without-reason scenarios
- `go build ./...` and `go test ./pkg/plugins/nemo/` pass with no errors or lint issues
- E2E tested on a Kind cluster with a NeMo Guardrails deployment using Rob's Colang config that sets `message_action` and `block_reason`:
  - Normal message - plugin returns `action: pass`, request forwarded to backend (HTTP 200)
  - Forbidden words ("I hate everyone") - plugin returns `action: block`, client gets HTTP 403 with `"Forbidden words found in input"`
  - PII message ("My name is John Smith") - plugin returns `action: modify`, request passes through (redaction is follow-up PR)

## Context

- TrustyAI will maintain a catalog of standardized Colang configs that set `message_action` to `"pass"`, `"block"`, or `"modify"` and populate `block_reason`
- The legacy `/v1/guardrail/checks` endpoint only supported blocking; the new endpoint enables both blocking and PII redaction
- Follow-up PRs: redaction support (rewrite message content on `modify`), unit tests for `nemo_guard_base.go`, documentation update

## Related
#256 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * NeMo guardrails updated to a chat-style request/response flow; decisions now return structured actions (pass/modify/block) with optional reasons and content, and block responses surface a clear reason.

* **Tests**
  * Guardrail test suites and payload assertions updated to validate the new action/reason response format and decision semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->