### PR TITLE
feat: add ExternalProvider store and typed reconciler

### DIFF
--- a/pkg/plugins/model-provider-resolver/external_provider_reconciler.go
+++ b/pkg/plugins/model-provider-resolver/external_provider_reconciler.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model_provider_resolver
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+
+	inferencev1alpha1 "github.com/opendatahub-io/ai-gateway-payload-processing/api/inference/v1alpha1"
+)
+
+type externalProviderReconciler struct {
+	client.Reader
+	store *providerInfoStore
+}
+
+func (r *externalProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).V(logutil.DEFAULT)
+	logger.Info("reconciling ExternalProvider", "name", req.Name, "namespace", req.Namespace)
+
+	provider := &inferencev1alpha1.ExternalProvider{}
+	err := r.Get(ctx, req.NamespacedName, provider)
+	if err != nil && !errors.IsNotFound(err) {
+		return ctrl.Result{}, fmt.Errorf("unable to get ExternalProvider: %w", err)
+	}
+
+	if errors.IsNotFound(err) || !provider.GetDeletionTimestamp().IsZero() {
+		r.store.delete(req.NamespacedName)
+		logger.Info("ExternalProvider removed from store", "name", req.Name, "namespace", req.Namespace)
+		return ctrl.Result{}, nil
+	}
+
+	r.store.addOrUpdate(req.NamespacedName, &providerInfo{
+		provider:        provider.Spec.Provider,
+		endpoint:        provider.Spec.Endpoint,
+		secretName:      provider.Spec.Auth.SecretRef.Name,
+		secretNamespace: req.Namespace,
+		config:          provider.Spec.Config,
+	})
+
+	logger.Info("updated provider store", "provider", provider.Spec.Provider, "endpoint", provider.Spec.Endpoint)
+	return ctrl.Result{}, nil
+}

--- a/pkg/plugins/model-provider-resolver/external_provider_reconciler_test.go
+++ b/pkg/plugins/model-provider-resolver/external_provider_reconciler_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model_provider_resolver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	inferencev1alpha1 "github.com/opendatahub-io/ai-gateway-payload-processing/api/inference/v1alpha1"
+)
+
+type mockProviderReader struct {
+	objects map[types.NamespacedName]*inferencev1alpha1.ExternalProvider
+}
+
+func (m *mockProviderReader) Get(_ context.Context, key types.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+	stored, ok := m.objects[key]
+	if !ok {
+		return apierrors.NewNotFound(schema.GroupResource{Group: "inference.opendatahub.io", Resource: "externalproviders"}, key.Name)
+	}
+	*obj.(*inferencev1alpha1.ExternalProvider) = *stored.DeepCopy()
+	return nil
+}
+
+func (m *mockProviderReader) List(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
+	return nil
+}
+
+func TestProviderReconciler_ValidCR(t *testing.T) {
+	key := types.NamespacedName{Namespace: "models", Name: "my-openai"}
+	reader := &mockProviderReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalProvider{
+		key: {
+			ObjectMeta: metav1.ObjectMeta{Name: "my-openai", Namespace: "models"},
+			Spec: inferencev1alpha1.ExternalProviderSpec{
+				Provider: "openai",
+				Endpoint: "api.openai.com",
+				Auth:     inferencev1alpha1.AuthConfig{SecretRef: inferencev1alpha1.NameReference{Name: "openai-key"}},
+			},
+		},
+	}}
+	store := newProviderInfoStore()
+	r := &externalProviderReconciler{Reader: reader, store: store}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	info, found := store.get(key)
+	require.True(t, found)
+	assert.Equal(t, "openai", info.provider)
+	assert.Equal(t, "api.openai.com", info.endpoint)
+	assert.Equal(t, "openai-key", info.secretName)
+	assert.Equal(t, "models", info.secretNamespace)
+}
+
+func TestProviderReconciler_DeletedCR(t *testing.T) {
+	key := types.NamespacedName{Namespace: "models", Name: "deleted"}
+	reader := &mockProviderReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalProvider{}}
+
+	store := newProviderInfoStore()
+	store.addOrUpdate(key, &providerInfo{provider: "openai", endpoint: "api.openai.com"})
+
+	r := &externalProviderReconciler{Reader: reader, store: store}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	_, found := store.get(key)
+	assert.False(t, found, "store entry should be removed on delete")
+}
+
+func TestProviderReconciler_WithConfig(t *testing.T) {
+	key := types.NamespacedName{Namespace: "models", Name: "my-vertex"}
+	reader := &mockProviderReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalProvider{
+		key: {
+			ObjectMeta: metav1.ObjectMeta{Name: "my-vertex", Namespace: "models"},
+			Spec: inferencev1alpha1.ExternalProviderSpec{
+				Provider: "vertex-openai",
+				Endpoint: "us-central1-aiplatform.googleapis.com",
+				Auth:     inferencev1alpha1.AuthConfig{SecretRef: inferencev1alpha1.NameReference{Name: "vertex-key"}},
+				Config:   map[string]string{"project": "my-project", "location": "us-central1"},
+			},
+		},
+	}}
+	store := newProviderInfoStore()
+	r := &externalProviderReconciler{Reader: reader, store: store}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	info, found := store.get(key)
+	require.True(t, found)
+	assert.Equal(t, "my-project", info.config["project"])
+	assert.Equal(t, "us-central1", info.config["location"])
+}

