### PR TITLE
fix(ci): remove broken pathChanged filter from push pipeline CEL expressions

### DIFF
--- a/.tekton/ai-gateway-payload-processing-e2e-ci-on-push.yaml
+++ b/.tekton/ai-gateway-payload-processing-e2e-ci-on-push.yaml
@@ -7,11 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push"
-      && target_branch == "main"
-      && ( "./**".pathChanged()
-            || ".tekton/ai-gateway-payload-processing-e2e-ci-on-push.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds

--- a/.tekton/odh-ai-gateway-payload-processing-ci-on-push.yaml
+++ b/.tekton/odh-ai-gateway-payload-processing-ci-on-push.yaml
@@ -7,11 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push"
-      && target_branch == "main"
-      && ( "./**".pathChanged()
-            || ".tekton/odh-ai-gateway-payload-processing-ci-on-push.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds


### PR DESCRIPTION
## Summary
Both Konflux push pipelines (`odh-ai-gateway-payload-processing-ci-on-push` and `ai-gateway-payload-processing-e2e-ci-on-push`) have not been firing since late April due to a broken `pathChanged()` glob in the CEL trigger expression.

## Description
The `"./**".pathChanged()` glob does not match GitHub push event file paths, which are reported without a `./` prefix (e.g. `Dockerfile`, not `./Dockerfile`). This causes the CEL expression to evaluate to `false` on every push to main — unless the `.tekton/*.yaml` file itself was modified (which satisfies the fallback OR branch).

- This bug was originally fixed in 672bb70 (Apr 3) by removing the `pathChanged()` filter.
- The automated Tekton pipeline sync (bbd0080, Apr 24) re-introduced the broken pattern from the central template.
- Since April 29 (last commit that touched a push pipeline YAML), **neither** push pipeline has triggered — the `odh-stable` images on quay.io are stale.

This PR simplifies the CEL expression to `event == "push" && target_branch == "main"`, matching the pattern used in `opendatahub-io/models-as-a-service`.

**Files changed:**
- `.tekton/ai-gateway-payload-processing-e2e-ci-on-push.yaml`
- `.tekton/odh-ai-gateway-payload-processing-ci-on-push.yaml`

## How it was tested
- Verified via GitHub check-run API that push pipelines fired on commits before the `pathChanged()` filter was added (e.g. `f069836`, `89499fc`) and stopped firing on all commits after April 29.
- Confirmed the PR pipeline variants (`-on-pull-request`) are unaffected and continue to pass.
- The same fix was previously validated in production (672bb70, April 3).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Simplified CI/CD pipeline trigger expressions in Tekton configurations to improve maintainability and consistency in pipeline execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->