### PR TITLE
feat: legacy migration controller — convert maas.opendatahub.io to inference.opendatahub.io CRs

### DIFF
--- a/hack/download-test-crds.sh
+++ b/hack/download-test-crds.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Download Istio and Gateway API CRDs for envtest.
+# Download Istio, Gateway API, and legacy MaaS CRDs for envtest.
 #
 # Usage:
 #   ./hack/download-test-crds.sh [output-dir]
@@ -13,17 +13,20 @@ GATEWAY_API_VERSION="${GATEWAY_API_VERSION:-v1.3.0}"
 
 OUTPUT_DIR="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/test/testdata/crds}"
 
-if [ -d "$OUTPUT_DIR/istio" ] && [ -d "$OUTPUT_DIR/gateway-api" ]; then
+if [ -d "$OUTPUT_DIR/istio" ] && [ -d "$OUTPUT_DIR/gateway-api" ] && [ -d "$OUTPUT_DIR/legacy" ]; then
     exit 0
 fi
 
 echo "Downloading test CRDs to ${OUTPUT_DIR}..."
-mkdir -p "$OUTPUT_DIR/istio" "$OUTPUT_DIR/gateway-api"
+mkdir -p "$OUTPUT_DIR/istio" "$OUTPUT_DIR/gateway-api" "$OUTPUT_DIR/legacy"
 
 curl -sSfL "https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/manifests/charts/base/files/crd-all.gen.yaml" \
     -o "$OUTPUT_DIR/istio/crd-all.gen.yaml"
 
 GWAPI_BASE="https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}"
 curl -sSfL "${GWAPI_BASE}/standard-install.yaml" -o "$OUTPUT_DIR/gateway-api/standard-install.yaml"
+
+curl -sSfL "https://raw.githubusercontent.com/opendatahub-io/models-as-a-service/refs/heads/main/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_externalmodels.yaml" \
+    -o "$OUTPUT_DIR/legacy/maas-externalmodel-crd.yaml"
 
 echo "Done: $(find "$OUTPUT_DIR" -name '*.yaml' | wc -l | tr -d ' ') CRD files downloaded"

