### PR TITLE
feat: wire legacy migration controller into plugin resolver

### DIFF
--- a/pkg/plugins/model-provider-resolver/plugin.go
+++ b/pkg/plugins/model-provider-resolver/plugin.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -35,6 +36,7 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 
 	inferencev1alpha1 "github.com/opendatahub-io/ai-gateway-payload-processing/api/inference/v1alpha1"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/controller/legacymigration"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/state"
 )
 
@@ -95,6 +97,16 @@ func NewModelProviderResolver(reconcilerBuilder func() *builder.Builder, k8sClie
 		Watches(&inferencev1alpha1.ExternalProvider{}, handler.EnqueueRequestsFromMapFunc(mapProviderToModels)).
 		Complete(modelReconciler); err != nil {
 		return nil, fmt.Errorf("failed to register ExternalModel reconciler for plugin '%s' - %w", ModelProviderResolverPluginType, err)
+	}
+
+	// Legacy: watch maas.opendatahub.io ExternalModels and migrate to new CRs
+	legacyObj := &unstructured.Unstructured{}
+	legacyObj.SetGroupVersionKind(legacymigration.LegacyExternalModelGVK)
+	if err := reconcilerBuilder().
+		For(legacyObj).
+		Named("legacy-migration").
+		Complete(&legacymigration.Reconciler{Client: k8sClient}); err != nil {
+		return nil, fmt.Errorf("failed to register legacy migration reconciler for plugin '%s' - %w", ModelProviderResolverPluginType, err)
 	}
 
 	return &ModelProviderResolverPlugin{


### PR DESCRIPTION
## Summary

Register the legacy migration reconciler (from #299) in `NewModelProviderResolver` to watch `maas.opendatahub.io` ExternalModel CRs. This completes the legacy support flow:

```
Old CR (maas.opendatahub.io) → migration reconciler → creates new CRs (inference.opendatahub.io)
  → typed store reconcilers populate store
  → ProcessRequest resolves model → CycleState
```

Per Nir's comment on #299: "hook it to plugin resolver, no need for additional plugin."

## Test plan

- [x] `make test-unit` — all tests pass
- [x] `make lint` — 0 issues
- [x] 12 lines added, single file change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for legacy resource migration and monitoring alongside standard provider resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->