### PR TITLE
feat: external metering plugin and service (Dev Preview)

### DIFF
--- a/DEMO_ENV_SETUP_PROMPT.md
+++ b/DEMO_ENV_SETUP_PROMPT.md
@@ -1,0 +1,664 @@
+# AI Inference Gateway Demo Environment Setup
+
+Use this prompt with Claude Code to deploy the full MaaS + AI Gateway demo stack on an OpenShift cluster with RHOAI.
+
+---
+
+## Prompt for Claude
+
+```
+I need to deploy the AI Inference Gateway (MaaS) demo environment on an OpenShift cluster with RHOAI. This includes MaaS platform, the Inference Payload Processor (IPP) with custom plugins, external model routing to real providers (Anthropic, OpenAI), and a metering dashboard.
+
+## Architecture Overview
+
+The system routes AI inference requests through an Envoy gateway with ext_proc plugins:
+
+```
+Client (Claude Code / Codex / curl)
+  → Envoy Gateway (Istio, HTTPRoute)
+    → Kuadrant Auth (API key validation via Authorino)
+    → Pre-auth ext_proc (extracts model name from body → X-Gateway-Model-Name header)
+    → Post-auth ext_proc (IPP plugin chain):
+        → body-field-to-header (model name extraction)
+        → maas-headers-guard (captures + strips x-maas-* headers)
+        → external-metering (balance check + usage reporting)
+        → model-provider-resolver (resolves model → provider from ExternalModel CRDs)
+        → api-translation (format conversion between OpenAI/Anthropic/Azure/Bedrock/Vertex)
+        → apikey-injection (swaps MaaS key for provider API key from K8s secret)
+    → External Provider (api.anthropic.com, api.openai.com, etc.)
+```
+
+## Step 1: Deploy MaaS Platform
+
+Clone and deploy the MaaS platform:
+
+```bash
+git clone https://github.com/opendatahub-io/models-as-a-service.git
+cd models-as-a-service
+./scripts/deploy.sh --operator-type rhoai
+```
+
+This deploys: ODH/RHOAI operator, Kuadrant stack (Authorino + Limitador), MaaS controller, MaaS API, Gateway, and base CRDs.
+
+Wait for all pods in `opendatahub`, `openshift-ingress`, and `kuadrant-system` namespaces to be ready.
+
+## Step 2: Build Custom IPP Image
+
+The IPP (Inference Payload Processor) needs custom plugins not yet in upstream. Clone the combined-build repo and apply pending changes:
+
+### Repos needed:
+
+1. **ai-gateway-payload-processing** (IPP plugins):
+   ```bash
+   git clone https://github.com/opendatahub-io/ai-gateway-payload-processing.git
+   cd ai-gateway-payload-processing
+   ```
+
+2. **llm-d-inference-payload-processor** (IPP framework):
+   ```bash
+   git clone https://github.com/llm-d/llm-d-inference-payload-processor.git
+   ```
+
+### Pending PRs to include:
+
+These PRs contain features not yet merged into main. Cherry-pick or apply them:
+
+| PR | Repo | Branch | What it adds |
+|---|---|---|---|
+| #169 | llm-d/llm-d-inference-payload-processor | `noyitz:feat/response-body-mode-framework` | ResponseChunkProcessor interface for streaming response processing |
+| #320 | opendatahub-io/ai-gateway-payload-processing | `noyitz:feat/external-metering-dp` | External metering plugin (balance check + usage reporting) |
+| #359 | opendatahub-io/ai-gateway-payload-processing | `noyitz:feat/body-name-resolver-streaming-metering` | Body-name model resolution for single-URL routing |
+| #347 | opendatahub-io/ai-gateway-payload-processing | `asaadbalum:feat/issue-342-path-override` | Path field on CRDs for cross-cluster routing |
+
+### Build approach:
+
+The simplest way is to use the combined-build repo that merges everything:
+
+```bash
+git clone https://github.com/noyitz/ai-gateway-payload-processing.git combined-build
+cd combined-build
+git checkout combined-deploy-v2
+```
+
+This branch has all plugins pre-integrated. It uses a local `replace` directive in `go.mod` for the framework, so you need to:
+
+1. Clone the framework with PR #169:
+   ```bash
+   git clone https://github.com/noyitz/llm-d-inference-payload-processor.git
+   cd llm-d-inference-payload-processor
+   git checkout feat/response-body-mode-framework
+   cd ..
+   ```
+
+2. Update `go.mod` replace directive to point to your local framework path:
+   ```bash
+   cd combined-build
+   go mod edit -replace github.com/llm-d/llm-d-inference-payload-processor=../llm-d-inference-payload-processor
+   go mod vendor
+   ```
+
+3. Build and push the image:
+   ```bash
+   # Login to cluster registry
+   REGISTRY="default-route-openshift-image-registry.apps.<YOUR_CLUSTER_DOMAIN>"
+   oc whoami -t | docker login $REGISTRY -u $(oc whoami) --password-stdin
+
+   # Build for linux/amd64
+   docker build --platform linux/amd64 --no-cache --provenance=false \
+     --build-arg CGO_ENABLED=0 \
+     -t ${REGISTRY}/openshift-ingress/payload-processing-test:latest .
+
+   docker push ${REGISTRY}/openshift-ingress/payload-processing-test:latest
+   ```
+
+4. Deploy the custom image:
+   ```bash
+   oc set image deploy/payload-processing -n openshift-ingress \
+     payload-processing=image-registry.openshift-image-registry.svc:5000/openshift-ingress/payload-processing-test:latest
+   ```
+
+## Step 3: Set Environment Variables on IPP
+
+The reconciler needs to know the gateway name:
+
+```bash
+oc set env deploy/payload-processing -n openshift-ingress \
+  GATEWAY_NAME=maas-default-gateway \
+  GATEWAY_NAMESPACE=openshift-ingress
+```
+
+## Step 4: Create Provider Secrets
+
+Create Kubernetes secrets with your provider API keys. Replace the values with your actual keys:
+
+```bash
+# Anthropic
+oc create secret generic anthropic-api-key -n llm \
+  --from-literal=api-key='YOUR_ANTHROPIC_API_KEY'
+
+# OpenAI
+oc create secret generic openai-api-key -n llm \
+  --from-literal=api-key='YOUR_OPENAI_API_KEY'
+```
+
+If secrets already exist but aren't picked up, touch them to trigger reconciliation:
+```bash
+oc annotate secret anthropic-api-key openai-api-key -n llm touched="$(date -u +%s)" --overwrite
+```
+
+## Step 5: Create ExternalProvider CRDs
+
+```bash
+# Anthropic provider
+oc apply -f - <<'EOF'
+apiVersion: inference.opendatahub.io/v1alpha1
+kind: ExternalProvider
+metadata:
+  name: ext-anthropic
+  namespace: llm
+spec:
+  provider: anthropic
+  endpoint: api.anthropic.com
+  auth:
+    type: simple
+    secretRef:
+      name: anthropic-api-key
+EOF
+
+# OpenAI provider
+oc apply -f - <<'EOF'
+apiVersion: inference.opendatahub.io/v1alpha1
+kind: ExternalProvider
+metadata:
+  name: ext-openai
+  namespace: llm
+spec:
+  provider: openai
+  endpoint: api.openai.com
+  auth:
+    type: simple
+    secretRef:
+      name: openai-api-key
+EOF
+```
+
+## Step 6: Create ExternalModel CRDs
+
+Each model maps a client-facing model name to a provider:
+
+```bash
+# Claude Opus
+oc apply -f - <<'EOF'
+apiVersion: inference.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: ext-opus
+  namespace: llm
+spec:
+  modelName: claude-opus-4-8
+  externalProviderRefs:
+  - ref:
+      name: ext-anthropic
+    targetModel: claude-opus-4-8
+    apiFormat: messages
+    path: /v1/messages
+    weight: 1
+EOF
+
+# Claude Sonnet
+oc apply -f - <<'EOF'
+apiVersion: inference.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: ext-sonnet
+  namespace: llm
+spec:
+  modelName: claude-sonnet-4-6
+  externalProviderRefs:
+  - ref:
+      name: ext-anthropic
+    targetModel: claude-sonnet-4-6
+    apiFormat: messages
+    path: /v1/messages
+    weight: 1
+EOF
+
+# Claude Haiku
+oc apply -f - <<'EOF'
+apiVersion: inference.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: ext-haiku
+  namespace: llm
+spec:
+  modelName: claude-haiku-4-5-20251001
+  externalProviderRefs:
+  - ref:
+      name: ext-anthropic
+    targetModel: claude-haiku-4-5-20251001
+    apiFormat: messages
+    path: /v1/messages
+    weight: 1
+EOF
+
+# GPT-5.5
+oc apply -f - <<'EOF'
+apiVersion: inference.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: ext-openai
+  namespace: llm
+spec:
+  modelName: gpt-5.5
+  externalProviderRefs:
+  - ref:
+      name: ext-openai
+    targetModel: gpt-5.5
+    apiFormat: openai-responses
+    path: /v1/responses
+    weight: 1
+EOF
+```
+
+## Step 7: Create Istio Networking Resources
+
+External providers need ServiceEntry + DestinationRule for TLS:
+
+```bash
+# Anthropic
+oc apply -f - <<'EOF'
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: ext-anthropic
+  namespace: llm
+spec:
+  hosts: ["api.anthropic.com"]
+  location: MESH_EXTERNAL
+  resolution: DNS
+  ports:
+  - number: 443
+    name: https
+    protocol: HTTPS
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: ext-anthropic
+  namespace: llm
+spec:
+  host: api.anthropic.com
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+EOF
+
+# OpenAI
+oc apply -f - <<'EOF'
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: ext-openai
+  namespace: llm
+spec:
+  hosts: ["api.openai.com"]
+  location: MESH_EXTERNAL
+  resolution: DNS
+  ports:
+  - number: 443
+    name: https
+    protocol: HTTPS
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: ext-openai
+  namespace: llm
+spec:
+  host: api.openai.com
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+EOF
+```
+
+Also create ExternalName Services for the HTTPRoute backends:
+```bash
+for provider in ext-anthropic ext-openai; do
+  ENDPOINT=$(oc get externalprovider $provider -n llm -o jsonpath='{.spec.endpoint}')
+  oc apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: $provider
+  namespace: llm
+spec:
+  type: ExternalName
+  externalName: $ENDPOINT
+  ports:
+  - port: 443
+    protocol: TCP
+EOF
+done
+```
+
+## Step 8: Apply Required Patches
+
+### 8a. EnvoyFilter: FULL_DUPLEX_STREAMED mode
+
+The MaaS controller sets `response_body_mode: STREAMED` which breaks streaming. Fix it:
+
+```bash
+oc get envoyfilter payload-processing -n openshift-ingress -o json | \
+  python3 -c "
+import sys, json
+ef = json.load(sys.stdin)
+for p in ef['spec']['configPatches']:
+    pm = p.get('patch',{}).get('value',{}).get('typed_config',{}).get('processing_mode',{})
+    if 'response_body_mode' in pm:
+        pm['response_body_mode'] = 'FULL_DUPLEX_STREAMED'
+json.dump(ef, sys.stdout)
+" | oc apply -f -
+```
+
+### 8b. Restart gateway pod to pick up EnvoyFilter changes:
+
+```bash
+oc delete pod -n openshift-ingress \
+  -l gateway.networking.k8s.io/gateway-name=maas-default-gateway
+```
+
+### 8c. Lua filter for x-api-key → Authorization:Bearer conversion
+
+Claude Code sends `x-api-key` header but Kuadrant expects `Authorization: Bearer`. Add a Lua filter:
+
+```bash
+oc apply -f - <<'EOF'
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: xapikey-to-bearer
+  namespace: openshift-ingress
+spec:
+  workloadSelector:
+    labels:
+      gateway.networking.k8s.io/gateway-name: maas-default-gateway
+  configPatches:
+  - applyTo: HTTP_FILTER
+    match:
+      context: GATEWAY
+      listener:
+        filterChain:
+          filter:
+            name: envoy.filters.network.http_connection_manager
+            subFilter:
+              name: extensions.istio.io/wasmplugin/openshift-ingress.kuadrant-maas-default-gateway
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: envoy.filters.http.lua.xapikey
+        typed_config:
+          '@type': type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+          default_source_code:
+            inline_string: |
+              function envoy_on_request(handle)
+                local method = handle:headers():get(":method")
+                if method == "HEAD" then
+                  handle:respond({[":status"] = "200"}, "")
+                  return
+                end
+                local xkey = handle:headers():get("x-api-key")
+                if xkey and not handle:headers():get("authorization") then
+                  handle:headers():add("authorization", "Bearer " .. xkey)
+                end
+              end
+EOF
+```
+
+### 8d. URLRewrite on HTTPRoutes
+
+All HTTPRoutes need URLRewrite to strip the path prefix before sending to providers:
+
+```bash
+for route in $(oc get httproutes -n llm -o jsonpath='{.items[*].metadata.name}'); do
+  RULES=$(oc get httproute $route -n llm -o jsonpath='{range .spec.rules[*]}{.matches[0].path.value}{"\n"}{end}' | wc -l)
+  for i in $(seq 0 $(($RULES - 1))); do
+    oc patch httproute $route -n llm --type=json \
+      -p "[{\"op\": \"add\", \"path\": \"/spec/rules/$i/filters/-\", \"value\": {\"type\": \"URLRewrite\", \"urlRewrite\": {\"path\": {\"type\": \"ReplacePrefixMatch\", \"replacePrefixMatch\": \"/\"}}}}]" 2>/dev/null
+  done
+done
+```
+
+## Step 9: Update IPP Config
+
+Apply the IPP plugin chain configuration:
+
+```bash
+oc apply -f - <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ipp-config
+  namespace: openshift-ingress
+data:
+  config.yaml: |
+    plugins:
+    - name: model-extractor
+      parameters:
+        fieldName: model
+        headerName: X-Gateway-Model-Name
+      type: body-field-to-header
+    - name: maas-headers-guard
+      type: maas-headers-guard
+    - name: metering-streaming
+      parameters:
+        failOpen: true
+        featureKey: inference-tokens
+        meteringURL: http://metering-service.openshift-ingress.svc:8080
+        source: maas-gateway
+        timeoutSeconds: 5
+      type: external-metering-streaming
+    - name: model-provider-resolver
+      type: model-provider-resolver
+    - name: api-translation
+      type: api-translation
+    - name: apikey-injection
+      type: apikey-injection
+    profiles:
+    - name: default
+      plugins:
+        request:
+        - pluginRef: model-extractor
+        - pluginRef: maas-headers-guard
+        - pluginRef: metering-streaming
+        - pluginRef: model-provider-resolver
+        - pluginRef: api-translation
+        - pluginRef: apikey-injection
+        response:
+        - pluginRef: metering-streaming
+EOF
+```
+
+Restart IPP to pick up config:
+```bash
+oc rollout restart deploy/payload-processing -n openshift-ingress
+```
+
+## Step 10: Deploy Metering Dashboard (Optional)
+
+```bash
+git clone https://github.com/noyitz/ai-gateway-metering-service.git
+cd ai-gateway-metering-service
+
+# Build and push
+REGISTRY="default-route-openshift-image-registry.apps.<YOUR_CLUSTER_DOMAIN>"
+docker build --platform linux/amd64 --no-cache --provenance=false \
+  -t ${REGISTRY}/openshift-ingress/metering-dashboard:latest .
+docker push ${REGISTRY}/openshift-ingress/metering-dashboard:latest
+
+# Deploy
+oc apply -f - <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metering-service
+  namespace: openshift-ingress
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: metering-service
+  template:
+    metadata:
+      labels:
+        app: metering-service
+    spec:
+      containers:
+      - name: metering
+        image: image-registry.openshift-image-registry.svc:5000/openshift-ingress/metering-dashboard:latest
+        ports:
+        - containerPort: 8080
+        env:
+        - name: NAMESPACE
+          value: llm
+        - name: CONFIG_NAMESPACE
+          value: openshift-ingress
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metering-service
+  namespace: openshift-ingress
+spec:
+  selector:
+    app: metering-service
+  ports:
+  - port: 8080
+    targetPort: 8080
+EOF
+```
+
+Expose the dashboard via route:
+```bash
+oc create route edge metering-dashboard \
+  --service=metering-service \
+  --port=8080 \
+  -n openshift-ingress
+```
+
+## Step 11: Generate MaaS API Keys
+
+Port-forward to the MaaS API and create keys:
+
+```bash
+# Find the maas-api pod
+oc port-forward -n opendatahub svc/maas-api 8443:8443 &
+
+# Create a user API key
+curl -sk https://localhost:8443/v1/api-keys \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "X-MaaS-Username: YOUR_USERNAME" \
+  -H 'X-MaaS-Group: ["ai-eng"]' \
+  -H "X-MaaS-Tenant: models-as-a-service" \
+  -d '{"name":"my-key"}'
+```
+
+The response contains your MaaS API key (format: `sk-oai-{keyID}_{secret}`). Save it.
+
+## Step 12: Test with curl
+
+Get the gateway URL:
+```bash
+GATEWAY_URL=$(oc get gateway maas-default-gateway -n openshift-ingress \
+  -o jsonpath='{.status.addresses[0].value}')
+# Or use the route:
+GATEWAY_URL="https://maas.apps.<YOUR_CLUSTER_DOMAIN>"
+```
+
+Test Anthropic (single-URL, model in body):
+```bash
+curl -sk $GATEWAY_URL/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: YOUR_MAAS_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "claude-opus-4-8",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "max_tokens": 50
+  }'
+```
+
+Test OpenAI:
+```bash
+curl -sk $GATEWAY_URL/v1/responses \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_MAAS_API_KEY" \
+  -d '{
+    "model": "gpt-5.5",
+    "input": "Hello!",
+    "max_output_tokens": 50
+  }'
+```
+
+## Step 13: Configure Claude Code
+
+To use Claude Code through the gateway:
+
+```bash
+ANTHROPIC_BASE_URL=https://maas.apps.<YOUR_CLUSTER_DOMAIN>/v1 \
+ANTHROPIC_API_KEY=YOUR_MAAS_API_KEY \
+claude
+```
+
+Or for per-model URL pattern:
+```bash
+ANTHROPIC_BASE_URL=https://maas.apps.<YOUR_CLUSTER_DOMAIN>/llm/ext-opus \
+ANTHROPIC_API_KEY=YOUR_MAAS_API_KEY \
+claude
+```
+
+For Codex:
+```bash
+OPENAI_BASE_URL=https://maas.apps.<YOUR_CLUSTER_DOMAIN>/llm/ext-openai \
+OPENAI_API_KEY=YOUR_MAAS_API_KEY \
+codex
+```
+
+## Troubleshooting
+
+### Common issues:
+
+1. **503 upstream_reset_before_response_started**: Gateway pod needs restart after EnvoyFilter changes.
+
+2. **Empty response body (HTTP 200, 0 bytes)**: EnvoyFilter `response_body_mode` is wrong. Must be `FULL_DUPLEX_STREAMED`, not `STREAMED`. Re-apply step 8a and restart gateway.
+
+3. **401 auth errors**: Check that the Lua filter (step 8c) is in place for x-api-key conversion. Verify the MaaS API key is valid.
+
+4. **404 on requests**: Check HTTPRoute rules exist and have the correct gateway parentRef name (`maas-default-gateway`).
+
+5. **Secrets not picked up**: Annotate secrets to trigger reconciliation (step 4).
+
+6. **Model not found (passthrough)**: Check `spec.modelName` on ExternalModel matches what the client sends in the body `model` field.
+
+### Useful debug commands:
+
+```bash
+# Check IPP logs
+oc logs -n openshift-ingress -l app=payload-processing --tail=50
+
+# Check envoy access logs
+GW_POD=$(oc get pods -n openshift-ingress \
+  -l gateway.networking.k8s.io/gateway-name=maas-default-gateway \
+  -o jsonpath='{.items[0].metadata.name}')
+oc logs $GW_POD -n openshift-ingress -c istio-proxy --tail=20
+
+# Check CRD state
+oc get externalmodels.inference.opendatahub.io -n llm
+oc get externalproviders.inference.opendatahub.io -n llm
+oc get httproutes -n llm
+
+# Check IPP config
+oc get cm ipp-config -n openshift-ingress -o yaml
+```
+```

