### PR TITLE
feat: typed ExternalModel reconciler with cross-watch and config/auth override

### DIFF
--- a/pkg/plugins/common/state/state-keys.go
+++ b/pkg/plugins/common/state/state-keys.go
@@ -22,4 +22,5 @@ const (
 	ModelKey          = "model"
 	CredsRefName      = "credential-ref-name"
 	CredsRefNamespace = "credential-ref-namespace"
+	ModelConfigKey    = "model-config"
 )

--- a/pkg/plugins/model-provider-resolver/external_model_reconciler.go
+++ b/pkg/plugins/model-provider-resolver/external_model_reconciler.go
@@ -80,10 +80,7 @@ func (r *externalModelReconciler) resolveRef(namespace string, ref inferencev1al
 		return nil, false
 	}
 
-	config := providerInfo.config
-	if len(ref.Config) > 0 {
-		config = mergeConfig(providerInfo.config, ref.Config)
-	}
+	config := mergeConfig(providerInfo.config, ref.Config)
 
 	secretName := providerInfo.secretName
 	secretNamespace := providerInfo.secretNamespace

--- a/pkg/plugins/model-provider-resolver/external_model_reconciler.go
+++ b/pkg/plugins/model-provider-resolver/external_model_reconciler.go
@@ -19,64 +19,97 @@ package model_provider_resolver
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
+
+	inferencev1alpha1 "github.com/opendatahub-io/ai-gateway-payload-processing/api/inference/v1alpha1"
 )
 
-// externalModelGVK is the GroupVersionKind for ExternalModel CRD.
-var externalModelGVK = schema.GroupVersionKind{
-	Group:   "maas.opendatahub.io",
-	Version: "v1alpha1",
-	Kind:    "ExternalModel",
-}
+const providerRequeueDelay = 5 * time.Second
 
-// externalModelReconciler watches ExternalModel CRDs (via unstructured client)
-// and updates the model store with provider and credential information.
+// externalModelReconciler watches inference.opendatahub.io ExternalModel CRDs
+// and resolves provider info from the provider store.
 type externalModelReconciler struct {
 	client.Reader
 	store *infoStore
 }
 
-// Reconcile handles create/update/delete events for ExternalModel resources.
-// The ExternalModel CR name is used as the model key in the store, matching
-// the model name in inference request bodies.
 func (r *externalModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx).V(logutil.DEFAULT)
 	logger.Info("reconciling ExternalModel", "name", req.Name, "namespace", req.Namespace)
 
-	obj := &unstructured.Unstructured{}
-	obj.SetGroupVersionKind(externalModelGVK)
-
-	err := r.Get(ctx, req.NamespacedName, obj)
+	model := &inferencev1alpha1.ExternalModel{}
+	err := r.Get(ctx, req.NamespacedName, model)
 	if err != nil && !errors.IsNotFound(err) {
 		return ctrl.Result{}, fmt.Errorf("unable to get ExternalModel: %w", err)
 	}
 
