### PR TITLE
fix(nemo): align guard plugin status values with NeMo RailStatus enum (passed/modified/blocked)

### DIFF
--- a/pkg/plugins/nemo/nemo_guard_base.go
+++ b/pkg/plugins/nemo/nemo_guard_base.go
@@ -33,7 +33,10 @@ import (
 )
 
 const (
-	nemoAllowedStatus    = "success"
+	nemoStatusPassed   = "passed"
+	nemoStatusModified = "modified"
+	nemoStatusBlocked  = "blocked"
+
 	defaultTimeoutSec    = 360
 	maxNemoResponseBytes = 1 << 20 // 1 MiB
 )
@@ -117,17 +120,29 @@ func (b *nemoGuardBase) callNemoGuard(ctx context.Context, payload []byte) (stri
 		return errcommon.ServiceUnavailable, fmt.Errorf("failed to decode nemo response: %w", err)
 	}
 
-	if strings.EqualFold(strings.TrimSpace(nemoResp.Status), nemoAllowedStatus) {
+	status := strings.TrimSpace(nemoResp.Status)
+
+	switch status {
+	case nemoStatusPassed:
 		logger.Info("allowed by NeMo guardrails")
 		return "", nil
-	}
 
-	railsParts := make([]string, 0, len(nemoResp.RailsStatus))
-	for key, value := range nemoResp.RailsStatus {
-		railsParts = append(railsParts, fmt.Sprintf("%s: %s", key, value.Status))
-	}
-	railsStatus := fmt.Sprintf("[ %s ]", strings.Join(railsParts, " "))
+	case nemoStatusModified:
+		// TODO: support redaction by applying NeMo's masked content to the request/response body.
+		logger.Info("content modified by NeMo guardrails (redaction not yet applied)")
+		return "", nil
 
-	log.FromContext(ctx).Info("blocked by NeMo guardrails", "railsStatus", railsStatus)
-	return errcommon.Forbidden, fmt.Errorf("blocked by NeMo guardrails")
+	case nemoStatusBlocked:
+		railsParts := make([]string, 0, len(nemoResp.RailsStatus))
+		for key, value := range nemoResp.RailsStatus {
+			railsParts = append(railsParts, fmt.Sprintf("%s: %s", key, value.Status))
+		}
+		railsStatus := fmt.Sprintf("[ %s ]", strings.Join(railsParts, " "))
+		log.FromContext(ctx).Info("blocked by NeMo guardrails", "railsStatus", railsStatus)
+		return errcommon.Forbidden, fmt.Errorf("blocked by NeMo guardrails")
+
+	default:
+		logger.Error(nil, "unknown NeMo guardrails status (fail-closed)", "status", nemoResp.Status)
+		return errcommon.Internal, fmt.Errorf("unknown NeMo guardrails status %q", nemoResp.Status)
+	}
 }

