### PR TITLE
feat: install inference.opendatahub.io CRDs in E2E infra + read RBAC

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -43,6 +43,7 @@ WORKDIR /e2e
 COPY --from=builder /e2e-tests.test /e2e/e2e-tests.test
 COPY --from=builder /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY test/e2e/scripts/entrypoint.sh /e2e/entrypoint.sh
+COPY config/crd/bases/ /e2e/crds/
 
 RUN chmod +x /e2e/entrypoint.sh /e2e/e2e-tests.test && \
     mkdir -p /results

--- a/deploy/payload-processing/templates/rbac.yaml
+++ b/deploy/payload-processing/templates/rbac.yaml
@@ -11,9 +11,12 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
-  # model-provider-resolver plugin: watches ExternalModel CRD
+  # model-provider-resolver plugin: watches ExternalModel and ExternalProvider CRDs
   - apiGroups: ["maas.opendatahub.io"]
     resources: ["externalmodels"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["inference.opendatahub.io"]
+    resources: ["externalproviders", "externalmodels"]
     verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -40,9 +43,12 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
-  # model-provider-resolver plugin: watches ExternalModel CRD
+  # model-provider-resolver plugin: watches ExternalModel and ExternalProvider CRDs
   - apiGroups: ["maas.opendatahub.io"]
     resources: ["externalmodels"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["inference.opendatahub.io"]
+    resources: ["externalproviders", "externalmodels"]
     verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/scripts/entrypoint.sh
+++ b/test/e2e/scripts/entrypoint.sh
@@ -48,6 +48,15 @@ else
     echo "ExternalModel CRD already installed."
 fi
 
+# Ensure inference.opendatahub.io CRDs are installed.
+if ! kubectl get crd externalproviders.inference.opendatahub.io >/dev/null 2>&1; then
+    echo "Installing inference.opendatahub.io CRDs..."
+    kubectl apply -f /e2e/crds/
+    echo "inference.opendatahub.io CRDs installed."
+else
+    echo "inference.opendatahub.io CRDs already installed."
+fi
+
 # Build test arguments.
 TEST_ARGS=(
     -test.v

--- a/test/e2e/scripts/setup-kind.sh
+++ b/test/e2e/scripts/setup-kind.sh
@@ -85,6 +85,10 @@ install_external_model_crd() {
     echo "Installing ExternalModel CRD..."
     kubectl apply -f https://raw.githubusercontent.com/opendatahub-io/models-as-a-service/refs/heads/main/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_externalmodels.yaml
     echo "ExternalModel CRD installed"
+
+    echo "Installing inference.opendatahub.io CRDs..."
+    kubectl apply -f "$PROJECT_ROOT/config/crd/bases/"
+    echo "inference.opendatahub.io CRDs installed"
 }
 
 create_gateway() {


### PR DESCRIPTION
## Summary

Installs `inference.opendatahub.io` CRDs and adds read-only RBAC so the store reconcilers (from #285, #286) can watch ExternalProvider and ExternalModel resources.

**4 files, 22 lines.**

## What this does

- `setup-kind.sh` — install inference CRDs from `config/crd/bases/`
- `entrypoint.sh` — install inference CRDs in E2E test container
- `Dockerfile.e2e` — embed CRD files in test image
- `rbac.yaml` — add `inference.opendatahub.io` get/list/watch for externalproviders and externalmodels

## Why needed

Without this, the store reconcilers crash in CI:
```
"if kind is a CRD, it should be installed before calling Start"
"no matches for kind ExternalProvider in version inference.opendatahub.io/v1alpha1"
```

## Risk analysis

- **Risk rating**: 1
- **Why**: Only adds CRD installation and read-only RBAC. No code changes.

cc @nirrozenbaum