### PR TITLE
fix: address #308 review — model name check bug, pointer slices, style

### DIFF
--- a/pkg/plugins/model-provider-resolver/external_model_reconciler.go
+++ b/pkg/plugins/model-provider-resolver/external_model_reconciler.go
@@ -58,14 +58,14 @@ func (r *externalModelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Resolve all refs whose providers are available in the store.
-	var resolved []resolvedProviderRef
-	for _, ref := range model.Spec.ExternalProviderRefs {
-		rr, found := r.resolveRef(req.Namespace, ref)
+	var resolved []*resolvedProviderRef
+	for i := range model.Spec.ExternalProviderRefs {
+		resolvedRef, found := r.resolveRef(req.Namespace, &model.Spec.ExternalProviderRefs[i])
 		if !found {
-			logger.Info("ExternalProvider not yet available, skipping ref", "provider", ref.Ref.Name)
+			logger.Info("ExternalProvider not yet available, skipping ref", "provider", model.Spec.ExternalProviderRefs[i].Ref.Name)
 			continue
 		}
-		resolved = append(resolved, *rr)
+		resolved = append(resolved, resolvedRef)
 	}
 
 	if len(resolved) == 0 {
@@ -80,7 +80,7 @@ func (r *externalModelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 // resolveRef resolves a single ExternalProviderRef to provider info.
 // Returns (nil, false) if the provider is not yet available in the store.
-func (r *externalModelReconciler) resolveRef(namespace string, ref inferencev1alpha1.ExternalProviderRef) (*resolvedProviderRef, bool) {
+func (r *externalModelReconciler) resolveRef(namespace string, ref *inferencev1alpha1.ExternalProviderRef) (*resolvedProviderRef, bool) {
 	providerKey := types.NamespacedName{Namespace: namespace, Name: ref.Ref.Name}
 	providerInfo, found := r.store.getProvider(providerKey)
 	if !found {

--- a/pkg/plugins/model-provider-resolver/external_model_reconciler_test.go
+++ b/pkg/plugins/model-provider-resolver/external_model_reconciler_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -49,8 +50,6 @@ func (m *mockModelReader) Get(_ context.Context, key types.NamespacedName, obj c
 func (m *mockModelReader) List(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
 	return nil
 }
-
-func intPtr(v int) *int { return &v }
 
 func newTestModel(name, ns string, refs ...inferencev1alpha1.ExternalProviderRef) *inferencev1alpha1.ExternalModel {
 	return &inferencev1alpha1.ExternalModel{
@@ -95,6 +94,7 @@ func TestModelReconciler_HappyPath(t *testing.T) {
 	assert.Equal(t, "gpt-4o", info.refs[0].targetModel)
 	assert.Equal(t, apiformat.OpenAIChatCompletions, info.refs[0].apiFormat)
 	assert.Equal(t, "openai-key", info.refs[0].secretName)
+	assert.Equal(t, "models", info.refs[0].secretNamespace)
 	assert.Equal(t, 1, info.refs[0].weight)
 }
 
@@ -103,7 +103,7 @@ func TestModelReconciler_DeletedCR(t *testing.T) {
 	reader := &mockModelReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalModel{}}
 
 	store := newInfoStore()
-	store.addOrUpdateModel(key, &externalModelInfo{refs: []resolvedProviderRef{
+	store.addOrUpdateModel(key, &externalModelInfo{refs: []*resolvedProviderRef{
 		{provider: "openai", targetModel: "gpt-4o", weight: 1},
 	}})
 
@@ -191,6 +191,9 @@ func TestModelReconciler_MultiRefPartialAvailability(t *testing.T) {
 	require.True(t, found)
 	require.Len(t, info.refs, 1, "only the available ref should be stored")
 	assert.Equal(t, "anthropic", info.refs[0].provider)
+	assert.Equal(t, "claude-sonnet", info.refs[0].targetModel)
+	assert.Equal(t, apiformat.Messages, info.refs[0].apiFormat)
+	assert.Equal(t, "anthropic-key", info.refs[0].secretName)
 }
 
 func TestModelReconciler_AuthOverride(t *testing.T) {
@@ -219,16 +222,16 @@ func TestModelReconciler_AuthOverride(t *testing.T) {
 
 	info, found := store.getModel(key)
 	require.True(t, found)
-	assert.Equal(t, "model-specific-key", info.refs[0].secretName)
+	assert.Equal(t, "model-specific-key", info.refs[0].secretName, "model auth should override provider auth")
 	assert.Equal(t, "models", info.refs[0].secretNamespace)
 }
 
 func TestModelReconciler_WeightFromCRD(t *testing.T) {
 	key := types.NamespacedName{Namespace: "models", Name: "weighted"}
 	ref1 := newRef("openai-provider", "gpt-4o", "openai-chat")
-	ref1.Weight = intPtr(80)
+	ref1.Weight = ptr.To(80)
 	ref2 := newRef("azure-provider", "gpt-4o", "openai-chat")
-	ref2.Weight = intPtr(20)
+	ref2.Weight = ptr.To(20)
 
 	reader := &mockModelReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalModel{
 		key: newTestModel("weighted", "models", ref1, ref2),

--- a/pkg/plugins/model-provider-resolver/model_store_test.go
+++ b/pkg/plugins/model-provider-resolver/model_store_test.go
@@ -29,7 +29,7 @@ func TestModelStore_AddAndGetExternalModel(t *testing.T) {
 	store := newInfoStore()
 	key := types.NamespacedName{Namespace: "ns", Name: "external-model"}
 
-	store.addOrUpdateModel(key, &externalModelInfo{refs: []resolvedProviderRef{
+	store.addOrUpdateModel(key, &externalModelInfo{refs: []*resolvedProviderRef{
 		{provider: provider.Anthropic, weight: 1},
 	}})
 
@@ -43,7 +43,7 @@ func TestModelStore_GetModelInfo_NotFound(t *testing.T) {
 	store := newInfoStore()
 	store.addOrUpdateModel(
 		types.NamespacedName{Namespace: "ns", Name: "ext"},
-		&externalModelInfo{refs: []resolvedProviderRef{{provider: provider.OpenAI, weight: 1}}},
+		&externalModelInfo{refs: []*resolvedProviderRef{{provider: provider.OpenAI, weight: 1}}},
 	)
 
 	_, found := store.getModel(types.NamespacedName{Namespace: "ns", Name: "other"})
@@ -53,7 +53,7 @@ func TestModelStore_GetModelInfo_NotFound(t *testing.T) {
 func TestModelStore_DeleteExternalModel(t *testing.T) {
 	store := newInfoStore()
 	key := types.NamespacedName{Namespace: "ns", Name: "ext"}
-	store.addOrUpdateModel(key, &externalModelInfo{refs: []resolvedProviderRef{
+	store.addOrUpdateModel(key, &externalModelInfo{refs: []*resolvedProviderRef{
 		{provider: provider.OpenAI, weight: 1},
 	}})
 
@@ -69,7 +69,7 @@ func TestModelStore_CrossNamespaceIsolation(t *testing.T) {
 	store := newInfoStore()
 	store.addOrUpdateModel(
 		types.NamespacedName{Namespace: "ns-a", Name: "shared-model"},
-		&externalModelInfo{refs: []resolvedProviderRef{{provider: provider.OpenAI, weight: 1}}},
+		&externalModelInfo{refs: []*resolvedProviderRef{{provider: provider.OpenAI, weight: 1}}},
 	)
 
 	_, found := store.getModel(types.NamespacedName{Namespace: "ns-b", Name: "shared-model"})

--- a/pkg/plugins/model-provider-resolver/plugin.go
+++ b/pkg/plugins/model-provider-resolver/plugin.go
@@ -168,13 +168,14 @@ func (p *ModelProviderResolverPlugin) ProcessRequest(ctx context.Context, cycleS
 		return errcommon.Error{Code: errcommon.BadRequest, Msg: fmt.Sprintf("unsupported API path: %s", relativePath)}
 	}
 
-	ref := selectByWeight(modelInfo.refs)
-
-	if ref.targetModel != model {
-		logger.Error(nil, "model mismatch between request body and ExternalModel", "requestModel", model, "externalModel", ref.targetModel)
+	// model in request body must match the ExternalModel CR name (client-facing name)
+	if modelKey.Name != model {
+		logger.Error(nil, "model mismatch between request body and ExternalModel", "requestModel", model, "externalModel", modelKey.Name)
 		return errcommon.Error{Code: errcommon.NotFound, Msg: fmt.Sprintf("model in request body '%s' doesn't match ExternalModel", model)}
 	}
 
+	// select a provider ref based on weights
+	ref := selectByWeight(modelInfo.refs)
 	cycleState.Write(state.ProviderKey, ref.provider)
 	cycleState.Write(state.ModelKey, ref.targetModel)
 	cycleState.Write(state.APIFormatKey, ref.apiFormat)
@@ -203,22 +204,22 @@ func detectInputAPIFormat(path string) apiformat.APIFormat {
 
 // selectByWeight picks a provider ref using weighted random selection.
 // With a single ref, returns it directly (no randomness).
-func selectByWeight(refs []resolvedProviderRef) *resolvedProviderRef {
+func selectByWeight(refs []*resolvedProviderRef) *resolvedProviderRef {
 	if len(refs) == 1 {
-		return &refs[0]
+		return refs[0]
 	}
 	totalWeight := 0
-	for i := range refs {
-		totalWeight += refs[i].weight
+	for _, ref := range refs {
+		totalWeight += ref.weight
 	}
 	r := rand.IntN(totalWeight)
-	for i := range refs {
-		r -= refs[i].weight
+	for _, ref := range refs {
+		r -= ref.weight
 		if r < 0 {
-			return &refs[i]
+			return ref
 		}
 	}
-	return &refs[len(refs)-1]
+	return refs[len(refs)-1]
 }
 
 func sanitizePath(relativeUrlPath string) string {

--- a/pkg/plugins/model-provider-resolver/plugin_test.go
+++ b/pkg/plugins/model-provider-resolver/plugin_test.go
@@ -39,7 +39,7 @@ func TestProcessRequest_ModelResolved(t *testing.T) {
 	)
 	store.addOrUpdateModel(
 		types.NamespacedName{Namespace: extNS, Name: extName},
-		&externalModelInfo{refs: []resolvedProviderRef{{
+		&externalModelInfo{refs: []*resolvedProviderRef{{
 			provider:        provider.Anthropic,
 			targetModel:     targetModel,
 			apiFormat:       apiformat.Messages,
@@ -54,7 +54,8 @@ func TestProcessRequest_ModelResolved(t *testing.T) {
 	cs := framework.NewCycleState()
 	req := framework.NewInferenceRequest()
 	req.Headers[":path"] = "/" + extNS + "/" + extName + "/v1/chat/completions"
-	req.Body["model"] = targetModel
+	// model in body must match CR name (extName), not targetModel
+	req.Body["model"] = extName
 
 	err := plugin.ProcessRequest(context.Background(), cs, req)
 	require.NoError(t, err)
@@ -78,6 +79,26 @@ func TestProcessRequest_ModelResolved(t *testing.T) {
 	actualAPIFormat, err := framework.ReadCycleStateKey[apiformat.APIFormat](cs, state.APIFormatKey)
 	require.NoError(t, err)
 	require.Equal(t, apiformat.Messages, actualAPIFormat)
+}
+
+func TestProcessRequest_ModelMismatch(t *testing.T) {
+	store := newInfoStore()
+	store.addOrUpdateModel(
+		types.NamespacedName{Namespace: "llm", Name: "gpt4"},
+		&externalModelInfo{refs: []*resolvedProviderRef{{
+			provider: provider.OpenAI, targetModel: "gpt-4o",
+			secretName: "k", secretNamespace: "llm",
+			config: map[string]string{}, weight: 1,
+		}}},
+	)
+	p := &ModelProviderResolverPlugin{store: store}
+	cs := framework.NewCycleState()
+	req := framework.NewInferenceRequest()
+	req.Headers[":path"] = "/llm/gpt4/v1/chat/completions"
+	req.Body["model"] = "wrong-name"
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.Error(t, err, "should error when body model doesn't match CR name")
 }
 
 func TestProcessRequest_ModelNotFound(t *testing.T) {
@@ -113,7 +134,7 @@ func TestProcessRequest_BadPath(t *testing.T) {
 	store := newInfoStore()
 	store.addOrUpdateModel(
 		types.NamespacedName{Namespace: "llm", Name: "ext"},
-		&externalModelInfo{refs: []resolvedProviderRef{{
+		&externalModelInfo{refs: []*resolvedProviderRef{{
 			provider: provider.OpenAI, targetModel: "gpt-4o",
 			secretName: "k", secretNamespace: "llm",
 			config: map[string]string{}, weight: 1,
@@ -133,7 +154,7 @@ func TestProcessRequest_BadPath(t *testing.T) {
 }
 
 func TestSelectByWeight_SingleRef(t *testing.T) {
-	refs := []resolvedProviderRef{
+	refs := []*resolvedProviderRef{
 		{provider: "openai", weight: 1},
 	}
 	selected := selectByWeight(refs)
@@ -141,7 +162,7 @@ func TestSelectByWeight_SingleRef(t *testing.T) {
 }
 
 func TestSelectByWeight_Distribution(t *testing.T) {
-	refs := []resolvedProviderRef{
+	refs := []*resolvedProviderRef{
 		{provider: "openai", weight: 80},
 		{provider: "anthropic", weight: 20},
 	}
@@ -157,7 +178,7 @@ func TestSelectByWeight_Distribution(t *testing.T) {
 }
 
 func TestSelectByWeight_EqualWeights(t *testing.T) {
-	refs := []resolvedProviderRef{
+	refs := []*resolvedProviderRef{
 		{provider: "a", weight: 1},
 		{provider: "b", weight: 1},
 		{provider: "c", weight: 1},
@@ -178,7 +199,7 @@ func TestProcessRequest_AnthropicMessages(t *testing.T) {
 	store := newInfoStore()
 	store.addOrUpdateModel(
 		types.NamespacedName{Namespace: "llm", Name: "claude"},
-		&externalModelInfo{refs: []resolvedProviderRef{{
+		&externalModelInfo{refs: []*resolvedProviderRef{{
 			provider: provider.Anthropic, targetModel: "claude-opus-4-6",
 			apiFormat: "messages", secretName: "key", secretNamespace: "llm",
 			config: map[string]string{}, weight: 1,
@@ -189,7 +210,7 @@ func TestProcessRequest_AnthropicMessages(t *testing.T) {
 	cs := framework.NewCycleState()
 	req := framework.NewInferenceRequest()
 	req.Headers[":path"] = "/llm/claude/v1/messages"
-	req.Body["model"] = "claude-opus-4-6"
+	req.Body["model"] = "claude"
 
 	err := p.ProcessRequest(context.Background(), cs, req)
 	require.NoError(t, err)
@@ -207,7 +228,7 @@ func TestProcessRequest_OpenAIResponses(t *testing.T) {
 	store := newInfoStore()
 	store.addOrUpdateModel(
 		types.NamespacedName{Namespace: "llm", Name: "gpt"},
-		&externalModelInfo{refs: []resolvedProviderRef{{
+		&externalModelInfo{refs: []*resolvedProviderRef{{
 			provider: provider.OpenAI, targetModel: "gpt-5.5",
 			apiFormat: "openai-chat", secretName: "key", secretNamespace: "llm",
 			config: map[string]string{}, weight: 1,
@@ -218,7 +239,7 @@ func TestProcessRequest_OpenAIResponses(t *testing.T) {
 	cs := framework.NewCycleState()
 	req := framework.NewInferenceRequest()
 	req.Headers[":path"] = "/llm/gpt/v1/responses"
-	req.Body["model"] = "gpt-5.5"
+	req.Body["model"] = "gpt"
 
 	err := p.ProcessRequest(context.Background(), cs, req)
 	require.NoError(t, err)
@@ -232,7 +253,7 @@ func TestProcessRequest_UnsupportedPath(t *testing.T) {
 	store := newInfoStore()
 	store.addOrUpdateModel(
 		types.NamespacedName{Namespace: "llm", Name: "model"},
-		&externalModelInfo{refs: []resolvedProviderRef{{
+		&externalModelInfo{refs: []*resolvedProviderRef{{
 			provider: provider.OpenAI, targetModel: "gpt-4o",
 			apiFormat: "openai-chat", secretName: "key", secretNamespace: "llm",
 			config: map[string]string{}, weight: 1,
@@ -243,7 +264,7 @@ func TestProcessRequest_UnsupportedPath(t *testing.T) {
 	cs := framework.NewCycleState()
 	req := framework.NewInferenceRequest()
 	req.Headers[":path"] = "/llm/model/v1/unknown"
-	req.Body["model"] = "gpt-4o"
+	req.Body["model"] = "model"
 
 	err := p.ProcessRequest(context.Background(), cs, req)
 	require.Error(t, err)

--- a/pkg/plugins/model-provider-resolver/store.go
+++ b/pkg/plugins/model-provider-resolver/store.go
@@ -46,7 +46,7 @@ type resolvedProviderRef struct {
 // externalModelInfo holds all resolved provider refs for an external model.
 // The plugin selects a provider based on weights at request time.
 type externalModelInfo struct {
-	refs []resolvedProviderRef
+	refs []*resolvedProviderRef
 }
 
 // infoStore is a thread-safe in-memory store for both provider and model info.


### PR DESCRIPTION
Follow-up to #308 per Nir review comments (PR merged before review complete).

Bug fix:
- Model name validation now compares against ExternalModel CR name (client-facing name), not targetModel
- Validation moved BEFORE weighted provider selection

Style:
- Pointer slices, pass ref as pointer, descriptive names, k8s.io/utils/ptr
- Restore removed test assertions, add TestProcessRequest_ModelMismatch

Test plan:
- make test-unit passes (76.6% coverage)
- make lint 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Requests are now validated against the resolved external model name before provider selection; mismatches return a clear not-found error.
  * Unavailable provider references are skipped until available, improving reliability of provider resolution.

* **Chores**
  * Internal reference handling and in-memory storage updated for more consistent provider resolution and selection behavior.

* **Tests**
  * Tests strengthened for secret/namespace handling, selection distribution, and model-mismatch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->