--- a/pkg/plugins/model-provider-resolver/store.go
+++ b/pkg/plugins/model-provider-resolver/store.go
@@ -22,6 +22,44 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+type providerInfo struct {
+	provider        string
+	endpoint        string
+	secretName      string
+	secretNamespace string
+	config          map[string]string
+}
+
+type providerInfoStore struct {
+	providers map[string]*providerInfo
+	lock      sync.RWMutex
+}
+
+func newProviderInfoStore() *providerInfoStore {
+	return &providerInfoStore{
+		providers: make(map[string]*providerInfo),
+	}
+}
+
+func (s *providerInfoStore) addOrUpdate(key types.NamespacedName, info *providerInfo) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.providers[key.String()] = info
+}
+
+func (s *providerInfoStore) delete(key types.NamespacedName) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	delete(s.providers, key.String())
+}
+
+func (s *providerInfoStore) get(key types.NamespacedName) (*providerInfo, bool) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	info, ok := s.providers[key.String()]
+	return info, ok
+}
+
 // externalModelInfo holds the provider and secret name/namespace for an external model.
 type externalModelInfo struct {
 	provider        string
@@ -45,7 +83,6 @@ func newModelInfoStore() *modelInfoStore {
 	}
 }
 
-// addOrUpdateExternalModel stores ExternalModel information.
 func (s *modelInfoStore) addOrUpdateExternalModel(externalModelKey types.NamespacedName, modelInfo *externalModelInfo) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
@@ -55,7 +92,6 @@ func (s *modelInfoStore) addOrUpdateExternalModel(externalModelKey types.Namespa
 	s.externalModelToModelInfo[externalModelKey.Namespace][externalModelKey.Name] = modelInfo
 }
 
-// deleteExternalModel deletes ExternalModel information.
 func (s *modelInfoStore) deleteExternalModel(externalModelKey types.NamespacedName) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
@@ -69,20 +105,18 @@ func (s *modelInfoStore) deleteExternalModel(externalModelKey types.NamespacedNa
 	}
 }
 
-// getModelInfo returns the modelInfo stored in ExternalModel and bool if found or not.
-// if no externalModelInfo found, nil is returned in the first return value.
 func (s *modelInfoStore) getModelInfo(externalModelKey types.NamespacedName) (*externalModelInfo, bool) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
 	modelsByNamespace, found := s.externalModelToModelInfo[externalModelKey.Namespace]
 	if !found {
-		return nil, false // ExternalModel namespace not found
+		return nil, false
 	}
 
 	externalModelInfo, ok := modelsByNamespace[externalModelKey.Name]
 	if !ok {
-		return nil, false // ExternalModel not found
+		return nil, false
 	}
 
 	return externalModelInfo, true

--- a/pkg/plugins/model-provider-resolver/store_test.go
+++ b/pkg/plugins/model-provider-resolver/store_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model_provider_resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestProviderStore_AddGetDelete(t *testing.T) {
+	store := newProviderInfoStore()
+	key := types.NamespacedName{Namespace: "models", Name: "my-openai"}
+
+	_, found := store.get(key)
+	assert.False(t, found)
+
+	store.addOrUpdate(key, &providerInfo{
+		provider: "openai", endpoint: "api.openai.com",
+		secretName: "key", secretNamespace: "models",
+	})
+
+	info, found := store.get(key)
+	require.True(t, found)
+	assert.Equal(t, "openai", info.provider)
+	assert.Equal(t, "api.openai.com", info.endpoint)
+
+	store.delete(key)
+	_, found = store.get(key)
+	assert.False(t, found)
+}
+
+func TestProviderStore_Update(t *testing.T) {
+	store := newProviderInfoStore()
+	key := types.NamespacedName{Namespace: "models", Name: "my-openai"}
+
+	store.addOrUpdate(key, &providerInfo{provider: "openai", endpoint: "old.com"})
+	store.addOrUpdate(key, &providerInfo{provider: "openai", endpoint: "new.com"})
+
+	info, _ := store.get(key)
+	assert.Equal(t, "new.com", info.endpoint)
+}
+
+func TestProviderStore_WithConfig(t *testing.T) {
+	store := newProviderInfoStore()
+	key := types.NamespacedName{Namespace: "models", Name: "my-vertex"}
+
+	store.addOrUpdate(key, &providerInfo{
+		provider: "vertex-openai", endpoint: "aiplatform.googleapis.com",
+		secretName: "key", secretNamespace: "models",
+		config: map[string]string{"project": "my-project", "location": "us-central1"},
+	})
+
+	info, found := store.get(key)
+	require.True(t, found)
+	assert.Equal(t, "my-project", info.config["project"])
+}


### PR DESCRIPTION
## Summary

Adds a provider info store and typed reconciler for `inference.opendatahub.io` ExternalProvider CRDs. This is the first of a series of small incremental PRs to wire ExternalProvider/ExternalModel into the model-provider-resolver plugin.

**4 files, 124 lines production code, 193 lines tests.**

## What this does

- `provider_store.go` — thread-safe in-memory store for provider info (endpoint, credentials, config)
- `external_provider_reconciler.go` — typed client reconciler that watches ExternalProvider CRDs and populates the store
- Tests for both

## What this does NOT do (follow-up PRs)

- Does not register the reconciler in the plugin factory (next PR)
- Does not modify the model reconciler to use the provider store (next PR)
- No RBAC, no Helm changes, no E2E infra changes

## Test plan

- [x] Unit tests pass
- [x] Lint clean (0 issues)

## Risk analysis

- **Risk rating**: 1
- **Why**: Adds new files only, no existing code modified. The store and reconciler are not wired into anything yet — zero runtime impact until the next PR registers them.

cc @nirrozenbaum

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External provider resources can now be automatically reconciled and managed within the system.
  * Provider configurations are persisted in an internal store for dynamic access.

* **Tests**
  * Added comprehensive unit tests for provider reconciliation scenarios including creation, updates, and deletion.
  * Added tests validating provider configuration storage and retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->