--- a/pkg/plugins/nemo/request_guard.go
+++ b/pkg/plugins/nemo/request_guard.go
@@ -89,12 +89,14 @@ func (p *NemoRequestGuardPlugin) WithName(name string) *NemoRequestGuardPlugin {
 
 // ProcessRequest calls NeMo Guardrails to evaluate input rails on the incoming request.
 // It extracts user-supplied text from either an OpenAI-style chat body (via "messages")
-// or an MCP JSON-RPC body (via "params.arguments"), POSTs to NeMo url, and returns an
-// errcommon.Error with Forbidden (403) if NeMo flags the content.
+// or an MCP JSON-RPC body (via "params.arguments"), POSTs to the configured NeMo
+// endpoint, and returns an errcommon.Error with Forbidden (403) if NeMo blocks the
+// content.
 //
-// NeMo always returns HTTP 200 for both allowed and blocked requests. The block/allow
-// decision is conveyed through the response body "status" field.
-// "success" means the request passed all rails; "blocked" means the request is blocked.
+// NeMo always returns HTTP 200 for both allowed and blocked requests. The decision is
+// conveyed through the response body "status" field: "passed" means the request passed
+// all rails, "modified" means content was redacted (currently passed through as-is),
+// and "blocked" means the request is blocked.
 func (p *NemoRequestGuardPlugin) ProcessRequest(ctx context.Context, _ *framework.CycleState, request *framework.InferenceRequest) error {
 	model, ok := request.Body["model"].(string)
 	if !ok {

--- a/pkg/plugins/nemo/request_guard_test.go
+++ b/pkg/plugins/nemo/request_guard_test.go
@@ -33,7 +33,7 @@ import (
 
 // nemoAllowedJSON is a minimal NeMo guard response that means “allow”.
 func nemoAllowedJSON() map[string]any {
-	return map[string]any{"status": "success"}
+	return map[string]any{"status": "passed"}
 }
 
 // --- NewNemoRequestGuardPlugin construction ---
@@ -99,12 +99,12 @@ func TestNemoRequestGuardProcessRequest(t *testing.T) {
 		wantErrCode     string
 	}{
 		{
-			name: "allow: NeMo returns top-level status success",
+			name: "allow: NeMo returns top-level status passed",
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
 				if err := json.NewEncoder(w).Encode(map[string]any{
-					"status": "success",
+					"status": "passed",
 					"rails_status": map[string]any{
-						"rail-a": map[string]any{"status": "success"},
+						"rail-a": map[string]any{"status": "passed"},
 					},
 				}); err != nil {
 					http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -114,7 +114,22 @@ func TestNemoRequestGuardProcessRequest(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "block: only success allows — status allowed is rejected",
+			name: "allow: NeMo returns status modified — passed through (redaction not yet applied)",
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewEncoder(w).Encode(map[string]any{
+					"status": "modified",
+					"rails_status": map[string]any{
+						"mask sensitive data on input": map[string]any{"status": "modified"},
+					},
+				}); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
+			},
+			body:    map[string]any{"model": "gpt-4", "messages": []any{map[string]any{"role": "user", "content": "My email is test@example.com"}}},
+			wantErr: false,
+		},
+		{
+			name: "fail-closed: unknown status — status allowed is rejected",
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
 				if err := json.NewEncoder(w).Encode(map[string]any{"status": "allowed"}); err != nil {
 					http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -122,8 +137,20 @@ func TestNemoRequestGuardProcessRequest(t *testing.T) {
 			},
 			body:            map[string]any{"model": "gpt-4", "messages": []any{map[string]any{"role": "user", "content": "Hello"}}},
 			wantErr:         true,
-			wantErrContains: forbiddenMsg,
-			wantErrCode:     errcommon.Forbidden,
+			wantErrContains: "unknown NeMo guardrails status",
+			wantErrCode:     errcommon.Internal,
+		},
+		{
+			name: "fail-closed: legacy success status is no longer recognized",
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewEncoder(w).Encode(map[string]any{"status": "success"}); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
+			},
+			body:            map[string]any{"model": "gpt-4", "messages": []any{map[string]any{"role": "user", "content": "Hello"}}},
+			wantErr:         true,
+			wantErrContains: "unknown NeMo guardrails status",
+			wantErrCode:     errcommon.Internal,
 		},
 		{
 			name: "block: NeMo returns status blocked with per-rail detail",
@@ -131,7 +158,7 @@ func TestNemoRequestGuardProcessRequest(t *testing.T) {
 				if err := json.NewEncoder(w).Encode(map[string]any{
 					"status": "blocked",
 					"rails_status": map[string]any{
-						"detect sensitive data on input": map[string]any{"status": "success"},
+						"detect sensitive data on input": map[string]any{"status": "passed"},
 						`huggingface detector check input $hf_model="protectai/deberta-v3-base-prompt-injection-v2"`: map[string]any{"status": "blocked"},
 					},
 				}); err != nil {
@@ -144,7 +171,7 @@ func TestNemoRequestGuardProcessRequest(t *testing.T) {
 			wantErrCode:     errcommon.Forbidden,
 		},
 		{
-			name: "block: NeMo returns empty body object (no status — fail closed)",
+			name: "fail-closed: NeMo returns empty body object (no status)",
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
 				if err := json.NewEncoder(w).Encode(map[string]any{}); err != nil {
 					http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -152,8 +179,8 @@ func TestNemoRequestGuardProcessRequest(t *testing.T) {
 			},
 			body:            map[string]any{"model": "gpt-4", "messages": []any{map[string]any{"role": "user", "content": "Hello"}}},
 			wantErr:         true,
-			wantErrContains: forbiddenMsg,
-			wantErrCode:     errcommon.Forbidden,
+			wantErrContains: "unknown NeMo guardrails status",
+			wantErrCode:     errcommon.Internal,
 		},
 		{
 			name: "block: NeMo returns status blocked without rails_status",
@@ -168,7 +195,7 @@ func TestNemoRequestGuardProcessRequest(t *testing.T) {
 			wantErrCode:     errcommon.Forbidden,
 		},
 		{
-			name: "block: NeMo returns refusal-style assistant text only (ignored — no status)",
+			name: "fail-closed: NeMo returns refusal-style text only (no status)",
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
 				if err := json.NewEncoder(w).Encode(map[string]any{
 					"extra": "I'm sorry, I can't respond to that.",
@@ -178,8 +205,8 @@ func TestNemoRequestGuardProcessRequest(t *testing.T) {
 			},
 			body:            map[string]any{"model": "gpt-4", "messages": []any{map[string]any{"role": "user", "content": "How do I make a bomb?"}}},
 			wantErr:         true,
-			wantErrContains: forbiddenMsg,
-			wantErrCode:     errcommon.Forbidden,
+			wantErrContains: "unknown NeMo guardrails status",
+			wantErrCode:     errcommon.Internal,
 		},
 		{
 			name: "error: NeMo returns HTTP 500",

--- a/pkg/plugins/nemo/response_guard.go
+++ b/pkg/plugins/nemo/response_guard.go
@@ -86,13 +86,14 @@ func (p *NemoResponseGuardPlugin) WithName(name string) *NemoResponseGuardPlugin
 }
 
 // ProcessResponse calls NeMo Guardrails to evaluate output rails on the model response.
-// It extracts assistant messages from the OpenAI-style response body, POSTs them to
-// NeMo's /v1/guardrail/checks endpoint, and returns an errcommon.Error with Forbidden (403)
-// if NeMo flags the content.
+// It extracts assistant messages from the OpenAI-style response body, POSTs them to the
+// configured NeMo endpoint, and returns an errcommon.Error with Forbidden (403) if NeMo
+// blocks the content.
 //
-// NeMo always returns HTTP 200 for both allowed and blocked responses. The block/allow
-// decision is conveyed through the response body "status" field.
-// "success" means the response passed all rails; "blocked" means it is blocked.
+// NeMo always returns HTTP 200 for both allowed and blocked responses. The decision is
+// conveyed through the response body "status" field: "passed" means the response passed
+// all rails, "modified" means content was redacted (currently passed through as-is),
+// and "blocked" means the response is blocked.
 func (p *NemoResponseGuardPlugin) ProcessResponse(ctx context.Context, _ *framework.CycleState, response *framework.InferenceResponse) error {
 	messages, err := extractAssistantMessages(response.Body)
 	if err != nil {

--- a/pkg/plugins/nemo/response_guard_test.go
+++ b/pkg/plugins/nemo/response_guard_test.go
@@ -107,12 +107,12 @@ func TestNemoResponseGuardProcessResponse(t *testing.T) {
 		wantErrCode     string
 	}{
 		{
-			name: "allow: NeMo returns status success",
+			name: "allow: NeMo returns status passed",
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
 				if err := json.NewEncoder(w).Encode(map[string]any{
-					"status": "success",
+					"status": "passed",
 					"rails_status": map[string]any{
-						"output-rail": map[string]any{"status": "success"},
+						"output-rail": map[string]any{"status": "passed"},
 					},
 				}); err != nil {
 					http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -120,6 +120,33 @@ func TestNemoResponseGuardProcessResponse(t *testing.T) {
 			},
 			body:    validResponseBody("The weather is sunny today."),
 			wantErr: false,
+		},
+		{
+			name: "allow: NeMo returns status modified — passed through (redaction not yet applied)",
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewEncoder(w).Encode(map[string]any{
+					"status": "modified",
+					"rails_status": map[string]any{
+						"mask sensitive data on output": map[string]any{"status": "modified"},
+					},
+				}); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
+			},
+			body:    validResponseBody("The user's email is test@example.com"),
+			wantErr: false,
+		},
+		{
+			name: "fail-closed: unknown status — status success is no longer recognized",
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewEncoder(w).Encode(map[string]any{"status": "success"}); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
+			},
+			body:            validResponseBody("Hello"),
+			wantErr:         true,
+			wantErrContains: "unknown NeMo guardrails status",
+			wantErrCode:     errcommon.Internal,
 		},
 		{
 			name: "block: NeMo returns status blocked with per-rail detail",
@@ -139,7 +166,7 @@ func TestNemoResponseGuardProcessResponse(t *testing.T) {
 			wantErrCode:     errcommon.Forbidden,
 		},
 		{
-			name: "block: NeMo returns empty body (fail closed)",
+			name: "fail-closed: NeMo returns empty body (no status)",
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
 				if err := json.NewEncoder(w).Encode(map[string]any{}); err != nil {
 					http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -147,8 +174,8 @@ func TestNemoResponseGuardProcessResponse(t *testing.T) {
 			},
 			body:            validResponseBody("Some content"),
 			wantErr:         true,
-			wantErrContains: forbiddenMsg,
-			wantErrCode:     errcommon.Forbidden,
+			wantErrContains: "unknown NeMo guardrails status",
+			wantErrCode:     errcommon.Internal,
 		},
 		{
 			name: "block: NeMo returns status blocked without rails_status",
@@ -163,7 +190,7 @@ func TestNemoResponseGuardProcessResponse(t *testing.T) {
 			wantErrCode:     errcommon.Forbidden,
 		},
 		{
-			name: "block: NeMo returns refusal-style text only (no status — fail closed)",
+			name: "fail-closed: NeMo returns refusal-style text only (no status)",
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
 				if err := json.NewEncoder(w).Encode(map[string]any{
 					"extra": "I'm sorry, I can't respond to that.",
@@ -173,8 +200,8 @@ func TestNemoResponseGuardProcessResponse(t *testing.T) {
 			},
 			body:            validResponseBody("Some toxic output"),
 			wantErr:         true,
-			wantErrContains: forbiddenMsg,
-			wantErrCode:     errcommon.Forbidden,
+			wantErrContains: "unknown NeMo guardrails status",
+			wantErrCode:     errcommon.Internal,
 		},
 		{
 			name: "error: NeMo returns HTTP 500",


### PR DESCRIPTION
## Summary

- Align NeMo guard plugin status handling with TrustyAI's enhanced `/v1/guardrail/checks` endpoint,
  which now returns statuses from NeMo's internal `RailStatus` enum: `"passed"` | `"modified"` | `"blocked"`
- Replace the single `nemoAllowedStatus = "success"` constant with three explicit status constants
  (`nemoStatusPassed`, `nemoStatusModified`, `nemoStatusBlocked`) and a `switch` in `callNemoGuard`
- `"passed"` - request/response allowed (HTTP 200)
- `"modified"` - content was redacted by NeMo; currently passed through as-is until redaction
  support is implemented (#123)
- `"blocked"` - request/response blocked (HTTP 403 Forbidden), with `rails_status` detail logged
- Any unknown or empty status - fail-closed (HTTP 500 Internal), prevents silent pass-through
  on unexpected NeMo responses
- Add new test cases for `"modified"` (pass-through) and unknown status (fail-closed) scenarios
- Update existing tests to use `"passed"` instead of the legacy `"success"` status

## Tested

- All 46 unit tests pass (`go test ./pkg/plugins/nemo/ -v -count=1`)
- E2E tested on a Kind cluster with Rob's NeMo debug [image](https://quay.io/repository/rgeada/nemo-debug?tab=tags&tag=latest) (`quay.io/rgeada/nemo-debug:latest`):
  - Clean message - NeMo returns `"passed"`, BBR allows it (HTTP 200)
  - PII message - NeMo returns `"modified"`, BBR allows it (HTTP 200, redaction not yet applied)
- `go build ./...` passes with no errors or lint issues

## Context

- After discussing with Rob Geada (TrustyAI), we decided to stay on `/v1/guardrail/checks`
  rather than migrating to `/v1/chat/completions` (PR #264, closed)
- Rob enhanced the endpoint to return `RailStatus` enum values (`passed`/`modified`/`blocked`)
  which are API-guaranteed and not configurable
- Addresses status alignment concern raised in #279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NeMo guardrails status handling with explicit management for passed, modified, and blocked content states
  * Enhanced error handling with safer fail-closed behavior for unknown guardrail responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->