### PR TITLE
refactor: unify store into single infoStore with explicit function names

### DIFF
--- a/pkg/plugins/model-provider-resolver/external_model_reconciler.go
+++ b/pkg/plugins/model-provider-resolver/external_model_reconciler.go
@@ -40,7 +40,7 @@ var externalModelGVK = schema.GroupVersionKind{
 // and updates the model store with provider and credential information.
 type externalModelReconciler struct {
 	client.Reader
-	store *modelInfoStore
+	store *infoStore
 }
 
 // Reconcile handles create/update/delete events for ExternalModel resources.
@@ -59,7 +59,7 @@ func (r *externalModelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	if errors.IsNotFound(err) || !obj.GetDeletionTimestamp().IsZero() {
-		r.store.deleteExternalModel(req.NamespacedName)
+		r.store.deleteModel(req.NamespacedName)
 		logger.Info("ExternalModel removed from store", "name", req.Name, "namespace", req.Namespace)
 		return ctrl.Result{}, nil
 	}
@@ -75,7 +75,7 @@ func (r *externalModelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		secretName:      credsName,
 		secretNamespace: req.Namespace, // secret namespace is always the namespace of the ExternalModel
 	}
-	r.store.addOrUpdateExternalModel(req.NamespacedName, info)
+	r.store.addOrUpdateModel(req.NamespacedName, info)
 
 	logger.Info("updated model store", "provider", provider, "targetModel", targetModel)
 	return ctrl.Result{}, nil

--- a/pkg/plugins/model-provider-resolver/external_provider_reconciler.go
+++ b/pkg/plugins/model-provider-resolver/external_provider_reconciler.go
@@ -31,7 +31,7 @@ import (
 
 type externalProviderReconciler struct {
 	client.Reader
-	store *providerInfoStore
+	store *infoStore
 }
 
 func (r *externalProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -45,12 +45,12 @@ func (r *externalProviderReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	if errors.IsNotFound(err) || !provider.GetDeletionTimestamp().IsZero() {
-		r.store.delete(req.NamespacedName)
+		r.store.deleteProvider(req.NamespacedName)
 		logger.Info("ExternalProvider removed from store", "name", req.Name, "namespace", req.Namespace)
 		return ctrl.Result{}, nil
 	}
 
-	r.store.addOrUpdate(req.NamespacedName, &providerInfo{
+	r.store.addOrUpdateProvider(req.NamespacedName, &providerInfo{
 		provider:        provider.Spec.Provider,
 		endpoint:        provider.Spec.Endpoint,
 		secretName:      provider.Spec.Auth.SecretRef.Name,

--- a/pkg/plugins/model-provider-resolver/external_provider_reconciler_test.go
+++ b/pkg/plugins/model-provider-resolver/external_provider_reconciler_test.go
@@ -61,14 +61,14 @@ func TestProviderReconciler_ValidCR(t *testing.T) {
 			},
 		},
 	}}
-	store := newProviderInfoStore()
+	store := newInfoStore()
 	r := &externalProviderReconciler{Reader: reader, store: store}
 
 	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 	require.NoError(t, err)
 	assert.Equal(t, ctrl.Result{}, result)
 
-	info, found := store.get(key)
+	info, found := store.getProvider(key)
 	require.True(t, found)
 	assert.Equal(t, "openai", info.provider)
 	assert.Equal(t, "api.openai.com", info.endpoint)
@@ -80,8 +80,8 @@ func TestProviderReconciler_DeletedCR(t *testing.T) {
 	key := types.NamespacedName{Namespace: "models", Name: "deleted"}
 	reader := &mockProviderReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalProvider{}}
 
-	store := newProviderInfoStore()
-	store.addOrUpdate(key, &providerInfo{provider: "openai", endpoint: "api.openai.com"})
+	store := newInfoStore()
+	store.addOrUpdateProvider(key, &providerInfo{provider: "openai", endpoint: "api.openai.com"})
 
 	r := &externalProviderReconciler{Reader: reader, store: store}
 
@@ -89,7 +89,7 @@ func TestProviderReconciler_DeletedCR(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, ctrl.Result{}, result)
 
-	_, found := store.get(key)
+	_, found := store.getProvider(key)
 	assert.False(t, found, "store entry should be removed on delete")
 }
 
@@ -106,14 +106,14 @@ func TestProviderReconciler_WithConfig(t *testing.T) {
 			},
 		},
 	}}
-	store := newProviderInfoStore()
+	store := newInfoStore()
 	r := &externalProviderReconciler{Reader: reader, store: store}
 
 	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
 	require.NoError(t, err)
 	assert.Equal(t, ctrl.Result{}, result)
 
-	info, found := store.get(key)
+	info, found := store.getProvider(key)
 	require.True(t, found)
 	assert.Equal(t, "my-project", info.config["project"])
 	assert.Equal(t, "us-central1", info.config["location"])

--- a/pkg/plugins/model-provider-resolver/model_store_test.go
+++ b/pkg/plugins/model-provider-resolver/model_store_test.go
@@ -26,48 +26,48 @@ import (
 )
 
 func TestModelStore_AddAndGetExternalModel(t *testing.T) {
-	store := newModelInfoStore()
+	store := newInfoStore()
 	key := types.NamespacedName{Namespace: "ns", Name: "external-model"}
 
-	store.addOrUpdateExternalModel(key, &externalModelInfo{provider: provider.Anthropic})
+	store.addOrUpdateModel(key, &externalModelInfo{provider: provider.Anthropic})
 
-	info, found := store.getModelInfo(key)
+	info, found := store.getModel(key)
 	assert.True(t, found)
 	assert.NotNil(t, info)
 	assert.Equal(t, provider.Anthropic, info.provider)
 }
 
 func TestModelStore_GetModelInfo_NotFound(t *testing.T) {
-	store := newModelInfoStore()
-	store.addOrUpdateExternalModel(
+	store := newInfoStore()
+	store.addOrUpdateModel(
 		types.NamespacedName{Namespace: "ns", Name: "ext"},
 		&externalModelInfo{provider: provider.OpenAI},
 	)
 
-	_, found := store.getModelInfo(types.NamespacedName{Namespace: "ns", Name: "other"})
+	_, found := store.getModel(types.NamespacedName{Namespace: "ns", Name: "other"})
 	assert.False(t, found)
 }
 
 func TestModelStore_DeleteExternalModel(t *testing.T) {
-	store := newModelInfoStore()
+	store := newInfoStore()
 	key := types.NamespacedName{Namespace: "ns", Name: "ext"}
-	store.addOrUpdateExternalModel(key, &externalModelInfo{provider: provider.OpenAI})
+	store.addOrUpdateModel(key, &externalModelInfo{provider: provider.OpenAI})
 
-	_, foundBefore := store.getModelInfo(key)
+	_, foundBefore := store.getModel(key)
 	assert.True(t, foundBefore)
 
-	store.deleteExternalModel(key)
-	_, foundAfter := store.getModelInfo(key)
+	store.deleteModel(key)
+	_, foundAfter := store.getModel(key)
 	assert.False(t, foundAfter)
 }
 
 func TestModelStore_CrossNamespaceIsolation(t *testing.T) {
-	store := newModelInfoStore()
-	store.addOrUpdateExternalModel(
+	store := newInfoStore()
+	store.addOrUpdateModel(
 		types.NamespacedName{Namespace: "ns-a", Name: "shared-model"},
 		&externalModelInfo{provider: provider.OpenAI},
 	)
 
-	_, found := store.getModelInfo(types.NamespacedName{Namespace: "ns-b", Name: "shared-model"})
+	_, found := store.getModel(types.NamespacedName{Namespace: "ns-b", Name: "shared-model"})
 	assert.False(t, found)
 }

--- a/pkg/plugins/model-provider-resolver/plugin.go
+++ b/pkg/plugins/model-provider-resolver/plugin.go
@@ -53,10 +53,10 @@ func ModelProviderResolverFactory(name string, _ json.RawMessage, handle framewo
 }
 
 func NewModelProviderResolver(reconcilerBuilder func() *builder.Builder, clientReader client.Reader) (*ModelProviderResolverPlugin, error) {
-	modelInfoStore := newModelInfoStore()
+	store := newInfoStore()
 	reconciler := &externalModelReconciler{
 		Reader: clientReader,
-		store:  modelInfoStore,
+		store:  store,
 	}
 
 	// Watch ExternalModel CRDs directly (no MaaS dependency)
@@ -69,7 +69,7 @@ func NewModelProviderResolver(reconcilerBuilder func() *builder.Builder, clientR
 
 	return &ModelProviderResolverPlugin{
 		typedName:      plugin.TypedName{Type: ModelProviderResolverPluginType, Name: ModelProviderResolverPluginType},
-		modelInfoStore: modelInfoStore,
+		store: store,
 	}, nil
 }
 
@@ -78,7 +78,7 @@ func NewModelProviderResolver(reconcilerBuilder func() *builder.Builder, clientR
 // (api-translation, api-key-injection).
 type ModelProviderResolverPlugin struct {
 	typedName      plugin.TypedName
-	modelInfoStore *modelInfoStore
+	store *infoStore
 }
 
 // TypedName returns the type and name tuple of this plugin instance.
@@ -115,7 +115,7 @@ func (p *ModelProviderResolverPlugin) ProcessRequest(ctx context.Context, cycleS
 	modelKey := types.NamespacedName{Namespace: segments[0], Name: segments[1]}
 	log.FromContext(ctx).V(logutil.VERBOSE).Info("exported namespaced name from path", "key", modelKey)
 
-	externalModelInfo, found := p.modelInfoStore.getModelInfo(modelKey)
+	externalModelInfo, found := p.store.getModel(modelKey)
 	if !found { // info is stored only for external models
 		return nil // this is not considered an error, we just need to skip if it's internal model
 	}

--- a/pkg/plugins/model-provider-resolver/plugin_test.go
+++ b/pkg/plugins/model-provider-resolver/plugin_test.go
@@ -29,14 +29,14 @@ import (
 )
 
 func TestProcessRequest_ModelResolved(t *testing.T) {
-	store := newModelInfoStore()
+	store := newInfoStore()
 	const (
 		extNS       = "llm"
 		extName     = "claude-sonnet"
 		targetModel = "claude-sonnet-1234"
 		credName    = "anthropic-key"
 	)
-	store.addOrUpdateExternalModel(
+	store.addOrUpdateModel(
 		types.NamespacedName{Namespace: extNS, Name: extName},
 		&externalModelInfo{
 			provider:        provider.Anthropic,
@@ -46,7 +46,7 @@ func TestProcessRequest_ModelResolved(t *testing.T) {
 		},
 	)
 
-	plugin := &ModelProviderResolverPlugin{modelInfoStore: store}
+	plugin := &ModelProviderResolverPlugin{store: store}
 	cs := framework.NewCycleState()
 	req := framework.NewInferenceRequest()
 	req.Headers[":path"] = "/" + extNS + "/" + extName + "/v1/chat/completions"
@@ -74,8 +74,8 @@ func TestProcessRequest_ModelResolved(t *testing.T) {
 }
 
 func TestProcessRequest_ModelNotFound(t *testing.T) {
-	store := newModelInfoStore()
-	p := &ModelProviderResolverPlugin{modelInfoStore: store}
+	store := newInfoStore()
+	p := &ModelProviderResolverPlugin{store: store}
 	cs := framework.NewCycleState()
 	req := framework.NewInferenceRequest()
 	req.Headers[":path"] = "/model-ns/model-name/v1/chat/completions"
@@ -89,8 +89,8 @@ func TestProcessRequest_ModelNotFound(t *testing.T) {
 }
 
 func TestProcessRequest_NoModel(t *testing.T) {
-	store := newModelInfoStore()
-	p := &ModelProviderResolverPlugin{modelInfoStore: store}
+	store := newInfoStore()
+	p := &ModelProviderResolverPlugin{store: store}
 	cs := framework.NewCycleState()
 
 	err := p.ProcessRequest(context.Background(), cs, framework.NewInferenceRequest())
@@ -104,12 +104,12 @@ func TestProcessRequest_NoModel(t *testing.T) {
 }
 
 func TestProcessRequest_BadPath(t *testing.T) {
-	store := newModelInfoStore()
-	store.addOrUpdateExternalModel(
+	store := newInfoStore()
+	store.addOrUpdateModel(
 		types.NamespacedName{Namespace: "llm", Name: "ext"},
 		&externalModelInfo{provider: provider.OpenAI, targetModel: "gpt-4o", secretName: "k", secretNamespace: "llm"},
 	)
-	p := &ModelProviderResolverPlugin{modelInfoStore: store}
+	p := &ModelProviderResolverPlugin{store: store}
 	cs := framework.NewCycleState()
 	req := framework.NewInferenceRequest()
 	req.Headers[":path"] = "/incomplete"

--- a/pkg/plugins/model-provider-resolver/store.go
+++ b/pkg/plugins/model-provider-resolver/store.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+// providerInfo holds cached ExternalProvider state.
 type providerInfo struct {
 	provider        string
 	endpoint        string
@@ -30,94 +31,85 @@ type providerInfo struct {
 	config          map[string]string
 }
 
-type providerInfoStore struct {
+// externalModelInfo holds the provider and secret name/namespace for an external model.
+type externalModelInfo struct {
+	provider        string
+	targetModel     string
+	secretName      string
+	secretNamespace string
+}
+
+// infoStore is a thread-safe in-memory store for both provider and model info.
+// The reconcilers write to it; the plugin reads from it during request processing.
+type infoStore struct {
 	providers map[string]*providerInfo
+	models    map[string]map[string]*externalModelInfo // namespace -> name -> info
 	lock      sync.RWMutex
 }
 
-func newProviderInfoStore() *providerInfoStore {
-	return &providerInfoStore{
+func newInfoStore() *infoStore {
+	return &infoStore{
 		providers: make(map[string]*providerInfo),
+		models:    make(map[string]map[string]*externalModelInfo),
 	}
 }
 
-func (s *providerInfoStore) addOrUpdate(key types.NamespacedName, info *providerInfo) {
+// addOrUpdateProvider stores ExternalProvider information.
+func (s *infoStore) addOrUpdateProvider(key types.NamespacedName, info *providerInfo) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	s.providers[key.String()] = info
 }
 
-func (s *providerInfoStore) delete(key types.NamespacedName) {
+// deleteProvider removes ExternalProvider information.
+func (s *infoStore) deleteProvider(key types.NamespacedName) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	delete(s.providers, key.String())
 }
 
-func (s *providerInfoStore) get(key types.NamespacedName) (*providerInfo, bool) {
+// getProvider returns provider info if found.
+func (s *infoStore) getProvider(key types.NamespacedName) (*providerInfo, bool) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	info, ok := s.providers[key.String()]
 	return info, ok
 }
 
-// externalModelInfo holds the provider and secret name/namespace for an external model.
-type externalModelInfo struct {
-	provider        string
-	targetModel     string // this is the name of the model that will be used in the request
-	secretName      string
-	secretNamespace string
-}
-
-// modelInfoStore is a thread-safe in-memory store that maps model names to their provider info.
-// The reconciler writes to it; the plugin reads from it during request processing.
-type modelInfoStore struct {
-	// externalModelToModelInfo maps namespace -> external model name -> externalModelInfo.
-	externalModelToModelInfo map[string]map[string]*externalModelInfo
-
-	lock sync.RWMutex
-}
-
-func newModelInfoStore() *modelInfoStore {
-	return &modelInfoStore{
-		externalModelToModelInfo: make(map[string]map[string]*externalModelInfo),
-	}
-}
-
-func (s *modelInfoStore) addOrUpdateExternalModel(externalModelKey types.NamespacedName, modelInfo *externalModelInfo) {
+// addOrUpdateModel stores ExternalModel information.
+func (s *infoStore) addOrUpdateModel(key types.NamespacedName, info *externalModelInfo) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	if _, found := s.externalModelToModelInfo[externalModelKey.Namespace]; !found {
-		s.externalModelToModelInfo[externalModelKey.Namespace] = make(map[string]*externalModelInfo)
+	if _, found := s.models[key.Namespace]; !found {
+		s.models[key.Namespace] = make(map[string]*externalModelInfo)
 	}
-	s.externalModelToModelInfo[externalModelKey.Namespace][externalModelKey.Name] = modelInfo
+	s.models[key.Namespace][key.Name] = info
 }
 
-func (s *modelInfoStore) deleteExternalModel(externalModelKey types.NamespacedName) {
+// deleteModel removes ExternalModel information.
+func (s *infoStore) deleteModel(key types.NamespacedName) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	modelsByNamespace, found := s.externalModelToModelInfo[externalModelKey.Namespace]
+	modelsByNamespace, found := s.models[key.Namespace]
 	if !found {
 		return
 	}
-	delete(modelsByNamespace, externalModelKey.Name)
+	delete(modelsByNamespace, key.Name)
 	if len(modelsByNamespace) == 0 {
-		delete(s.externalModelToModelInfo, externalModelKey.Namespace)
+		delete(s.models, key.Namespace)
 	}
 }
 
-func (s *modelInfoStore) getModelInfo(externalModelKey types.NamespacedName) (*externalModelInfo, bool) {
+// getModel returns model info if found.
+func (s *infoStore) getModel(key types.NamespacedName) (*externalModelInfo, bool) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
-	modelsByNamespace, found := s.externalModelToModelInfo[externalModelKey.Namespace]
+	modelsByNamespace, found := s.models[key.Namespace]
 	if !found {
 		return nil, false
 	}
 
-	externalModelInfo, ok := modelsByNamespace[externalModelKey.Name]
-	if !ok {
-		return nil, false
-	}
-
-	return externalModelInfo, true
+	info, ok := modelsByNamespace[key.Name]
+	return info, ok
 }

--- a/pkg/plugins/model-provider-resolver/store_test.go
+++ b/pkg/plugins/model-provider-resolver/store_test.go
@@ -25,49 +25,49 @@ import (
 )
 
 func TestProviderStore_AddGetDelete(t *testing.T) {
-	store := newProviderInfoStore()
+	store := newInfoStore()
 	key := types.NamespacedName{Namespace: "models", Name: "my-openai"}
 
-	_, found := store.get(key)
+	_, found := store.getProvider(key)
 	assert.False(t, found)
 
-	store.addOrUpdate(key, &providerInfo{
+	store.addOrUpdateProvider(key, &providerInfo{
 		provider: "openai", endpoint: "api.openai.com",
 		secretName: "key", secretNamespace: "models",
 	})
 
-	info, found := store.get(key)
+	info, found := store.getProvider(key)
 	require.True(t, found)
 	assert.Equal(t, "openai", info.provider)
 	assert.Equal(t, "api.openai.com", info.endpoint)
 
-	store.delete(key)
-	_, found = store.get(key)
+	store.deleteProvider(key)
+	_, found = store.getProvider(key)
 	assert.False(t, found)
 }
 
 func TestProviderStore_Update(t *testing.T) {
-	store := newProviderInfoStore()
+	store := newInfoStore()
 	key := types.NamespacedName{Namespace: "models", Name: "my-openai"}
 
-	store.addOrUpdate(key, &providerInfo{provider: "openai", endpoint: "old.com"})
-	store.addOrUpdate(key, &providerInfo{provider: "openai", endpoint: "new.com"})
+	store.addOrUpdateProvider(key, &providerInfo{provider: "openai", endpoint: "old.com"})
+	store.addOrUpdateProvider(key, &providerInfo{provider: "openai", endpoint: "new.com"})
 
-	info, _ := store.get(key)
+	info, _ := store.getProvider(key)
 	assert.Equal(t, "new.com", info.endpoint)
 }
 
 func TestProviderStore_WithConfig(t *testing.T) {
-	store := newProviderInfoStore()
+	store := newInfoStore()
 	key := types.NamespacedName{Namespace: "models", Name: "my-vertex"}
 
-	store.addOrUpdate(key, &providerInfo{
+	store.addOrUpdateProvider(key, &providerInfo{
 		provider: "vertex-openai", endpoint: "aiplatform.googleapis.com",
 		secretName: "key", secretNamespace: "models",
 		config: map[string]string{"project": "my-project", "location": "us-central1"},
 	})
 
-	info, found := store.get(key)
+	info, found := store.getProvider(key)
 	require.True(t, found)
 	assert.Equal(t, "my-project", info.config["project"])
 }


### PR DESCRIPTION
## Summary

Addresses #285 review comments from Nir:
- Merge `providerInfoStore` + `modelInfoStore` into single `infoStore` with one lock
- Rename functions to be explicit: `addOrUpdateProvider`, `deleteProvider`, `getProvider`, `addOrUpdateModel`, `deleteModel`, `getModel`
- Add godoc comments on all types and methods

**8 files, 92 insertions, 100 deletions (net -8 lines).**

## Risk analysis

- **Risk rating**: 1
- **Why**: Pure rename/restructure refactor. Same logic, same tests, same behavior. All callers updated.

cc @nirrozenbaum

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal storage architecture for the model provider resolver component to improve code organization and maintainability.

* **Tests**
  * Updated test suites to ensure compatibility with the refactored storage implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->