### PR TITLE
docs: update apiFormat naming, sample manifests, and godoc

### DIFF
--- a/api/inference/v1alpha1/externalmodel_types.go
+++ b/api/inference/v1alpha1/externalmodel_types.go
@@ -60,7 +60,9 @@ type ExternalProviderRef struct {
 	TargetModel string `json:"targetModel"`
 
 	// APIFormat determines how requests/responses are translated for this provider.
-	// e.g. "openai", "anthropic", "bedrock-openai", "azure-openai", "vertex-openai".
+	// Supported values:
+	//   - "openai-chat": OpenAI Chat Completions API (/v1/chat/completions)
+	//   - "messages": Anthropic Messages API (/v1/messages)
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63

--- a/config/crd/bases/inference.opendatahub.io_externalmodels.yaml
+++ b/config/crd/bases/inference.opendatahub.io_externalmodels.yaml
@@ -59,7 +59,9 @@ spec:
                     apiFormat:
                       description: |-
                         APIFormat determines how requests/responses are translated for this provider.
-                        e.g. "openai", "anthropic", "bedrock-openai", "azure-openai", "vertex-openai".
+                        Supported values:
+                          - "openai-chat": OpenAI Chat Completions API (/v1/chat/completions)
+                          - "messages": Anthropic Messages API (/v1/messages)
                       maxLength: 63
                       minLength: 1
                       type: string

--- a/deploy/samples/manifests/anthropic.yaml
+++ b/deploy/samples/manifests/anthropic.yaml
@@ -3,7 +3,7 @@ kind: Secret
 metadata:
   name: anthropic-credentials
   labels:
-    inference.networking.k8s.io/bbr-managed: "true" # TODO: will change to inference.llm-d.ai/ipp-managed
+    inference.llm-d.ai/ipp-managed: "true"
 type: Opaque
 stringData:
   api-key: <your-anthropic-api-key>
@@ -16,6 +16,7 @@ spec:
   provider: anthropic
   endpoint: api.anthropic.com
   auth:
+    type: simple
     secretRef:
       name: anthropic-credentials
 ---

--- a/deploy/samples/manifests/multi-provider-weights.yaml
+++ b/deploy/samples/manifests/multi-provider-weights.yaml
@@ -1,0 +1,62 @@
+# Multi-provider with weighted traffic splitting.
+# 80% of requests go to OpenAI, 20% to Azure OpenAI.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openai-credentials
+  labels:
+    inference.llm-d.ai/ipp-managed: "true"
+type: Opaque
+stringData:
+  api-key: <your-openai-api-key>
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azure-credentials
+  labels:
+    inference.llm-d.ai/ipp-managed: "true"
+type: Opaque
+stringData:
+  api-key: <your-azure-api-key>
+---
+apiVersion: inference.opendatahub.io/v1alpha1
+kind: ExternalProvider
+metadata:
+  name: openai
+spec:
+  provider: openai
+  endpoint: api.openai.com
+  auth:
+    type: simple
+    secretRef:
+      name: openai-credentials
+---
+apiVersion: inference.opendatahub.io/v1alpha1
+kind: ExternalProvider
+metadata:
+  name: azure
+spec:
+  provider: azure-openai
+  endpoint: my-resource.openai.azure.com
+  auth:
+    type: simple
+    secretRef:
+      name: azure-credentials
+---
+apiVersion: inference.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: gpt4-weighted
+spec:
+  externalProviderRefs:
+    - ref:
+        name: openai
+      targetModel: gpt-4o
+      apiFormat: openai-chat
+      weight: 80
+    - ref:
+        name: azure
+      targetModel: gpt-4o
+      apiFormat: openai-chat
+      weight: 20

--- a/deploy/samples/manifests/openai.yaml
+++ b/deploy/samples/manifests/openai.yaml
@@ -3,7 +3,7 @@ kind: Secret
 metadata:
   name: openai-credentials
   labels:
-    inference.networking.k8s.io/bbr-managed: "true" # TODO: will change to inference.llm-d.ai/ipp-managed
+    inference.llm-d.ai/ipp-managed: "true"
 type: Opaque
 stringData:
   api-key: <your-openai-api-key>
@@ -16,6 +16,7 @@ spec:
   provider: openai
   endpoint: api.openai.com
   auth:
+    type: simple
     secretRef:
       name: openai-credentials
 ---
@@ -28,4 +29,4 @@ spec:
     - ref:
         name: openai
       targetModel: gpt-4o
-      apiFormat: chat-completions
+      apiFormat: openai-chat

--- a/deploy/samples/manifests/vertex-openai.yaml
+++ b/deploy/samples/manifests/vertex-openai.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vertex-credentials
+  labels:
+    inference.llm-d.ai/ipp-managed: "true"
+type: Opaque
+stringData:
+  api-key: <your-vertex-api-key>
+---
+apiVersion: inference.opendatahub.io/v1alpha1
+kind: ExternalProvider
+metadata:
+  name: vertex-openai
+spec:
+  provider: vertex-openai
+  endpoint: us-central1-aiplatform.googleapis.com
+  auth:
+    type: simple # TODO: replace with oauth2 once merged
+    secretRef:
+      name: vertex-credentials
+  config:
+    project: my-gcp-project
+    location: us-central1
+---
+apiVersion: inference.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: gemini
+spec:
+  externalProviderRefs:
+    - ref:
+        name: vertex-openai
+      targetModel: gemini-2.5-pro
+      apiFormat: openai-chat
+      config:
+        endpoint: openapi # Vertex AI endpoint name (not network endpoint — that's on the provider)


### PR DESCRIPTION
## Summary

Per Nir's follow-up list from #304:

- **apiFormat godoc** — updated to document `openai-chat` and `messages` as the supported values (was listing stale names like `openai`, `anthropic`, `bedrock-openai`)
- **Sample manifests fixed** — added `auth.type: simple` (required after #290), corrected apiFormat values
- **New Vertex AI sample** — includes provider config (`project`, `location`) and model config override (`endpoint`)
- **New multi-provider weighted sample** — 80/20 traffic split between OpenAI and Azure OpenAI
- **CRD YAML regenerated** for updated godoc

## Test plan

- [x] `go build ./...` — compiles
- [x] `make lint` — 0 issues
- [x] `make verify-codegen` — generated files up to date

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sample configuration for multi-provider inference with weighted traffic splitting between OpenAI and Azure providers
  * Added Vertex AI provider sample configuration with Gemini model support

* **Documentation**
  * Clarified supported API translation formats ("openai-chat" and "messages") in external provider documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->