-	if errors.IsNotFound(err) || !obj.GetDeletionTimestamp().IsZero() {
+	if errors.IsNotFound(err) || !model.GetDeletionTimestamp().IsZero() {
 		r.store.deleteModel(req.NamespacedName)
 		logger.Info("ExternalModel removed from store", "name", req.Name, "namespace", req.Namespace)
 		return ctrl.Result{}, nil
 	}
 
-	provider, _, _ := unstructured.NestedString(obj.Object, "spec", "provider")
-	targetModel, _, _ := unstructured.NestedString(obj.Object, "spec", "targetModel")
-	credsName, _, _ := unstructured.NestedString(obj.Object, "spec", "credentialRef", "name")
-
-	// targetModel is the model that will be used in the request body when getting inference requests.
-	info := &externalModelInfo{
-		provider:        provider,
-		targetModel:     targetModel,
-		secretName:      credsName,
-		secretNamespace: req.Namespace, // secret namespace is always the namespace of the ExternalModel
+	// Use the first ref whose provider is available in the store.
+	for _, ref := range model.Spec.ExternalProviderRefs {
+		info, found := r.resolveRef(req.Namespace, ref)
+		if !found {
+			continue
+		}
+		r.store.addOrUpdateModel(req.NamespacedName, info)
+		logger.Info("updated model store", "provider", info.provider, "targetModel", info.targetModel)
+		return ctrl.Result{}, nil
 	}
-	r.store.addOrUpdateModel(req.NamespacedName, info)
 
-	logger.Info("updated model store", "provider", provider, "targetModel", targetModel)
-	return ctrl.Result{}, nil
+	logger.Info("no ExternalProvider available for any ref, requeuing")
+	return ctrl.Result{RequeueAfter: providerRequeueDelay}, nil
 }
+
+// resolveRef resolves a single ExternalProviderRef to model info.
+// Returns (nil, false) if the provider is not yet available in the store.
+func (r *externalModelReconciler) resolveRef(namespace string, ref inferencev1alpha1.ExternalProviderRef) (*externalModelInfo, bool) {
+	providerKey := types.NamespacedName{Namespace: namespace, Name: ref.Ref.Name}
+	providerInfo, found := r.store.getProvider(providerKey)
+	if !found {
+		return nil, false
+	}
+
+	config := providerInfo.config
+	if len(ref.Config) > 0 {
+		config = mergeConfig(providerInfo.config, ref.Config)
+	}
+
+	secretName := providerInfo.secretName
+	secretNamespace := providerInfo.secretNamespace
+	if ref.Auth != nil {
+		secretName = ref.Auth.SecretRef.Name
+		secretNamespace = namespace
+	}
+
+	return &externalModelInfo{
+		provider:        providerInfo.provider,
+		targetModel:     ref.TargetModel,
+		secretName:      secretName,
+		secretNamespace: secretNamespace,
+		config:          config,
+	}, true
+}
+
+// mergeConfig copies provider config and applies model overrides.
+func mergeConfig(providerConfig, modelConfig map[string]string) map[string]string {
+	merged := make(map[string]string, len(providerConfig))
+	for k, v := range providerConfig {
+		merged[k] = v
+	}
+	for k, v := range modelConfig {
+		merged[k] = v
+	}
+	return merged
+}
+

--- a/pkg/plugins/model-provider-resolver/plugin.go
+++ b/pkg/plugins/model-provider-resolver/plugin.go
@@ -22,16 +22,19 @@ import (
 	"fmt"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
 	errcommon "sigs.k8s.io/gateway-api-inference-extension/pkg/common/error"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 
+	inferencev1alpha1 "github.com/opendatahub-io/ai-gateway-payload-processing/api/inference/v1alpha1"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/state"
 )
 
@@ -39,10 +42,9 @@ const (
 	ModelProviderResolverPluginType = "model-provider-resolver"
 )
 
-// compile-time type validation
 var _ framework.RequestProcessor = &ModelProviderResolverPlugin{}
 
-// ModelProviderResolverFactory defines the factory function for ModelProviderResolverPlugin
+// ModelProviderResolverFactory defines the factory function for ModelProviderResolverPlugin.
 func ModelProviderResolverFactory(name string, _ json.RawMessage, handle framework.Handle) (framework.BBRPlugin, error) {
 	plugin, err := NewModelProviderResolver(handle.ReconcilerBuilder, handle.Client())
 	if err != nil {
@@ -52,24 +54,52 @@ func ModelProviderResolverFactory(name string, _ json.RawMessage, handle framewo
 	return plugin.WithName(name), nil
 }
 
-func NewModelProviderResolver(reconcilerBuilder func() *builder.Builder, clientReader client.Reader) (*ModelProviderResolverPlugin, error) {
+// NewModelProviderResolver registers store reconcilers for inference.opendatahub.io
+// ExternalProvider and ExternalModel CRDs.
+func NewModelProviderResolver(reconcilerBuilder func() *builder.Builder, k8sClient client.Client) (*ModelProviderResolverPlugin, error) {
+	utilruntime.Must(inferencev1alpha1.AddToScheme(k8sClient.Scheme()))
 	store := newInfoStore()
-	reconciler := &externalModelReconciler{
-		Reader: clientReader,
-		store:  store,
+
+	// Watch ExternalProvider CRDs (inference.opendatahub.io) using typed client
+	providerReconciler := &externalProviderReconciler{Reader: k8sClient, store: store}
+	if err := reconcilerBuilder().For(&inferencev1alpha1.ExternalProvider{}).Complete(providerReconciler); err != nil {
+		return nil, fmt.Errorf("failed to register ExternalProvider reconciler for plugin '%s' - %w", ModelProviderResolverPluginType, err)
 	}
 
-	// Watch ExternalModel CRDs directly (no MaaS dependency)
-	obj := &unstructured.Unstructured{}
-	obj.SetGroupVersionKind(externalModelGVK)
-
-	if err := reconcilerBuilder().For(obj).Complete(reconciler); err != nil {
+	// Watch ExternalModel CRDs (inference.opendatahub.io) using typed client.
+	// Cross-watch ExternalProviders so credential/endpoint changes propagate.
+	modelReconciler := &externalModelReconciler{Reader: k8sClient, store: store}
+	mapProviderToModels := func(ctx context.Context, obj client.Object) []reconcile.Request {
+		provider := obj.(*inferencev1alpha1.ExternalProvider)
+		modelList := &inferencev1alpha1.ExternalModelList{}
+		if err := k8sClient.List(ctx, modelList, client.InNamespace(provider.Namespace)); err != nil {
+			log.FromContext(ctx).Error(err, "failed to list ExternalModels for provider mapping",
+				"provider", provider.Name, "namespace", provider.Namespace)
+			return nil
+		}
+		var requests []reconcile.Request
+		for i := range modelList.Items {
+			for _, ref := range modelList.Items[i].Spec.ExternalProviderRefs {
+				if ref.Ref.Name == provider.Name {
+					requests = append(requests, reconcile.Request{
+						NamespacedName: types.NamespacedName{Name: modelList.Items[i].Name, Namespace: modelList.Items[i].Namespace},
+					})
+				}
+			}
+		}
+		return requests
+	}
+	if err := reconcilerBuilder().
+		For(&inferencev1alpha1.ExternalModel{}).
+		Named("inference-externalmodel").
+		Watches(&inferencev1alpha1.ExternalProvider{}, handler.EnqueueRequestsFromMapFunc(mapProviderToModels)).
+		Complete(modelReconciler); err != nil {
 		return nil, fmt.Errorf("failed to register ExternalModel reconciler for plugin '%s' - %w", ModelProviderResolverPluginType, err)
 	}
 
 	return &ModelProviderResolverPlugin{
-		typedName:      plugin.TypedName{Type: ModelProviderResolverPluginType, Name: ModelProviderResolverPluginType},
-		store: store,
+		typedName: plugin.TypedName{Type: ModelProviderResolverPluginType, Name: ModelProviderResolverPluginType},
+		store:     store,
 	}, nil
 }
 
@@ -77,14 +107,12 @@ func NewModelProviderResolver(reconcilerBuilder func() *builder.Builder, clientR
 // It writes the model, provider and credential reference to CycleState for downstream plugins
 // (api-translation, api-key-injection).
 type ModelProviderResolverPlugin struct {
-	typedName      plugin.TypedName
-	store *infoStore
+	typedName plugin.TypedName
+	store     *infoStore
 }
 
 // TypedName returns the type and name tuple of this plugin instance.
-func (p *ModelProviderResolverPlugin) TypedName() plugin.TypedName {
-	return p.typedName
-}
+func (p *ModelProviderResolverPlugin) TypedName() plugin.TypedName { return p.typedName }
 
 // WithName sets the name of the plugin instance.
 func (p *ModelProviderResolverPlugin) WithName(name string) *ModelProviderResolverPlugin {
@@ -93,14 +121,14 @@ func (p *ModelProviderResolverPlugin) WithName(name string) *ModelProviderResolv
 }
 
 // ProcessRequest reads the model name from the request body, resolves the provider
-// from the modelInfoStore (populated by ExternalModel reconciler), and writes model, provider
+// from the store (populated by ExternalModel reconciler), and writes model, provider
 // and credential reference info to CycleState.
 func (p *ModelProviderResolverPlugin) ProcessRequest(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceRequest) error {
 	logger := log.FromContext(ctx).V(logutil.DEFAULT)
 
 	model, ok := request.Body["model"].(string)
 	if !ok || model == "" {
-		return nil // not an inference request (e.g. API key management, model listing)
+		return nil
 	}
 
 	log.FromContext(ctx).V(logutil.VERBOSE).Info("received incoming request", "path", request.Headers[":path"])
@@ -116,26 +144,27 @@ func (p *ModelProviderResolverPlugin) ProcessRequest(ctx context.Context, cycleS
 	log.FromContext(ctx).V(logutil.VERBOSE).Info("exported namespaced name from path", "key", modelKey)
 
 	externalModelInfo, found := p.store.getModel(modelKey)
-	if !found { // info is stored only for external models
-		return nil // this is not considered an error, we just need to skip if it's internal model
+	if !found {
+		return nil
 	}
 
-	if !strings.HasSuffix(relativePath, "chat/completions") { // no support for other input types
+	if !strings.HasSuffix(relativePath, "chat/completions") {
 		logger.Error(nil, "unsupported route for external model", "model", modelKey.String(), "path", relativePath)
 		return errcommon.Error{Code: errcommon.BadRequest, Msg: "only /chat/completions input type is supported"}
 	}
 
-	// if there's a mismatch it's an error, we don't want to proceed
 	if externalModelInfo.targetModel != model {
 		logger.Error(nil, "model mismatch between request body and ExternalModel", "requestModel", model, "externalModel", externalModelInfo.targetModel)
 		return errcommon.Error{Code: errcommon.NotFound, Msg: fmt.Sprintf("model in request body '%s' doesn't match ExternalModel", model)}
 	}
 
-	// info of external model written to cycle state for next plugins
 	cycleState.Write(state.ProviderKey, externalModelInfo.provider)
 	cycleState.Write(state.ModelKey, externalModelInfo.targetModel)
 	cycleState.Write(state.CredsRefName, externalModelInfo.secretName)
 	cycleState.Write(state.CredsRefNamespace, externalModelInfo.secretNamespace)
+	if len(externalModelInfo.config) > 0 {
+		cycleState.Write(state.ModelConfigKey, externalModelInfo.config)
+	}
 
 	logger.Info("external model resolved", "model", modelKey.String(), "provider", externalModelInfo.provider)
 	return nil
@@ -143,10 +172,8 @@ func (p *ModelProviderResolverPlugin) ProcessRequest(ctx context.Context, cycleS
 
 func sanitizePath(relativeUrlPath string) string {
 	relativeUrlPath = strings.TrimSpace(relativeUrlPath)
-
 	if index := strings.IndexByte(relativeUrlPath, '?'); index >= 0 {
-		relativeUrlPath = relativeUrlPath[:index] // remove query params
+		relativeUrlPath = relativeUrlPath[:index]
 	}
-
 	return strings.Trim(relativeUrlPath, "/")
 }

--- a/pkg/plugins/model-provider-resolver/plugin.go
+++ b/pkg/plugins/model-provider-resolver/plugin.go
@@ -128,7 +128,7 @@ func (p *ModelProviderResolverPlugin) ProcessRequest(ctx context.Context, cycleS
 
 	model, ok := request.Body["model"].(string)
 	if !ok || model == "" {
-		return nil
+		return nil // not an inference request (e.g. API key management, model listing)
 	}
 
 	log.FromContext(ctx).V(logutil.VERBOSE).Info("received incoming request", "path", request.Headers[":path"])
@@ -145,7 +145,7 @@ func (p *ModelProviderResolverPlugin) ProcessRequest(ctx context.Context, cycleS
 
 	externalModelInfo, found := p.store.getModel(modelKey)
 	if !found {
-		return nil
+		return nil // not an external model — pass through for internal models
 	}
 
 	if !strings.HasSuffix(relativePath, "chat/completions") {
@@ -153,11 +153,13 @@ func (p *ModelProviderResolverPlugin) ProcessRequest(ctx context.Context, cycleS
 		return errcommon.Error{Code: errcommon.BadRequest, Msg: "only /chat/completions input type is supported"}
 	}
 
+	// model in request body must match the ExternalModel's targetModel
 	if externalModelInfo.targetModel != model {
 		logger.Error(nil, "model mismatch between request body and ExternalModel", "requestModel", model, "externalModel", externalModelInfo.targetModel)
 		return errcommon.Error{Code: errcommon.NotFound, Msg: fmt.Sprintf("model in request body '%s' doesn't match ExternalModel", model)}
 	}
 
+	// write resolved info to CycleState for downstream plugins (api-translation, apikey-injection)
 	cycleState.Write(state.ProviderKey, externalModelInfo.provider)
 	cycleState.Write(state.ModelKey, externalModelInfo.targetModel)
 	cycleState.Write(state.CredsRefName, externalModelInfo.secretName)

--- a/pkg/plugins/model-provider-resolver/store.go
+++ b/pkg/plugins/model-provider-resolver/store.go
@@ -37,6 +37,7 @@ type externalModelInfo struct {
 	targetModel     string
 	secretName      string
 	secretNamespace string
+	config          map[string]string
 }
 
 // infoStore is a thread-safe in-memory store for both provider and model info.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -56,20 +56,36 @@ stringData:
   api-key: %s
 `, p.Name, nsName, p.SimulatorKey))
 
-	// ExternalModel CR
+	// ExternalProvider CR
 	kubectlApplyLiteral(fmt.Sprintf(`
-apiVersion: maas.opendatahub.io/v1alpha1
-kind: ExternalModel
+apiVersion: inference.opendatahub.io/v1alpha1
+kind: ExternalProvider
 metadata:
   name: %s
   namespace: %s
 spec:
   provider: %s
-  targetModel: %s
   endpoint: %s
-  credentialRef:
-    name: %s
-`, p.Name, nsName, p.Provider, p.Name, simulatorEP, p.Name))
+  auth:
+    type: simple
+    secretRef:
+      name: %s
+`, p.Name, nsName, p.Provider, simulatorEP, p.Name))
+
+	// ExternalModel CR
+	kubectlApplyLiteral(fmt.Sprintf(`
+apiVersion: inference.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  externalProviderRefs:
+    - ref:
+        name: %s
+      targetModel: %s
+      apiFormat: %s
+`, p.Name, nsName, p.Name, p.Name, p.Provider))
 
 	// ExternalName Service pointing to simulator
 	kubectlApplyLiteral(fmt.Sprintf(`
@@ -124,7 +140,8 @@ spec:
 func deleteProviderResources(p Provider) {
 	kubectlDeleteResource("httproute", p.Name, nsName)
 	kubectlDeleteResource("service", p.Name, nsName)
-	kubectlDeleteResource("externalmodel", p.Name, nsName)
+	kubectlDeleteResource("externalmodels.inference.opendatahub.io", p.Name, nsName)
+	kubectlDeleteResource("externalproviders.inference.opendatahub.io", p.Name, nsName)
 	kubectlDeleteResource("secret", p.Name, nsName)
 }
 


### PR DESCRIPTION
## Summary

Depends on #285. Updates the model-provider-resolver plugin to use typed clients for `inference.opendatahub.io` ExternalModels with provider cross-watch, plus legacy backward compatibility for `maas.opendatahub.io`.

**4 files changed, 121 insertions, 46 deletions.**

## What this does

- Typed ExternalModel reconciler cross-references provider store for credential/config resolution
- Cross-watch: ExternalProvider changes trigger re-reconciliation of dependent models
- Legacy `maas.opendatahub.io` ExternalModel reconciler (unstructured, backward compat)
- `ModelConfigKey` for config propagation via CycleState
- Scheme registration in factory for typed client support
- Registers all three reconcilers (provider, model, legacy) in the plugin

## Test plan

- [x] Unit tests pass, lint clean (0 issues)

## Risk analysis

- **Risk rating**: 2
- **Why**: Modifies existing plugin.go (factory + reconciler registration). The legacy reconciler ensures backward compatibility with existing E2E tests that use maas.opendatahub.io CRDs.

Depends on: #285
cc @nirrozenbaum

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Store per-model configuration merged from providers and per-model overrides.

* **Improvements**
  * Reconciliation now uses typed provider/model APIs for more reliable provider discovery and credential handling.
  * Request validation tightened: only chat/completions paths accepted and incoming request model must match the target model.
  * Added a state key to persist resolved model configuration.

* **Refactor**
  * Resolver initialization rewritten to use a shared in-memory store and propagate provider changes to affected models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->