### PR TITLE
fix: use oc CLI instead of kubectl in E2E container

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -11,7 +11,7 @@
 
 ARG GOLANG_VERSION=1.25
 
-## Stage 1: Build the test binary and download kubectl
+## Stage 1: Build the test binary and download oc
 FROM registry.access.redhat.com/ubi9/go-toolset:$GOLANG_VERSION AS builder
 ARG OCP_VERSION=4.21.15
 ARG CGO_ENABLED=1
@@ -33,11 +33,12 @@ RUN CGO_ENABLED=${CGO_ENABLED} GOEXPERIMENT=strictfipsruntime GOOS=${TARGETOS} G
     go test -c -o /e2e-tests.test ./test/e2e/ \
     -ldflags="-s -w"
 
-# Download FIPS-compliant kubectl from the OpenShift client tarball (rhel9, CGO+OpenSSL).
+# Download FIPS-compliant oc and kubectl from the OpenShift client tarball.
 RUN curl -sL "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OCP_VERSION}/openshift-client-linux-${TARGETARCH}-rhel9-${OCP_VERSION}.tar.gz" | \
     tar -xz -C /tmp/ oc kubectl && \
+    mv /tmp/oc /usr/local/bin/oc && \
     mv /tmp/kubectl /usr/local/bin/kubectl && \
-    chmod +x /usr/local/bin/kubectl
+    chmod +x /usr/local/bin/oc /usr/local/bin/kubectl
 
 ## Stage 2: Runtime
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8@sha256:ae09ecc3d754bc1726cbda3e2599cc7839e09fe1cc547ce173cf669b645be3cc
@@ -45,6 +46,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8@sha256:ae09ecc3d754bc1726cb
 WORKDIR /e2e
 
 COPY --from=builder /e2e-tests.test /e2e/e2e-tests.test
+COPY --from=builder /usr/local/bin/oc /usr/local/bin/oc
 COPY --from=builder /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY test/e2e/scripts/entrypoint.sh /e2e/entrypoint.sh
 COPY config/crd/bases/ /e2e/crds/

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -34,7 +34,7 @@ var (
 	gatewaySvcName string
 	simulatorEP    string
 	curlTimeout    = 30 * time.Second
-	kubectlBin     = envOr("KUBECTL_BIN", "oc")
+	kubectlBin     = envOr("KUBECTL_BIN", "kubectl")
 )
 
 func TestE2E(t *testing.T) {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -34,6 +34,7 @@ var (
 	gatewaySvcName string
 	simulatorEP    string
 	curlTimeout    = 30 * time.Second
+	kubectlBin     = envOr("KUBECTL_BIN", "oc")
 )
 
 func TestE2E(t *testing.T) {
@@ -151,17 +152,17 @@ func createNamespace(name string) {
 }
 
 func kubectlApplyLiteral(yamlContent string) {
-	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd := exec.Command(kubectlBin, "apply", "-f", "-")
 	cmd.Stdin = strings.NewReader(yamlContent)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "kubectl apply failed: %s\n%s\n", err, string(out))
+		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "%s apply failed: %s\n%s\n", kubectlBin, err, string(out))
 	}
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), string(out))
 }
 
 func kubectlDeleteResource(kind, name, namespace string) {
-	cmd := exec.Command("kubectl", "delete", kind, name, "-n", namespace, "--ignore-not-found", "--timeout=30s")
+	cmd := exec.Command(kubectlBin, "delete", kind, name, "-n", namespace, "--ignore-not-found", "--timeout=30s")
 	_, _ = cmd.CombinedOutput()
 }
 

--- a/test/e2e/scripts/entrypoint.sh
+++ b/test/e2e/scripts/entrypoint.sh
@@ -33,16 +33,16 @@ if [[ ! -f "$KUBECONFIG" ]]; then
 fi
 
 echo "Verifying cluster connectivity..."
-if ! kubectl cluster-info --request-timeout=10s >/dev/null 2>&1; then
+if ! oc cluster-info --request-timeout=10s >/dev/null 2>&1; then
     echo "ERROR: Cannot connect to the cluster. Check KUBECONFIG."
     exit 1
 fi
 echo "Cluster connectivity OK."
 
 # Ensure ExternalModel CRD is installed (required for E2E tests).
-if ! kubectl get crd externalmodels.maas.opendatahub.io >/dev/null 2>&1; then
+if ! oc get crd externalmodels.maas.opendatahub.io >/dev/null 2>&1; then
     echo "ExternalModel CRD not found, installing..."
-    kubectl apply -f https://raw.githubusercontent.com/opendatahub-io/models-as-a-service/refs/heads/main/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_externalmodels.yaml
+    oc apply -f https://raw.githubusercontent.com/opendatahub-io/models-as-a-service/refs/heads/main/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_externalmodels.yaml
     echo "ExternalModel CRD installed."
 else
     echo "ExternalModel CRD already installed."


### PR DESCRIPTION
## Summary

- Replace `kubectl` with `oc` in the E2E Dockerfile and entrypoint script for OpenShift/Konflux compatibility
- Download `oc` from Red Hat mirror (`stable-4.17` channel) — the tarball includes both `oc` and `kubectl`
- Go test helpers use `KUBECTL_BIN` env var (default: `oc`) so local runs can override with `kubectl`
- `setup-kind.sh` is unchanged — it targets Kind clusters where `kubectl` is correct

Per DevTestOps team request to use `oc` in E2E test containers.

## Test plan

- [x] `go vet ./test/e2e/` — clean
- [x] `make lint` — 0 issues
- [ ] Verify Dockerfile builds with `oc` download (CI)
- [ ] E2E on Konflux with `oc` (CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for overriding the kubectl binary via `KUBECTL_BIN` environment variable in E2E tests.
  * E2E container runtime now includes the OpenShift CLI (`oc`) binary.

* **Bug Fixes**
  * Improved error reporting and debugging output for kubectl command failures in E2E tests.
  * E2E setup now uses OpenShift CLI for cluster connectivity verification and CRD management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->