### PR TITLE
feat: add controller RBAC and gateway config to Helm chart

### DIFF
--- a/deploy/payload-processing/templates/rbac.yaml
+++ b/deploy/payload-processing/templates/rbac.yaml
@@ -17,7 +17,23 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["inference.opendatahub.io"]
     resources: ["externalproviders", "externalmodels"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "create", "update"]
+  - apiGroups: ["inference.opendatahub.io"]
+    resources: ["externalproviders/status", "externalmodels/status"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["inference.opendatahub.io"]
+    resources: ["externalproviders/finalizers", "externalmodels/finalizers"]
+    verbs: ["update"]
+  # controller reconcilers: create networking resources
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: ["networking.istio.io"]
+    resources: ["serviceentries", "destinationrules"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -49,7 +65,23 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["inference.opendatahub.io"]
     resources: ["externalproviders", "externalmodels"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "create", "update"]
+  - apiGroups: ["inference.opendatahub.io"]
+    resources: ["externalproviders/status", "externalmodels/status"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["inference.opendatahub.io"]
+    resources: ["externalproviders/finalizers", "externalmodels/finalizers"]
+    verbs: ["update"]
+  # controller reconcilers: create networking resources
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: ["networking.istio.io"]
+    resources: ["serviceentries", "destinationrules"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/test/e2e/scripts/e2e-values.yaml
+++ b/test/e2e/scripts/e2e-values.yaml
@@ -8,6 +8,9 @@ upstreamBbr:
           headerName: X-Gateway-Model-Name
       - type: model-provider-resolver
         name: model-provider-resolver
+        json:
+          gatewayName: "e2e-gateway"
+          gatewayNamespace: "default"
       - type: api-translation
         name: api-translation
         json:


### PR DESCRIPTION
## Summary

Add RBAC permissions for controller reconcilers and legacy migration to the Helm chart. This is the final piece — without these permissions, the controllers registered in #310 cannot create networking resources.

**RBAC additions (both ClusterRole and Role paths):**
- `inference.opendatahub.io` externalproviders/externalmodels: added `create`, `update` (for legacy migration controller)
- `inference.opendatahub.io` status + finalizers: `get`, `update`, `patch` (for reconciliation)
- `""` services: `get`, `list`, `watch`, `create`, `update`, `delete` (ExternalProvider controller)
- `gateway.networking.k8s.io` httproutes: `get`, `list`, `watch`, `create`, `update`, `delete` (ExternalModel controller)
- `networking.istio.io` serviceentries, destinationrules: `get`, `list`, `watch`, `create`, `update`, `delete` (Istio resources)

**E2E values:**
- Added `gatewayName` and `gatewayNamespace` to model-provider-resolver plugin config so HTTPRoutes get the correct parent ref in CI.

## Test plan

- [x] `helm template` renders correctly with all RBAC rules
- [x] Verified locally — manually applied equivalent RBAC, full pipeline works end-to-end (see #310 integration test comment)
- [x] E2E should pass with this + #310 merged (controller wiring + RBAC)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded RBAC permissions to allow create/update operations on external models and related resources, plus targeted status and finalizers management
  * Enhanced network infrastructure permissions for services, HTTP routes, and Istio configurations
  * Updated end-to-end test configuration with gateway settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->