### PR TITLE
fix: enable CGO and FIPS-compliant kubectl in e2e Dockerfile

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,4 +1,4 @@
-# Dockerfile.konflux.e2e builds a container image for running E2E tests.
+# Dockerfile.e2e builds a container image for running E2E tests.
 # Used by the RHOAI shift-left Jenkins pipeline via `podman run`.
 #
 # Usage:
@@ -10,11 +10,13 @@
 #     quay.io/opendatahub/ai-gateway-payload-processing-e2e:latest
 
 ARG GOLANG_VERSION=1.25
-ARG KUBECTL_VERSION=v1.31.0
 
 ## Stage 1: Build the test binary and download kubectl
 FROM registry.access.redhat.com/ubi9/go-toolset:$GOLANG_VERSION AS builder
-ARG KUBECTL_VERSION
+ARG OCP_VERSION=4.21.15
+ARG CGO_ENABLED=1
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
 
 USER root
 
@@ -26,13 +28,15 @@ COPY cmd/ cmd/
 COPY pkg/ pkg/
 COPY test/ test/
 
-# Compile the Ginkgo test binary (static, no CGO).
-RUN CGO_ENABLED=0 go test -c -o /e2e-tests.test ./test/e2e/ \
+# Compile the Ginkgo test binary with CGO and strict FIPS runtime (matches Dockerfile pattern).
+RUN CGO_ENABLED=${CGO_ENABLED} GOEXPERIMENT=strictfipsruntime GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go test -c -o /e2e-tests.test ./test/e2e/ \
     -ldflags="-s -w"
 
-# Download kubectl in the builder stage (has curl and network access).
-RUN curl -sLo /usr/local/bin/kubectl \
-      "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+# Download FIPS-compliant kubectl from the OpenShift client tarball (rhel9, CGO+OpenSSL).
+RUN curl -sL "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OCP_VERSION}/openshift-client-linux-${TARGETARCH}-rhel9-${OCP_VERSION}.tar.gz" | \
+    tar -xz -C /tmp/ oc kubectl && \
+    mv /tmp/kubectl /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
 ## Stage 2: Runtime


### PR DESCRIPTION
## Summary

Fix two FIPS `check-payload` scanner failures in the e2e image — the e2e test binary was built without CGO, and the prefetched kubectl was a statically-linked upstream binary.

Jira: [RHOAIENG-62483](https://redhat.atlassian.net/browse/RHOAIENG-62483)

## Description

The `check-payload` FIPS scanner flagged the e2e image as non-compliant due to two statically-linked binaries:

- **`/e2e/e2e-tests.test`**: `Dockerfile.e2e` was using `CGO_ENABLED=0`, producing a pure-Go static binary that bypasses the system's FIPS-validated OpenSSL/libcrypto.
  - Fix: set `CGO_ENABLED=1` and `GOEXPERIMENT=strictfipsruntime`, matching the pattern already used in `Dockerfile`.
  - Added `ARG CGO_ENABLED=1`, `ARG TARGETOS=linux`, `ARG TARGETARCH=amd64` to the builder stage for consistency and cross-arch correctness.

- **`/usr/local/bin/kubectl`**: was pulled from `dl.k8s.io` (upstream Kubernetes), which ships a `CGO_ENABLED=0` static binary by default.
  - Fix: switch to the **OpenShift client tarball (rhel9 variant)** from `mirror.openshift.com`, built by Red Hat with CGO and dynamically linked against OpenSSL (FIPS-validated).
  - Replaced `ARG KUBECTL_VERSION` with `ARG OCP_VERSION=4.21.14`, scoped to the builder stage only (not exposed at global scope).
  - Updated the `RUN` command to stream and extract `kubectl` from the tarball (`oc` is extracted alongside it since `kubectl` is a hard link to `oc` in the archive).

Also fixes a stale comment header that incorrectly referenced `Dockerfile.konflux.e2e`.

## How It Was Tested

- Built `--target builder` locally against `Dockerfile.e2e`; compilation succeeded with `CGO_ENABLED=1` + `GOEXPERIMENT=strictfipsruntime`.
- Ran `ldd` on `/e2e-tests.test` — confirmed **dynamically linked** (`libc.so.6`), proving CGO is active.
- Ran `file` + `ldd` on the extracted `/usr/local/bin/kubectl` — confirmed **dynamically linked** (`libc.so.6`).
- Verified the tarball hard-link behaviour (`kubectl` → `oc`) and confirmed the `tar oc kubectl` extraction pattern resolves it correctly.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated E2E test Docker image build to use an enhanced Go build stage for improved FIPS-runtime compatibility.
  * Changed kubectl provisioning to extract the kubectl binary from a parameterized OpenShift client package instead of direct download.
  * Revised Docker image documentation and build comments to reflect the new build and runtime structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->