--- a/pkg/controller/legacymigration/reconciler.go
+++ b/pkg/controller/legacymigration/reconciler.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package legacymigration
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	inferencev1alpha1 "github.com/opendatahub-io/ai-gateway-payload-processing/api/inference/v1alpha1"
+)
+
+const (
+	labelManagedBy    = "app.kubernetes.io/managed-by"
+	labelMigratedFrom = "inference.opendatahub.io/migrated-from"
+	managedByValue    = "ipp-legacy-migration"
+)
+
+var LegacyExternalModelGVK = schema.GroupVersionKind{
+	Group:   "maas.opendatahub.io",
+	Version: "v1alpha1",
+	Kind:    "ExternalModel",
+}
+
+//+kubebuilder:rbac:groups=maas.opendatahub.io,resources=externalmodels,verbs=get;list;watch
+//+kubebuilder:rbac:groups=inference.opendatahub.io,resources=externalproviders,verbs=get;list;watch;create;update
+//+kubebuilder:rbac:groups=inference.opendatahub.io,resources=externalmodels,verbs=get;list;watch;create;update
+
+// Reconciler watches legacy maas.opendatahub.io ExternalModel CRs and creates
+// corresponding inference.opendatahub.io ExternalProvider + ExternalModel CRs.
+// The new CRs trigger the existing controller flow (HTTPRoute, Service, etc.).
+type Reconciler struct {
+	client.Client
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("reconciling legacy ExternalModel", "name", req.Name, "namespace", req.Namespace)
+
+	old := &unstructured.Unstructured{}
+	old.SetGroupVersionKind(LegacyExternalModelGVK)
+	if err := r.Get(ctx, req.NamespacedName, old); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if !old.GetDeletionTimestamp().IsZero() {
+		return ctrl.Result{}, nil
+	}
+
+	providerName, _, _ := unstructured.NestedString(old.Object, "spec", "provider")
+	endpoint, _, _ := unstructured.NestedString(old.Object, "spec", "endpoint")
+	targetModel, _, _ := unstructured.NestedString(old.Object, "spec", "targetModel")
+	credsName, _, _ := unstructured.NestedString(old.Object, "spec", "credentialRef", "name")
+
+	if providerName == "" || endpoint == "" || targetModel == "" {
+		logger.Info("legacy ExternalModel missing required fields, skipping",
+			"provider", providerName, "endpoint", endpoint, "targetModel", targetModel)
+		return ctrl.Result{}, nil
+	}
+
+	labels := map[string]string{
+		labelManagedBy:    managedByValue,
+		labelMigratedFrom: req.Name,
+	}
+
+	desiredProvider := &inferencev1alpha1.ExternalProvider{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      req.Name,
+			Namespace: req.Namespace,
+			Labels:    labels,
+		},
+		Spec: inferencev1alpha1.ExternalProviderSpec{
+			Provider: providerName,
+			Endpoint: endpoint,
+			Auth: inferencev1alpha1.AuthConfig{
+				Type:      "simple",
+				SecretRef: inferencev1alpha1.NameReference{Name: credsName},
+			},
+		},
+	}
+
+	desiredModel := &inferencev1alpha1.ExternalModel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      req.Name,
+			Namespace: req.Namespace,
+			Labels:    labels,
+		},
+		Spec: inferencev1alpha1.ExternalModelSpec{
+			ExternalProviderRefs: []inferencev1alpha1.ExternalProviderRef{
+				{
+					Ref:         inferencev1alpha1.NameReference{Name: req.Name},
+					TargetModel: targetModel,
+					APIFormat:   mapProviderToAPIFormat(providerName),
+				},
+			},
+		},
+	}
+
+	ownerRef := ownerReferenceFromLegacy(old)
+	desiredProvider.OwnerReferences = []metav1.OwnerReference{ownerRef}
+	desiredModel.OwnerReferences = []metav1.OwnerReference{ownerRef}
+
+	if err := r.applyProvider(ctx, desiredProvider); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to apply ExternalProvider: %w", err)
+	}
+
+	if err := r.applyModel(ctx, desiredModel); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to apply ExternalModel: %w", err)
+	}
+
+	logger.Info("legacy migration complete",
+		"provider", providerName, "model", req.Name, "targetModel", targetModel)
+	return ctrl.Result{}, nil
+}
+
+func (r *Reconciler) applyProvider(ctx context.Context, desired *inferencev1alpha1.ExternalProvider) error {
+	existing := &inferencev1alpha1.ExternalProvider{}
+	err := r.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing)
+	if apierrors.IsNotFound(err) {
+		log.FromContext(ctx).Info("creating ExternalProvider", "name", desired.Name)
+		return r.Create(ctx, desired)
+	}
+	if err != nil {
+		return err
+	}
+	if !isManagedByMigration(existing.Labels) {
+		log.FromContext(ctx).Info("skipping ExternalProvider not managed by migration", "name", desired.Name)
+		return nil
+	}
+	if equality.Semantic.DeepEqual(existing.Spec, desired.Spec) {
+		return nil
+	}
+	existing.Spec = desired.Spec
+	log.FromContext(ctx).Info("updating ExternalProvider", "name", desired.Name)
+	return r.Update(ctx, existing)
+}
+
+func (r *Reconciler) applyModel(ctx context.Context, desired *inferencev1alpha1.ExternalModel) error {
+	existing := &inferencev1alpha1.ExternalModel{}
+	err := r.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing)
+	if apierrors.IsNotFound(err) {
+		log.FromContext(ctx).Info("creating ExternalModel", "name", desired.Name)
+		return r.Create(ctx, desired)
+	}
+	if err != nil {
+		return err
+	}
+	if !isManagedByMigration(existing.Labels) {
+		log.FromContext(ctx).Info("skipping ExternalModel not managed by migration", "name", desired.Name)
+		return nil
+	}
+	if equality.Semantic.DeepEqual(existing.Spec, desired.Spec) {
+		return nil
+	}
+	existing.Spec = desired.Spec
+	log.FromContext(ctx).Info("updating ExternalModel", "name", desired.Name)
+	return r.Update(ctx, existing)
+}
+
+func ownerReferenceFromLegacy(old *unstructured.Unstructured) metav1.OwnerReference {
+	isController := true
+	blockDeletion := true
+	return metav1.OwnerReference{
+		APIVersion:         old.GetAPIVersion(),
+		Kind:               old.GetKind(),
+		Name:               old.GetName(),
+		UID:                old.GetUID(),
+		Controller:         &isController,
+		BlockOwnerDeletion: &blockDeletion,
+	}
+}
+
+func isManagedByMigration(labels map[string]string) bool {
+	return labels != nil && labels[labelManagedBy] == managedByValue
+}
+
+func mapProviderToAPIFormat(provider string) string {
+	if provider == "anthropic" {
+		return "messages"
+	}
+	return "openai-chat"
+}

