### PR TITLE
feat: wire controller reconcilers into plugin factory

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,6 +28,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"github.com/llm-d/llm-d-inference-payload-processor/cmd/runner"
 
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/controllers"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins"
 )
 
@@ -37,7 +38,13 @@ func main() {
 
 	if err := runner.NewRunner().
 		WithExecutableName("ai-gateway-payload-processing").
-		// WithCustomCollectors(...). // THIS should be used for custom metrics exposed by our plugins
+		WithCustomControllers(
+			controllers.ProviderController(),
+			controllers.ModelController(
+				os.Getenv("GATEWAY_NAME"),
+				os.Getenv("GATEWAY_NAMESPACE"),
+			),
+		).
 		Run(ctrl.SetupSignalHandler()); err != nil {
 		os.Exit(1)
 	}

--- a/pkg/controllers/setup.go
+++ b/pkg/controllers/setup.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	inferencev1alpha1 "github.com/opendatahub-io/ai-gateway-payload-processing/api/inference/v1alpha1"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/controller/externalmodel"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/controller/externalprovider"
+)
+
+// ProviderController returns a setup function that registers the ExternalProvider
+// controller. It creates Service, ServiceEntry, and DestinationRule resources.
+// Does not use Owns() to avoid cluster-wide Service informers that delay startup.
+func ProviderController() func(client.Client, *ctrlbuilder.Builder) error {
+	return func(c client.Client, b *ctrlbuilder.Builder) error {
+		utilruntime.Must(inferencev1alpha1.AddToScheme(c.Scheme()))
+
+		return b.
+			For(&inferencev1alpha1.ExternalProvider{}).
+			Named("external-provider-controller").
+			Complete(&externalprovider.Reconciler{Client: c, Scheme: c.Scheme()})
+	}
+}
+
+// ModelController returns a setup function that registers the ExternalModel
+// controller. It creates HTTPRoute resources with the specified gateway parent ref.
+// Does not use Owns() to avoid cluster-wide HTTPRoute informers that delay startup.
+func ModelController(gatewayName, gatewayNamespace string) func(client.Client, *ctrlbuilder.Builder) error {
+	return func(c client.Client, b *ctrlbuilder.Builder) error {
+		utilruntime.Must(inferencev1alpha1.AddToScheme(c.Scheme()))
+		utilruntime.Must(gatewayapiv1.Install(c.Scheme()))
+
+		reconciler := &externalmodel.Reconciler{
+			Client:           c,
+			Scheme:           c.Scheme(),
+			GatewayName:      gatewayName,
+			GatewayNamespace: gatewayNamespace,
+		}
+
+		return b.
+			For(&inferencev1alpha1.ExternalModel{}).
+			Named("external-model-controller").
+			Watches(&inferencev1alpha1.ExternalProvider{},
+				handler.EnqueueRequestsFromMapFunc(reconciler.MapProviderToModels)).
+			Complete(reconciler)
+	}
+}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -32,8 +32,9 @@ var (
 	gatewayNs      string
 	gatewayName    string
 	gatewaySvcName string
-	simulatorEP    string
-	curlTimeout    = 30 * time.Second
+	simulatorEP   string
+	simulatorFQDN string
+	curlTimeout   = 30 * time.Second
 )
 
 func TestE2E(t *testing.T) {
@@ -47,6 +48,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	gatewayName = envOr("E2E_GATEWAY_NAME", defaultGatewayName)
 	gatewaySvcName = envOr("E2E_GATEWAY_SVC_NAME", gatewayName+"-istio")
 	simulatorEP = envOr("E2E_SIMULATOR_ENDPOINT", defaultSimulatorEndpoint)
+	simulatorFQDN = strings.ReplaceAll(simulatorEP, ".", "-") + ".sslip.io"
 
 	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		clientcmd.NewDefaultClientConfigLoadingRules(), nil,
@@ -66,38 +68,6 @@ var _ = ginkgo.AfterSuite(func() {
 func setupInfra() {
 	ginkgo.By("Creating test namespace")
 	createNamespace(nsName)
-
-	ginkgo.By("Creating simulator ServiceEntry and DestinationRule")
-	kubectlApplyLiteral(fmt.Sprintf(`
-apiVersion: networking.istio.io/v1
-kind: ServiceEntry
-metadata:
-  name: e2e-simulator
-  namespace: %s
-spec:
-  hosts:
-  - e2e-simulator.external
-  location: MESH_EXTERNAL
-  ports:
-  - number: 443
-    name: https
-    protocol: HTTPS
-  resolution: STATIC
-  endpoints:
-  - address: %s
----
-apiVersion: networking.istio.io/v1
-kind: DestinationRule
-metadata:
-  name: e2e-simulator
-  namespace: %s
-spec:
-  host: e2e-simulator.external
-  trafficPolicy:
-    tls:
-      mode: SIMPLE
-      insecureSkipVerify: true
-`, nsName, simulatorEP, nsName))
 
 	ginkgo.By("Creating curl client pod")
 	kubectlApplyLiteral(fmt.Sprintf(`
@@ -119,16 +89,14 @@ spec:
 		createProviderResources(p)
 	}
 
-	ginkgo.By("Waiting for plugin reconcilers to sync")
-	time.Sleep(10 * time.Second)
+	ginkgo.By("Waiting for controllers to create networking resources and routes to propagate")
+	time.Sleep(20 * time.Second)
 }
 
 func cleanupInfra() {
 	for _, p := range providers {
 		deleteProviderResources(p)
 	}
-	kubectlDeleteResource("destinationrule", "e2e-simulator", nsName)
-	kubectlDeleteResource("serviceentry", "e2e-simulator", nsName)
 	kubectlDeleteResource("pod", "curl", nsName)
 	_ = kubeClient.CoreV1().Namespaces().Delete(context.TODO(), nsName, metav1.DeleteOptions{})
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -70,7 +70,7 @@ spec:
     type: simple
     secretRef:
       name: %s
-`, p.Name, nsName, p.Provider, simulatorEP, p.Name))
+`, p.Name, nsName, p.Provider, simulatorFQDN, p.Name))
 
 	// ExternalModel CR
 	kubectlApplyLiteral(fmt.Sprintf(`
@@ -86,60 +86,11 @@ spec:
       targetModel: %s
       apiFormat: %s
 `, p.Name, nsName, p.Name, p.Name, p.Provider))
-
-	// ExternalName Service pointing to simulator
-	kubectlApplyLiteral(fmt.Sprintf(`
-apiVersion: v1
-kind: Service
-metadata:
-  name: %s
-  namespace: %s
-spec:
-  type: ExternalName
-  externalName: e2e-simulator.external
-  ports:
-  - port: 443
-    protocol: TCP
-`, p.Name, nsName))
-
-	// HTTPRoute with path-based + header-based routing
-	kubectlApplyLiteral(fmt.Sprintf(`
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: %s
-  namespace: %s
-spec:
-  parentRefs:
-  - group: gateway.networking.k8s.io
-    kind: Gateway
-    name: %s
-    namespace: %s
-  rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /%s/%s/
-    backendRefs:
-    - name: %s
-      port: 443
-  - matches:
-    - headers:
-      - name: X-Gateway-Model-Name
-        type: Exact
-        value: %s
-      path:
-        type: PathPrefix
-        value: /
-    backendRefs:
-    - name: %s
-      port: 443
-`, p.Name, nsName, gatewayName, gatewayNs, nsName, p.Name, p.Name, p.Name, p.Name))
 }
 
 func deleteProviderResources(p Provider) {
-	kubectlDeleteResource("httproute", p.Name, nsName)
-	kubectlDeleteResource("service", p.Name, nsName)
+	// Controller-created resources (Service, ServiceEntry, DestinationRule, HTTPRoute)
+	// are cleaned up via owner references when the CRs are deleted.
 	kubectlDeleteResource("externalmodels.inference.opendatahub.io", p.Name, nsName)
 	kubectlDeleteResource("externalproviders.inference.opendatahub.io", p.Name, nsName)
 	kubectlDeleteResource("secret", p.Name, nsName)

--- a/test/e2e/scripts/setup-kind.sh
+++ b/test/e2e/scripts/setup-kind.sh
@@ -141,10 +141,13 @@ deploy_bbr() {
         --set upstreamIpp.provider.name=istio \
         --set upstreamIpp.provider.istio.envoyFilter.operation=INSERT_FIRST
 
-    # Disable sidecar injection on BBR pod (ext_proc uses self-signed TLS,
-    # sidecar intercepts and breaks the connection)
+    # Disable sidecar injection on BBR pod
     kubectl patch deployment payload-processing -n "$GATEWAY_NAMESPACE" --type=merge \
         -p='{"spec":{"template":{"metadata":{"annotations":{"sidecar.istio.io/inject":"false"}}}}}'
+
+    # Set gateway config env vars for controller
+    kubectl set env deployment/payload-processing -n "$GATEWAY_NAMESPACE" \
+        GATEWAY_NAME="$GATEWAY_NAME" GATEWAY_NAMESPACE="$GATEWAY_NAMESPACE"
 
     kubectl rollout status deployment/payload-processing \
         -n "$GATEWAY_NAMESPACE" --timeout=120s


### PR DESCRIPTION
## Summary

Wire the controller reconcilers from `pkg/controller/` (merged in #183) into the model-provider-resolver plugin factory. This is the step that makes the CRDs fully operational — creating an ExternalProvider or ExternalModel CR now automatically creates the networking resources.

**Flow after this PR:**
```
ExternalProvider CR → controller creates Service + ServiceEntry + DestinationRule
ExternalModel CR → controller creates HTTPRoute (with gateway parent ref)
```

**Changes:**
- `resolverConfig` struct for gateway name/namespace/timeout from plugin JSON config
- Gateway API scheme registration in factory
- `externalprovider.Reconciler` registered with `Owns(&corev1.Service{})` and managed-by predicate
- `externalmodel.Reconciler` registered with `Owns(&gatewayapiv1.HTTPRoute{})` and cross-watch on ExternalProvider

## Size note

60 lines added, single file change. All production code, no tests needed (controller reconcilers have their own envtest suites in `pkg/controller/`).

## Test plan

- [x] `make test-unit` — all tests pass
- [x] `make lint` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled additional controller wiring in the main runner to support inference provider resources and gateway-backed model resources.
  * Added dedicated reconciliation setup so model resources automatically refresh in response to related provider changes.
* **Tests**
  * Updated end-to-end simulator behavior to use a derived simulator hostname when creating provider resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->