--- a/deploy/examples/external-metering/README.md
+++ b/deploy/examples/external-metering/README.md
@@ -1,0 +1,110 @@
+# External Metering — Example Deployment
+
+Dev Preview: per-user token usage tracking and cost attribution for the AI Inference Gateway.
+
+**RHAISTRAT-1919** | Not included in the default plugin chain — operators enable manually.
+
+## Architecture
+
+```
+Client → Gateway → IPP Plugin Chain
+                      ├── model-provider-resolver
+                      ├── external-metering ← checks balance, reports usage
+                      ├── api-translation
+                      └── apikey-injection
+                              ↓
+                    OpenMeter (or compatible metering backend)
+                      ├── POST /api/v1/events (CloudEvents ingestion)
+                      └── GET /api/v1/customers/{id}/entitlements/{key}/value
+```
+
+## Prerequisites
+
+- RHOAI cluster with AI Inference Gateway deployed
+- `oc` CLI logged in with cluster-admin
+- A metering backend that accepts CloudEvents v1.0 (e.g., [OpenMeter](https://openmeter.io))
+
+## Deploy OpenMeter
+
+OpenMeter can run as a pod within the cluster. See the [OpenMeter quickstart](https://openmeter.io/docs/getting-started/quickstart) for deployment options.
+
+Example using their Helm chart:
+
+```bash
+helm repo add openmeter https://openmeter.github.io/helm-charts
+helm install openmeter openmeter/openmeter -n metering --create-namespace
+```
+
+## Enable the Plugin
+
+Merge `values-with-metering.yaml` with your existing Helm values, updating `meteringURL` to point to your OpenMeter (or compatible) service:
+
+```bash
+helm upgrade ai-gateway <chart> -f values-with-metering.yaml
+```
+
+## Plugin Configuration
+
+```yaml
+- type: external-metering
+  name: external-metering
+  json:
+    meteringURL: "http://openmeter.metering.svc:8080"
+    timeoutSeconds: 5
+    featureKey: "inference-tokens"
+    source: "maas-gateway"
+    failOpen: true
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `meteringURL` | (required) | Metering backend endpoint (OpenMeter or compatible) |
+| `timeoutSeconds` | `5` | HTTP timeout for balance checks |
+| `featureKey` | `inference-tokens` | Entitlement key for quota lookup |
+| `source` | `maas-gateway` | CloudEvents source identifier |
+| `failOpen` | `true` | Allow requests when metering backend is unavailable |
+
+## CloudEvents Format
+
+The plugin emits events in [CloudEvents v1.0](https://cloudevents.io) format:
+
+```json
+{
+  "specversion": "1.0",
+  "id": "evt-<uuid>",
+  "source": "maas-gateway",
+  "type": "inference.tokens.used",
+  "subject": "<username>",
+  "time": "2026-06-10T12:00:00Z",
+  "datacontenttype": "application/json",
+  "data": {
+    "user": "<username>",
+    "group": "<group>",
+    "subscription": "<subscription>",
+    "provider": "anthropic",
+    "model": "claude-opus-4-8",
+    "prompt_tokens": 150,
+    "completion_tokens": 80,
+    "total_tokens": 230,
+    "cached_input_tokens": 12000,
+    "cache_creation_tokens": 100,
+    "reasoning_tokens": 0,
+    "duration_ms": 1200
+  }
+}
+```
+
+## Token Types Tracked
+
+| Token Type | OpenAI field | Anthropic field |
+|-----------|-------------|-----------------|
+| Input (new) | `prompt_tokens` | `input_tokens` |
+| Output | `completion_tokens` | `output_tokens` |
+| Cached read | `prompt_tokens_details.cached_tokens` | `cache_read_input_tokens` |
+| Cache write | — | `cache_creation_input_tokens` |
+| Reasoning | `completion_tokens_details.reasoning_tokens` | — |
+
+## Testing with the Development Metering Service
+
+For testing without OpenMeter, a standalone development metering service with PostgreSQL and built-in dashboards is available at:
+[noyitz/ai-gateway-metering-service](https://github.com/noyitz/ai-gateway-metering-service)

--- a/deploy/examples/external-metering/values-with-metering.yaml
+++ b/deploy/examples/external-metering/values-with-metering.yaml
@@ -1,0 +1,27 @@
+# Example Helm values to enable external-metering in the IPP plugin chain.
+# Merge with your existing values file.
+#
+# The external-metering plugin should run AFTER model-provider-resolver
+# (needs provider/model info in CycleState) and BEFORE api-translation
+# (to access raw response token formats before translation).
+
+upstreamBbr:
+  bbr:
+    plugins:
+      - type: model-provider-resolver
+        name: model-provider-resolver
+
+      - type: external-metering
+        name: external-metering
+        json:
+          meteringURL: "http://openmeter.metering.svc:8080"
+          timeoutSeconds: 5
+          featureKey: "inference-tokens"
+          source: "maas-gateway"
+          failOpen: true
+
+      - type: api-translation
+        name: api-translation
+
+      - type: apikey-injection
+        name: apikey-injection

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.28.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/pkg/plugins/common/state/state-keys.go
+++ b/pkg/plugins/common/state/state-keys.go
@@ -28,4 +28,11 @@ const (
 	InputAPIFormatKey = "input-api-format"
 	EndpointKey       = "endpoint"
 	PathKey           = "path"
+
+	// Metering CycleState keys
+	MeteringUsernameKey     = "metering-username"
+	MeteringGroupKey        = "metering-group"
+	MeteringSubscriptionKey = "metering-subscription"
+	MeteringModelKey        = "metering-model"
+	MeteringRequestTimeKey  = "metering-request-time"
 )

--- a/pkg/plugins/external-metering/client.go
+++ b/pkg/plugins/external-metering/client.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package external_metering
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	neturl "net/url"
+	"time"
+)
+
+const maxResponseBytes = 1 << 20 // 1 MiB
+
+type entitlementValue struct {
+	HasAccess bool    `json:"hasAccess"`
+	Balance   float64 `json:"balance"`
+	Usage     float64 `json:"usage"`
+	Overage   float64 `json:"overage"`
+}
+
+type meteringClient struct {
+	httpClient *http.Client
+	baseURL    string
+}
+
+func newMeteringClient(baseURL string, timeoutSeconds int) *meteringClient {
+	timeout := time.Duration(timeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	return &meteringClient{
+		httpClient: &http.Client{Timeout: timeout},
+		baseURL:    baseURL,
+	}
+}
+
+func (c *meteringClient) checkBalance(ctx context.Context, customerID, featureKey, model string) (*entitlementValue, error) {
+	url := fmt.Sprintf("%s/api/v1/customers/%s/entitlements/%s/value?model=%s",
+		c.baseURL, neturl.PathEscape(customerID), neturl.PathEscape(featureKey), neturl.QueryEscape(model))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create balance check request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("balance check call failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("balance check returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read balance check response: %w", err)
+	}
+
+	var result entitlementValue
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to decode balance check response: %w", err)
+	}
+
+	return &result, nil
+}
+
+func (c *meteringClient) reportUsage(ctx context.Context, event []byte) error {
+	url := fmt.Sprintf("%s/api/v1/events", c.baseURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(event))
+	if err != nil {
+		return fmt.Errorf("failed to create usage report request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("usage report call failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("usage report returned status %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/pkg/plugins/external-metering/plugin.go
+++ b/pkg/plugins/external-metering/plugin.go
@@ -1,0 +1,364 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package external_metering
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	errcommon "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/error"
+	logutil "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
+
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/state"
+)
+
+const (
+	ExternalMeteringPluginType          = "external-metering"
+	ExternalMeteringStreamingPluginType = "external-metering-streaming"
+
+	defaultTimeoutSec = 5
+	defaultFeatureKey = "inference-tokens"
+	defaultSource     = "maas-gateway"
+)
+
+// compile-time interface assertions
+var _ requesthandling.RequestProcessor = &ExternalMeteringPlugin{}
+var _ requesthandling.ResponseProcessor = &ExternalMeteringPlugin{}
+var _ requesthandling.RequestProcessor = &ExternalMeteringStreamingPlugin{}
+
+// --- Shared config and construction ---
+
+type externalMeteringConfig struct {
+	MeteringURL    string `json:"meteringURL"`
+	TimeoutSeconds int    `json:"timeoutSeconds,omitempty"`
+	FeatureKey     string `json:"featureKey,omitempty"`
+	Source         string `json:"source,omitempty"`
+	FailOpen       *bool  `json:"failOpen,omitempty"`
+}
+
+type meteringBase struct {
+	typedName  plugin.TypedName
+	client     *meteringClient
+	featureKey string
+	source     string
+	failOpen   bool
+}
+
+func parseConfig(pluginType string, rawParameters json.RawMessage) (*meteringBase, error) {
+	defaultFailOpen := true
+	config := externalMeteringConfig{
+		TimeoutSeconds: defaultTimeoutSec,
+		FeatureKey:     defaultFeatureKey,
+		Source:         defaultSource,
+		FailOpen:       &defaultFailOpen,
+	}
+
+	if len(rawParameters) > 0 {
+		if err := json.Unmarshal(rawParameters, &config); err != nil {
+			return nil, fmt.Errorf("failed to parse the parameters of '%s' plugin - %w", pluginType, err)
+		}
+	}
+
+	if config.MeteringURL == "" {
+		return nil, fmt.Errorf("'meteringURL' is required for '%s' plugin", pluginType)
+	}
+
+	if config.FeatureKey == "" {
+		config.FeatureKey = defaultFeatureKey
+	}
+	if config.Source == "" {
+		config.Source = defaultSource
+	}
+
+	return &meteringBase{
+		typedName: plugin.TypedName{
+			Type: pluginType,
+			Name: pluginType,
+		},
+		client:     newMeteringClient(config.MeteringURL, config.TimeoutSeconds),
+		featureKey: config.FeatureKey,
+		source:     config.Source,
+		failOpen:   config.FailOpen == nil || *config.FailOpen,
+	}, nil
+}
+
+// processRequest is the shared request-side logic: read identity from maas-headers
+// CycleState (set by maas-headers-guard), check balance, inject stream_options.
+func (b *meteringBase) processRequest(ctx context.Context, cycleState *plugin.CycleState, request *requesthandling.InferenceRequest) error {
+	logger := log.FromContext(ctx)
+
+	// Read identity from maas-headers CycleState (set by maas-headers-guard plugin).
+	// Falls back to reading directly from request headers for backward compatibility.
+	var username, group, subscription string
+	if maasHeaders, err := plugin.ReadCycleStateKey[map[string]string](cycleState, "maas-headers"); err == nil {
+		username = maasHeaders["x-maas-username"]
+		if username == "" {
+			username = maasHeaders["X-MaaS-Username"]
+		}
+		group = maasHeaders["x-maas-group"]
+		if group == "" {
+			group = maasHeaders["X-MaaS-Group"]
+		}
+		subscription = maasHeaders["x-maas-subscription"]
+		if subscription == "" {
+			subscription = maasHeaders["X-MaaS-Subscription"]
+		}
+	}
+	if username == "" {
+		username = request.Headers["x-maas-username"]
+	}
+	if username == "" {
+		username = request.Headers["x-maas-subscription"]
+	}
+	if username == "" {
+		logger.V(logutil.VERBOSE).Info("no username or subscription header found, skipping metering")
+		return nil
+	}
+
+	if subscription == "" {
+		subscription = request.Headers["x-maas-subscription"]
+	}
+	if group == "" {
+		group = request.Headers["x-maas-group"]
+	}
+	if group == "" {
+		group = subscription
+	}
+
+	model, _ := request.Body["model"].(string)
+
+	cycleState.Write(state.MeteringUsernameKey, username)
+	cycleState.Write(state.MeteringGroupKey, group)
+	cycleState.Write(state.MeteringSubscriptionKey, subscription)
+	cycleState.Write(state.MeteringModelKey, model)
+	cycleState.Write(state.MeteringRequestTimeKey, time.Now())
+
+	result, err := b.client.checkBalance(ctx, username, b.featureKey, model)
+	if err != nil {
+		if b.failOpen {
+			logger.Error(err, "metering balance check failed (fail-open), allowing request")
+			return nil
+		}
+		return errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: fmt.Sprintf("metering system unavailable: %v", err)}
+	}
+
+	if !result.HasAccess {
+		logger.Info("request blocked by metering", "customer", username, "balance", result.Balance)
+		return errcommon.Error{Code: errcommon.ResourceExhausted, Msg: "token budget exhausted"}
+	}
+
+	logger.V(logutil.VERBOSE).Info("metering check passed", "customer", username, "balance", result.Balance)
+
+	// Inject stream_options.include_usage for streaming requests (OpenAI-compatible providers).
+	// Anthropic always includes usage in streaming responses regardless of this option.
+	if streaming, ok := request.Body["stream"].(bool); ok && streaming {
+		opts, _ := request.Body["stream_options"].(map[string]any)
+		if opts == nil {
+			opts = map[string]any{}
+		}
+		opts["include_usage"] = true
+		request.Body["stream_options"] = opts
+	}
+
+	return nil
+}
+
+// reportUsageEvent builds and sends a usage event to the metering service.
+func (b *meteringBase) reportUsageEvent(ctx context.Context, cycleState *plugin.CycleState, usage map[string]any) {
+	logger := log.FromContext(ctx)
+
+	username, _ := plugin.ReadCycleStateKey[string](cycleState, state.MeteringUsernameKey)
+	group, _ := plugin.ReadCycleStateKey[string](cycleState, state.MeteringGroupKey)
+	subscription, _ := plugin.ReadCycleStateKey[string](cycleState, state.MeteringSubscriptionKey)
+	model, _ := plugin.ReadCycleStateKey[string](cycleState, state.MeteringModelKey)
+	provider, _ := plugin.ReadCycleStateKey[string](cycleState, state.ProviderKey)
+
+	promptTokens, completionTokens, totalTokens := extractTokenCounts(usage)
+
+	cachedInputTokens := 0
+	cacheCreationTokens := 0
+	reasoningTokens := 0
+
+	if v := toInt(usage["cache_read_input_tokens"]); v > 0 {
+		cachedInputTokens = v
+	}
+	if v := toInt(usage["cache_creation_input_tokens"]); v > 0 {
+		cacheCreationTokens = v
+	}
+	if cachedInputTokens == 0 {
+		if details, ok := usage["prompt_tokens_details"].(map[string]any); ok {
+			cachedInputTokens = toInt(details["cached_tokens"])
+		}
+	}
+	if details, ok := usage["completion_tokens_details"].(map[string]any); ok {
+		reasoningTokens = toInt(details["reasoning_tokens"])
+	}
+
+	var durationMs int64
+	if reqTime, err := plugin.ReadCycleStateKey[time.Time](cycleState, state.MeteringRequestTimeKey); err == nil {
+		durationMs = time.Since(reqTime).Milliseconds()
+	}
+
+	event := map[string]any{
+		"specversion":     "1.0",
+		"id":              fmt.Sprintf("evt-%s", uuid.New().String()),
+		"source":          b.source,
+		"type":            "inference.tokens.used",
+		"subject":         username,
+		"time":            time.Now().UTC().Format(time.RFC3339),
+		"datacontenttype": "application/json",
+		"data": map[string]any{
+			"user":                  username,
+			"group":                 group,
+			"subscription":          subscription,
+			"provider":              provider,
+			"model":                 model,
+			"prompt_tokens":         promptTokens,
+			"completion_tokens":     completionTokens,
+			"total_tokens":          totalTokens,
+			"cached_input_tokens":   cachedInputTokens,
+			"cache_creation_tokens": cacheCreationTokens,
+			"reasoning_tokens":      reasoningTokens,
+			"duration_ms":           durationMs,
+		},
+	}
+
+	eventJSON, marshalErr := json.Marshal(event)
+	if marshalErr != nil {
+		logger.Error(marshalErr, "failed to marshal usage event")
+		return
+	}
+
+	if reportErr := b.client.reportUsage(ctx, eventJSON); reportErr != nil {
+		logger.Error(reportErr, "failed to report usage to metering system")
+	} else {
+		logger.V(logutil.VERBOSE).Info("usage reported", "customer", username, "model", model, "tokens", totalTokens)
+	}
+}
+
+// --- ExternalMeteringPlugin (ResponseProcessor — full body) ---
+
+// ExternalMeteringPlugin implements RequestProcessor and ResponseProcessor.
+// Use in profiles that buffer the full response body (e.g., with api-translation).
+type ExternalMeteringPlugin struct {
+	meteringBase
+}
+
+func ExternalMeteringFactory(name string, rawParameters json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+	base, err := parseConfig(ExternalMeteringPluginType, rawParameters)
+	if err != nil {
+		return nil, err
+	}
+	p := &ExternalMeteringPlugin{meteringBase: *base}
+	return p.WithName(name), nil
+}
+
+func (p *ExternalMeteringPlugin) TypedName() plugin.TypedName { return p.typedName }
+
+func (p *ExternalMeteringPlugin) WithName(name string) *ExternalMeteringPlugin {
+	p.typedName.Name = name
+	return p
+}
+
+func (p *ExternalMeteringPlugin) ProcessRequest(ctx context.Context, cycleState *plugin.CycleState, request *requesthandling.InferenceRequest) error {
+	return p.processRequest(ctx, cycleState, request)
+}
+
+func (p *ExternalMeteringPlugin) ProcessResponse(ctx context.Context, cycleState *plugin.CycleState, response *requesthandling.InferenceResponse) error {
+	username, err := plugin.ReadCycleStateKey[string](cycleState, state.MeteringUsernameKey)
+	if err != nil || username == "" {
+		return nil
+	}
+
+	usage, ok := response.Body["usage"].(map[string]any)
+	if !ok {
+		log.FromContext(ctx).V(logutil.VERBOSE).Info("no usage data in response, skipping metering report")
+		return nil
+	}
+
+	p.reportUsageEvent(ctx, cycleState, usage)
+	return nil
+}
+
+// --- ExternalMeteringStreamingPlugin (RequestProcessor only — for streaming profiles) ---
+
+// ExternalMeteringStreamingPlugin implements RequestProcessor only.
+// Use in profiles that stream response chunks (no buffering).
+// Response-side chunk processing (ResponseChunkProcessor) will be added
+// after the upstream framework merges the ResponseChunkProcessor interface (PR #169).
+type ExternalMeteringStreamingPlugin struct {
+	meteringBase
+}
+
+func ExternalMeteringStreamingFactory(name string, rawParameters json.RawMessage, _ plugin.Handle) (plugin.Plugin, error) {
+	base, err := parseConfig(ExternalMeteringStreamingPluginType, rawParameters)
+	if err != nil {
+		return nil, err
+	}
+	p := &ExternalMeteringStreamingPlugin{meteringBase: *base}
+	return p.WithName(name), nil
+}
+
+func (p *ExternalMeteringStreamingPlugin) TypedName() plugin.TypedName { return p.typedName }
+
+func (p *ExternalMeteringStreamingPlugin) WithName(name string) *ExternalMeteringStreamingPlugin {
+	p.typedName.Name = name
+	return p
+}
+
+func (p *ExternalMeteringStreamingPlugin) ProcessRequest(ctx context.Context, cycleState *plugin.CycleState, request *requesthandling.InferenceRequest) error {
+	return p.processRequest(ctx, cycleState, request)
+}
+
+// --- Shared helpers ---
+
+func extractTokenCounts(usage map[string]any) (prompt, completion, total int) {
+	prompt = toInt(usage["prompt_tokens"])
+	completion = toInt(usage["completion_tokens"])
+	total = toInt(usage["total_tokens"])
+
+	if prompt == 0 && completion == 0 {
+		prompt = toInt(usage["input_tokens"])
+		completion = toInt(usage["output_tokens"])
+	}
+
+	if total == 0 {
+		total = prompt + completion
+	}
+	return
+}
+
+func toInt(v any) int {
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	case json.Number:
+		i, _ := n.Int64()
+		return int(i)
+	default:
+		return 0
+	}
+}

--- a/pkg/plugins/external-metering/plugin_test.go
+++ b/pkg/plugins/external-metering/plugin_test.go
@@ -1,0 +1,493 @@
+/*
+Copyright 2026 The opendatahub.io Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package external_metering
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	
+	errcommon "github.com/llm-d/llm-d-inference-payload-processor/pkg/common/error"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
+	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/requesthandling"
+
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/state"
+)
+
+// --- Factory Tests ---
+
+func TestFactory_ValidConfig(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	config, _ := json.Marshal(map[string]any{
+		"meteringURL":    srv.URL,
+		"timeoutSeconds": 3,
+		"featureKey":     "tokens",
+		"source":         "test",
+		"failOpen":       false,
+	})
+
+	p, err := ExternalMeteringFactory("test-metering", config, nil)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	assert.Equal(t, "test-metering", p.TypedName().Name)
+	assert.Equal(t, ExternalMeteringPluginType, p.TypedName().Type)
+}
+
+func TestFactory_MissingURL(t *testing.T) {
+	config, _ := json.Marshal(map[string]any{})
+	_, err := ExternalMeteringFactory("test", config, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "meteringURL")
+}
+
+func TestFactory_InvalidJSON(t *testing.T) {
+	_, err := ExternalMeteringFactory("test", []byte("{invalid"), nil)
+	require.Error(t, err)
+}
+
+func TestFactory_Defaults(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	config, _ := json.Marshal(map[string]any{"meteringURL": srv.URL})
+	bp, err := ExternalMeteringFactory("test", config, nil)
+	require.NoError(t, err)
+
+	p := bp.(*ExternalMeteringPlugin)
+	assert.Equal(t, defaultFeatureKey, p.featureKey)
+	assert.Equal(t, defaultSource, p.source)
+	assert.True(t, p.failOpen)
+}
+
+// --- ProcessRequest Tests ---
+
+func TestProcessRequest_BalanceAllowed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/api/v1/customers/alice/entitlements/inference-tokens/value")
+		assert.Equal(t, "gpt-4o", r.URL.Query().Get("model"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"hasAccess":true,"balance":9000,"usage":1000,"overage":0}`))
+	}))
+	defer srv.Close()
+
+	p := newTestPlugin(t, srv.URL, true)
+	cs := plugin.NewCycleState()
+	req := newTestRequest("alice", "finance", "premium", "gpt-4o", false)
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err)
+
+	username, _ := plugin.ReadCycleStateKey[string](cs, state.MeteringUsernameKey)
+	assert.Equal(t, "alice", username)
+	group, _ := plugin.ReadCycleStateKey[string](cs, state.MeteringGroupKey)
+	assert.Equal(t, "finance", group)
+	sub, _ := plugin.ReadCycleStateKey[string](cs, state.MeteringSubscriptionKey)
+	assert.Equal(t, "premium", sub)
+	model, _ := plugin.ReadCycleStateKey[string](cs, state.MeteringModelKey)
+	assert.Equal(t, "gpt-4o", model)
+}
+
+func TestProcessRequest_BalanceDenied(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"hasAccess":false,"balance":0,"usage":10000,"overage":0}`))
+	}))
+	defer srv.Close()
+
+	p := newTestPlugin(t, srv.URL, true)
+	cs := plugin.NewCycleState()
+	req := newTestRequest("alice", "", "", "gpt-4o", false)
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.Error(t, err)
+
+	var commErr errcommon.Error
+	require.ErrorAs(t, err, &commErr)
+	assert.Equal(t, errcommon.ResourceExhausted, commErr.Code)
+}
+
+func TestProcessRequest_Unreachable_FailOpen(t *testing.T) {
+	p := newTestPlugin(t, "http://127.0.0.1:1", true)
+	cs := plugin.NewCycleState()
+	req := newTestRequest("alice", "", "", "gpt-4o", false)
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err)
+}
+
+func TestProcessRequest_Unreachable_FailClosed(t *testing.T) {
+	p := newTestPlugin(t, "http://127.0.0.1:1", false)
+	cs := plugin.NewCycleState()
+	req := newTestRequest("alice", "", "", "gpt-4o", false)
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.Error(t, err)
+
+	var commErr errcommon.Error
+	require.ErrorAs(t, err, &commErr)
+	assert.Equal(t, errcommon.ServiceUnavailable, commErr.Code)
+}
+
+func TestProcessRequest_MissingUsername(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("should not call metering when username is missing")
+	}))
+	defer srv.Close()
+
+	p := newTestPlugin(t, srv.URL, true)
+	cs := plugin.NewCycleState()
+	req := newTestRequest("", "", "", "gpt-4o", false)
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err)
+}
+
+func TestProcessRequest_StreamingInjectsUsageOption(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"hasAccess":true,"balance":9000,"usage":1000,"overage":0}`))
+	}))
+	defer srv.Close()
+
+	p := newTestPlugin(t, srv.URL, true)
+	cs := plugin.NewCycleState()
+	req := newTestRequest("alice", "", "", "gpt-4o", true)
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err)
+
+	streamOpts, exists := req.Body["stream_options"]
+	require.True(t, exists)
+	opts, ok := streamOpts.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, opts["include_usage"])
+}
+
+func TestProcessRequest_NonStreamingNoUsageOption(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"hasAccess":true,"balance":9000,"usage":1000,"overage":0}`))
+	}))
+	defer srv.Close()
+
+	p := newTestPlugin(t, srv.URL, true)
+	cs := plugin.NewCycleState()
+	req := newTestRequest("alice", "", "", "gpt-4o", false)
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err)
+
+	_, exists := req.Body["stream_options"]
+	assert.False(t, exists)
+}
+
+// --- ProcessResponse Tests ---
+
+func TestProcessResponse_ReportsUsage(t *testing.T) {
+	var mu sync.Mutex
+	var receivedEvent map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/events" {
+			var evt map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&evt)
+			mu.Lock()
+			receivedEvent = evt
+			mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	p := newTestPlugin(t, srv.URL, true)
+	cs := plugin.NewCycleState()
+	cs.Write(state.MeteringUsernameKey, "alice")
+	cs.Write(state.MeteringGroupKey, "finance")
+	cs.Write(state.MeteringSubscriptionKey, "premium")
+	cs.Write(state.MeteringModelKey, "gpt-4o")
+
+	resp := newTestResponse(150, 80, 230)
+
+	err := p.ProcessResponse(context.Background(), cs, resp)
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotNil(t, receivedEvent)
+	assert.Equal(t, "1.0", receivedEvent["specversion"])
+	assert.Equal(t, "inference.tokens.used", receivedEvent["type"])
+	assert.Equal(t, "alice", receivedEvent["subject"])
+	assert.Equal(t, "maas-gateway", receivedEvent["source"])
+
+	data, ok := receivedEvent["data"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "alice", data["user"])
+	assert.Equal(t, "finance", data["group"])
+	assert.Equal(t, "premium", data["subscription"])
+	assert.Equal(t, "gpt-4o", data["model"])
+	assert.Equal(t, float64(150), data["prompt_tokens"])
+	assert.Equal(t, float64(80), data["completion_tokens"])
+	assert.Equal(t, float64(230), data["total_tokens"])
+}
+
+func TestProcessResponse_MissingUsage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			t.Fatal("should not report when usage is missing")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	p := newTestPlugin(t, srv.URL, true)
+	cs := plugin.NewCycleState()
+	cs.Write(state.MeteringUsernameKey, "alice")
+
+	resp := requesthandling.NewInferenceResponse()
+	resp.Body["model"] = "gpt-4o"
+	resp.Body["choices"] = []any{}
+
+	err := p.ProcessResponse(context.Background(), cs, resp)
+	require.NoError(t, err)
+}
+
+func TestProcessResponse_MissingUsername(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			t.Fatal("should not report when username is missing")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	p := newTestPlugin(t, srv.URL, true)
+	cs := plugin.NewCycleState()
+
+	resp := newTestResponse(100, 50, 150)
+
+	err := p.ProcessResponse(context.Background(), cs, resp)
+	require.NoError(t, err)
+}
+
+func TestProcessResponse_ReportFailure_NoError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	p := newTestPlugin(t, srv.URL, true)
+	cs := plugin.NewCycleState()
+	cs.Write(state.MeteringUsernameKey, "alice")
+	cs.Write(state.MeteringModelKey, "gpt-4o")
+
+	resp := newTestResponse(100, 50, 150)
+
+	err := p.ProcessResponse(context.Background(), cs, resp)
+	require.NoError(t, err)
+}
+
+func TestProcessResponse_AnthropicFormat(t *testing.T) {
+	var mu sync.Mutex
+	var receivedEvent map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/events" {
+			var evt map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&evt)
+			mu.Lock()
+			receivedEvent = evt
+			mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	p := newTestPlugin(t, srv.URL, true)
+	cs := plugin.NewCycleState()
+	cs.Write(state.MeteringUsernameKey, "alice")
+	cs.Write(state.MeteringModelKey, "claude-sonnet")
+
+	resp := requesthandling.NewInferenceResponse()
+	resp.Body["model"] = "claude-sonnet"
+	resp.Body["usage"] = map[string]any{
+		"input_tokens":  float64(200),
+		"output_tokens": float64(100),
+	}
+
+	err := p.ProcessResponse(context.Background(), cs, resp)
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotNil(t, receivedEvent)
+	data, ok := receivedEvent["data"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(200), data["prompt_tokens"])
+	assert.Equal(t, float64(100), data["completion_tokens"])
+	assert.Equal(t, float64(300), data["total_tokens"])
+}
+
+func TestProcessResponse_OpenAICachedTokens(t *testing.T) {
+	var mu sync.Mutex
+	var receivedEvent map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/events" {
+			var evt map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&evt)
+			mu.Lock()
+			receivedEvent = evt
+			mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	p := newTestPlugin(t, srv.URL, true)
+	cs := plugin.NewCycleState()
+	cs.Write(state.MeteringUsernameKey, "alice")
+	cs.Write(state.MeteringModelKey, "gpt-5.5")
+
+	resp := requesthandling.NewInferenceResponse()
+	resp.Body["model"] = "gpt-5.5"
+	resp.Body["usage"] = map[string]any{
+		"prompt_tokens":     float64(5000),
+		"completion_tokens": float64(200),
+		"total_tokens":      float64(5200),
+		"prompt_tokens_details": map[string]any{
+			"cached_tokens": float64(4500),
+		},
+		"completion_tokens_details": map[string]any{
+			"reasoning_tokens": float64(50),
+		},
+	}
+
+	err := p.ProcessResponse(context.Background(), cs, resp)
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotNil(t, receivedEvent)
+	data, ok := receivedEvent["data"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(4500), data["cached_input_tokens"])
+	assert.Equal(t, float64(50), data["reasoning_tokens"])
+}
+
+func TestExtractTokenCounts(t *testing.T) {
+	tests := []struct {
+		name       string
+		usage      map[string]any
+		wantPrompt int
+		wantCompl  int
+		wantTotal  int
+	}{
+		{
+			name:       "OpenAI format",
+			usage:      map[string]any{"prompt_tokens": float64(10), "completion_tokens": float64(20), "total_tokens": float64(30)},
+			wantPrompt: 10, wantCompl: 20, wantTotal: 30,
+		},
+		{
+			name:       "Anthropic format",
+			usage:      map[string]any{"input_tokens": float64(50), "output_tokens": float64(25)},
+			wantPrompt: 50, wantCompl: 25, wantTotal: 75,
+		},
+		{
+			name:       "OpenAI without total",
+			usage:      map[string]any{"prompt_tokens": float64(10), "completion_tokens": float64(20)},
+			wantPrompt: 10, wantCompl: 20, wantTotal: 30,
+		},
+		{
+			name:       "empty usage",
+			usage:      map[string]any{},
+			wantPrompt: 0, wantCompl: 0, wantTotal: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, c, total := extractTokenCounts(tt.usage)
+			assert.Equal(t, tt.wantPrompt, p)
+			assert.Equal(t, tt.wantCompl, c)
+			assert.Equal(t, tt.wantTotal, total)
+		})
+	}
+}
+
+// --- Helpers ---
+
+func newTestPlugin(t *testing.T, meteringURL string, failOpen bool) *ExternalMeteringPlugin {
+	t.Helper()
+	config, _ := json.Marshal(map[string]any{
+		"meteringURL":    meteringURL,
+		"timeoutSeconds": 2,
+		"failOpen":       failOpen,
+	})
+	bp, err := ExternalMeteringFactory("test", config, nil)
+	require.NoError(t, err)
+	return bp.(*ExternalMeteringPlugin)
+}
+
+func newTestRequest(username, group, subscription, model string, streaming bool) *requesthandling.InferenceRequest {
+	req := requesthandling.NewInferenceRequest()
+	if username != "" {
+		req.Headers["x-maas-username"] = username
+	}
+	if group != "" {
+		req.Headers["x-maas-group"] = group
+	}
+	if subscription != "" {
+		req.Headers["x-maas-subscription"] = subscription
+	}
+	req.Body["model"] = model
+	if streaming {
+		req.Body["stream"] = true
+	}
+	return req
+}
+
+func newTestResponse(prompt, completion, total int) *requesthandling.InferenceResponse {
+	resp := requesthandling.NewInferenceResponse()
+	resp.Body["model"] = "gpt-4o"
+	resp.Body["usage"] = map[string]any{
+		"prompt_tokens":     float64(prompt),
+		"completion_tokens": float64(completion),
+		"total_tokens":      float64(total),
+	}
+	return resp
+}

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -19,6 +19,7 @@ package plugins
 import (
 	api_translation "github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/api-translation"
 	apikey_injection "github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/apikey-injection"
+	external_metering "github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/external-metering"
 	maas_headers_guard "github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/maas-headers-guard"
 	provider_resolver "github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/model-provider-resolver"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/nemo"
@@ -30,6 +31,8 @@ func RegisterPlugins() {
 	plugin.Register(provider_resolver.ModelProviderResolverPluginType, provider_resolver.ModelProviderResolverFactory)
 	plugin.Register(api_translation.APITranslationPluginType, api_translation.APITranslationFactory)
 	plugin.Register(apikey_injection.APIKeyInjectionPluginType, apikey_injection.APIKeyInjectionFactory)
+	plugin.Register(external_metering.ExternalMeteringPluginType, external_metering.ExternalMeteringFactory)
+	plugin.Register(external_metering.ExternalMeteringStreamingPluginType, external_metering.ExternalMeteringStreamingFactory)
 	plugin.Register(nemo.NemoRequestGuardPluginType, nemo.NemoRequestGuardFactory)
 	plugin.Register(nemo.NemoResponseGuardPluginType, nemo.NemoResponseGuardFactory)
 }


### PR DESCRIPTION
## Summary

Add per-user token usage tracking, cost attribution, and usage dashboards for the AI Inference Gateway. Ships as **Dev Preview** in 3.5 — the plugin is registered but **not** included in the default plugin chain. Operators enable it manually via Helm values.

**[RHAISTRAT-1919](https://redhat.atlassian.net/browse/RHAISTRAT-1919)** | [Jira](https://redhat.atlassian.net/browse/RHAISTRAT-1919)

## Components

### Plugin (`pkg/plugins/external-metering/`)
- **Request phase:** checks user balance against metering service, blocks if quota exhausted (configurable fail-open)
- **Response phase:** extracts token usage from provider response (OpenAI + Anthropic formats) and emits CloudEvents
- Cache-aware: tracks input, output, cached_read, cache_creation, reasoning tokens separately
- Streaming: injects `stream_options.include_usage=true` for usage in SSE responses

### Metering Service (`metering-service/`)
- Standalone Go service with PostgreSQL backend
- CloudEvents v1.0 ingestion + per-user/per-model aggregation
- Cache-aware cost calculation (different rates for input, output, cache read, cache write)
- Built-in usage dashboard with token type breakdown charts
- Admin UI with model routing visualization and cost optimizer

### Example Deployment (`deploy/examples/external-metering/`)
- PostgreSQL StatefulSet + metering service Deployment + Route
- Example Helm values showing plugin chain configuration
- README with setup guide

## What this does NOT change
- Default plugin chain is unchanged — external-metering is not added by default
- Same pattern as NeMo guards: registered in `plugins.go`, activated via Helm values
- No changes to existing plugins or behavior

## Test plan
- [x] `go build ./pkg/... ./cmd/...` — compiles
- [x] `go test ./pkg/plugins/external-metering/...` — all tests pass
- [x] `cd metering-service && go build ./... && go test ./...` — compiles and tests pass
- [ ] Deploy example manifests to RHOAI cluster
- [ ] Enable plugin via Helm values, send inference requests, verify dashboard shows usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an External Metering plugin to enforce token-budget access prior to inference and emit token-usage events after inference.
  * Supports configurable metering endpoint/timeouts, feature keys, and `failOpen`, plus streaming usage capture with normalized token mappings.
* **Documentation**
  * Added a complete External Metering example guide and a matching Helm values configuration.
* **Tests**
  * Expanded unit tests covering configuration validation/defaults, reachable/unreachable metering with fail-open vs fail-closed, streaming option injection, and usage/event reporting behavior.
* **Chores**
  * Updated dependency metadata and version pins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->