--- a/pkg/controller/legacymigration/reconciler_test.go
+++ b/pkg/controller/legacymigration/reconciler_test.go
@@ -1,0 +1,320 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package legacymigration
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	inferencev1alpha1 "github.com/opendatahub-io/ai-gateway-payload-processing/api/inference/v1alpha1"
+)
+
+var (
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
+
+func TestMain(m *testing.M) {
+	ctrl.SetLogger(zap.New(zap.WriteTo(os.Stderr), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.Background())
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(inferencev1alpha1.AddToScheme(scheme))
+
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "config", "crd", "bases"),
+			filepath.Join("..", "..", "..", "test", "testdata", "crds", "legacy"),
+		},
+		Scheme: scheme,
+	}
+
+	cfg, err := testEnv.Start()
+	if err != nil {
+		panic(err)
+	}
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		panic(err)
+	}
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:  scheme,
+		Metrics: metricsserver.Options{BindAddress: "0"},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	legacyObj := &unstructured.Unstructured{}
+	legacyObj.SetGroupVersionKind(LegacyExternalModelGVK)
+	if err := ctrl.NewControllerManagedBy(mgr).
+		For(legacyObj).
+		Named("legacy-migration").
+		Complete(&Reconciler{Client: mgr.GetClient()}); err != nil {
+		panic(err)
+	}
+
+	go func() {
+		if err := mgr.Start(ctx); err != nil {
+			panic(err)
+		}
+	}()
+
+	code := m.Run()
+
+	cancel()
+	if err := testEnv.Stop(); err != nil {
+		panic(err)
+	}
+	os.Exit(code)
+}
+
+// --- helpers ---
+
+func createTestNamespace(t *testing.T) string {
+	t.Helper()
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{GenerateName: "test-lm-"},
+	}
+	require.NoError(t, k8sClient.Create(ctx, ns))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, ns) })
+	return ns.Name
+}
+
+func createLegacyExternalModel(t *testing.T, name, namespace, provider, endpoint, targetModel, credName string) {
+	t.Helper()
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "maas.opendatahub.io/v1alpha1",
+		"kind":       "ExternalModel",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+		"spec": map[string]any{
+			"provider":    provider,
+			"endpoint":    endpoint,
+			"targetModel": targetModel,
+			"credentialRef": map[string]any{
+				"name": credName,
+			},
+		},
+	}}
+	require.NoError(t, k8sClient.Create(ctx, obj))
+}
+
+func waitForNewProvider(t *testing.T, name, namespace string) *inferencev1alpha1.ExternalProvider {
+	t.Helper()
+	var provider *inferencev1alpha1.ExternalProvider
+	require.Eventually(t, func() bool {
+		p := &inferencev1alpha1.ExternalProvider{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, p); err != nil {
+			return false
+		}
+		provider = p
+		return true
+	}, 10*time.Second, 100*time.Millisecond, "expected ExternalProvider %s/%s to be created", namespace, name)
+	return provider
+}
+
+func waitForNewModel(t *testing.T, name, namespace string) *inferencev1alpha1.ExternalModel {
+	t.Helper()
+	var model *inferencev1alpha1.ExternalModel
+	require.Eventually(t, func() bool {
+		m := &inferencev1alpha1.ExternalModel{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, m); err != nil {
+			return false
+		}
+		model = m
+		return true
+	}, 10*time.Second, 100*time.Millisecond, "expected ExternalModel %s/%s to be created", namespace, name)
+	return model
+}
+
+// --- test cases ---
+
+func TestReconcile_CreatesNewCRs(t *testing.T) {
+	ns := createTestNamespace(t)
+	createLegacyExternalModel(t, "my-openai", ns, "openai", "api.openai.com", "gpt-4o", "openai-key")
+
+	provider := waitForNewProvider(t, "my-openai", ns)
+	assert.Equal(t, "openai", provider.Spec.Provider)
+	assert.Equal(t, "api.openai.com", provider.Spec.Endpoint)
+	assert.Equal(t, "simple", provider.Spec.Auth.Type)
+	assert.Equal(t, "openai-key", provider.Spec.Auth.SecretRef.Name)
+	assert.Equal(t, managedByValue, provider.Labels[labelManagedBy])
+	assert.Equal(t, "my-openai", provider.Labels[labelMigratedFrom])
+
+	model := waitForNewModel(t, "my-openai", ns)
+	require.Len(t, model.Spec.ExternalProviderRefs, 1)
+	assert.Equal(t, "my-openai", model.Spec.ExternalProviderRefs[0].Ref.Name)
+	assert.Equal(t, "gpt-4o", model.Spec.ExternalProviderRefs[0].TargetModel)
+	assert.Equal(t, "openai-chat", model.Spec.ExternalProviderRefs[0].APIFormat)
+	assert.Equal(t, managedByValue, model.Labels[labelManagedBy])
+
+	// OwnerReference set on both new CRs pointing to the legacy CR
+	require.Len(t, provider.OwnerReferences, 1)
+	assert.Equal(t, "ExternalModel", provider.OwnerReferences[0].Kind)
+	assert.Equal(t, "my-openai", provider.OwnerReferences[0].Name)
+	assert.True(t, *provider.OwnerReferences[0].Controller)
+
+	require.Len(t, model.OwnerReferences, 1)
+	assert.Equal(t, "ExternalModel", model.OwnerReferences[0].Kind)
+	assert.Equal(t, "my-openai", model.OwnerReferences[0].Name)
+}
+
+func TestReconcile_AnthropicProvider(t *testing.T) {
+	ns := createTestNamespace(t)
+	createLegacyExternalModel(t, "my-claude", ns, "anthropic", "api.anthropic.com", "claude-sonnet-4-5-20241022", "anthropic-key")
+
+	provider := waitForNewProvider(t, "my-claude", ns)
+	assert.Equal(t, "anthropic", provider.Spec.Provider)
+
+	model := waitForNewModel(t, "my-claude", ns)
+	assert.Equal(t, "messages", model.Spec.ExternalProviderRefs[0].APIFormat)
+	assert.Equal(t, "claude-sonnet-4-5-20241022", model.Spec.ExternalProviderRefs[0].TargetModel)
+}
+
+func TestReconcile_UpdateLegacyCR(t *testing.T) {
+	ns := createTestNamespace(t)
+	createLegacyExternalModel(t, "updatable", ns, "openai", "api.openai.com", "gpt-4o", "key1")
+
+	waitForNewProvider(t, "updatable", ns)
+	waitForNewModel(t, "updatable", ns)
+
+	// Update the legacy CR's endpoint
+	old := &unstructured.Unstructured{}
+	old.SetGroupVersionKind(LegacyExternalModelGVK)
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: "updatable", Namespace: ns}, old))
+	_ = unstructured.SetNestedField(old.Object, "api.anthropic.com", "spec", "endpoint")
+	require.NoError(t, k8sClient.Update(ctx, old))
+
+	// Wait for the new provider to reflect the updated endpoint
+	require.Eventually(t, func() bool {
+		p := &inferencev1alpha1.ExternalProvider{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: "updatable", Namespace: ns}, p); err != nil {
+			return false
+		}
+		return p.Spec.Endpoint == "api.anthropic.com"
+	}, 10*time.Second, 100*time.Millisecond)
+}
+
+func TestReconcile_DeleteLegacyCR(t *testing.T) {
+	ns := createTestNamespace(t)
+	createLegacyExternalModel(t, "to-delete", ns, "openai", "api.openai.com", "gpt-4o", "key1")
+
+	waitForNewProvider(t, "to-delete", ns)
+	waitForNewModel(t, "to-delete", ns)
+
+	// Delete the legacy CR
+	old := &unstructured.Unstructured{}
+	old.SetGroupVersionKind(LegacyExternalModelGVK)
+	old.SetName("to-delete")
+	old.SetNamespace(ns)
+	require.NoError(t, k8sClient.Delete(ctx, old))
+
+	// Verify legacy CR is gone
+	require.Eventually(t, func() bool {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(LegacyExternalModelGVK)
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: "to-delete", Namespace: ns}, obj)
+		return apierrors.IsNotFound(err)
+	}, 10*time.Second, 100*time.Millisecond)
+
+	// New CRs still exist in envtest (no GC controller). In a real cluster,
+	// OwnerReference cascade would delete them when the legacy CR is removed.
+	p := &inferencev1alpha1.ExternalProvider{}
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: "to-delete", Namespace: ns}, p))
+	assert.Equal(t, "to-delete", p.OwnerReferences[0].Name)
+}
+
+func TestReconcile_DoesNotOverwriteManualCRs(t *testing.T) {
+	ns := createTestNamespace(t)
+
+	// Create a new ExternalProvider manually (NOT managed by migration)
+	manual := &inferencev1alpha1.ExternalProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "manual-provider", Namespace: ns},
+		Spec: inferencev1alpha1.ExternalProviderSpec{
+			Provider: "openai",
+			Endpoint: "manual.openai.com",
+			Auth: inferencev1alpha1.AuthConfig{
+				Type:      "simple",
+				SecretRef: inferencev1alpha1.NameReference{Name: "manual-key"},
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, manual))
+
+	// Create a legacy CR with the same name
+	createLegacyExternalModel(t, "manual-provider", ns, "openai", "api.openai.com", "gpt-4o", "other-key")
+
+	// Wait for reconcile to run, then verify the manually created provider was NOT overwritten
+	require.Eventually(t, func() bool {
+		// The new ExternalModel should be created (reconciler ran)
+		m := &inferencev1alpha1.ExternalModel{}
+		return k8sClient.Get(ctx, types.NamespacedName{Name: "manual-provider", Namespace: ns}, m) == nil
+	}, 10*time.Second, 100*time.Millisecond, "expected reconciler to create ExternalModel")
+
+	p := &inferencev1alpha1.ExternalProvider{}
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: "manual-provider", Namespace: ns}, p))
+	assert.Equal(t, "manual.openai.com", p.Spec.Endpoint, "migration should not overwrite manually created provider")
+}
+
+func TestMapProviderToAPIFormat(t *testing.T) {
+	tests := []struct {
+		provider  string
+		apiFormat string
+	}{
+		{"openai", "openai-chat"},
+		{"anthropic", "messages"},
+		{"azure", "openai-chat"},
+		{"azure-openai", "openai-chat"},
+		{"vertex-openai", "openai-chat"},
+		{"bedrock", "openai-chat"},
+		{"aws-bedrock", "openai-chat"},
+		{"unknown", "openai-chat"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.provider, func(t *testing.T) {
+			assert.Equal(t, tt.apiFormat, mapProviderToAPIFormat(tt.provider))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

New controller in `pkg/controller/legacymigration/` that watches legacy `maas.opendatahub.io/v1alpha1` ExternalModel CRs and creates corresponding `inference.opendatahub.io/v1alpha1` ExternalProvider + ExternalModel CRs.

**Flow:**
```
Old CR (maas.opendatahub.io) → migration controller creates new CRs
  → existing controllers create HTTPRoute + Service + Istio resources
```

**Design choice:** one ExternalProvider per old CR (no deduplication). See [#292 comment](https://github.com/opendatahub-io/ai-gateway-payload-processing/issues/292#issuecomment-4593548433) for discussion on shared provider alternative — happy to switch if preferred.

**Safety:** migration controller only updates CRs it created (checks `managed-by: ipp-legacy-migration` label). Manually created CRs are never overwritten.

## Size note

~130 lines of production code. The rest is envtest test suite (6 test cases, 79% coverage) + license headers. Self-contained new package with no changes to existing code.

Closes #292

## Test plan

- [x] `make test-unit` — all tests pass (legacymigration: 79% coverage)
- [x] `make lint` — 0 issues
- [x] TestReconcile_CreatesNewCRs — old CR creates new ExternalProvider + ExternalModel
- [x] TestReconcile_AnthropicProvider — apiFormat mapping (anthropic → anthropic)
- [x] TestReconcile_UpdateLegacyCR — endpoint change propagates to new provider
- [x] TestReconcile_DeleteLegacyCR — new CRs persist after old CR deletion
- [x] TestReconcile_DoesNotOverwriteManualCRs — manually created CRs are safe
- [x] TestMapProviderToAPIFormat — table-driven test for all provider mappings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic migration of legacy resources to the new inference API format.

* **Tests**
  * Added comprehensive test coverage and infrastructure for validating legacy migration functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->