### PR TITLE
fix: pointer slices, descriptive names, model mismatch test (#308 follow-up)

### DIFF
--- a/pkg/plugins/model-provider-resolver/external_model_reconciler.go
+++ b/pkg/plugins/model-provider-resolver/external_model_reconciler.go
@@ -58,14 +58,14 @@ func (r *externalModelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Resolve all refs whose providers are available in the store.
-	var resolved []resolvedProviderRef
-	for _, ref := range model.Spec.ExternalProviderRefs {
-		rr, found := r.resolveRef(req.Namespace, ref)
+	var resolved []*resolvedProviderRef
+	for i := range model.Spec.ExternalProviderRefs {
+		resolvedRef, found := r.resolveRef(req.Namespace, &model.Spec.ExternalProviderRefs[i])
 		if !found {
-			logger.Info("ExternalProvider not yet available, skipping ref", "provider", ref.Ref.Name)
+			logger.Info("ExternalProvider not yet available, skipping ref", "provider", model.Spec.ExternalProviderRefs[i].Ref.Name)
 			continue
 		}
-		resolved = append(resolved, *rr)
+		resolved = append(resolved, resolvedRef)
 	}
 
 	if len(resolved) == 0 {
@@ -85,7 +85,7 @@ func (r *externalModelReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 // resolveRef resolves a single ExternalProviderRef to provider info.
 // Returns (nil, false) if the provider is not yet available in the store.
-func (r *externalModelReconciler) resolveRef(namespace string, ref inferencev1alpha1.ExternalProviderRef) (*resolvedProviderRef, bool) {
+func (r *externalModelReconciler) resolveRef(namespace string, ref *inferencev1alpha1.ExternalProviderRef) (*resolvedProviderRef, bool) {
 	providerKey := types.NamespacedName{Namespace: namespace, Name: ref.Ref.Name}
 	providerInfo, found := r.store.getProvider(providerKey)
 	if !found {

--- a/pkg/plugins/model-provider-resolver/external_model_reconciler_test.go
+++ b/pkg/plugins/model-provider-resolver/external_model_reconciler_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -50,7 +51,7 @@ func (m *mockModelReader) List(_ context.Context, _ client.ObjectList, _ ...clie
 	return nil
 }
 
-func intPtr(v int) *int { return &v }
+
 
 func newTestModel(name, ns string, refs ...inferencev1alpha1.ExternalProviderRef) *inferencev1alpha1.ExternalModel {
 	return &inferencev1alpha1.ExternalModel{
@@ -132,7 +133,7 @@ func TestModelReconciler_DeletedCR(t *testing.T) {
 	reader := &mockModelReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalModel{}}
 
 	store := newInfoStore()
-	store.addOrUpdateModel(key, &externalModelInfo{refs: []resolvedProviderRef{
+	store.addOrUpdateModel(key, &externalModelInfo{refs: []*resolvedProviderRef{
 		{provider: "openai", targetModel: "gpt-4o", weight: 1},
 	}})
 
@@ -255,9 +256,9 @@ func TestModelReconciler_AuthOverride(t *testing.T) {
 func TestModelReconciler_WeightFromCRD(t *testing.T) {
 	key := types.NamespacedName{Namespace: "models", Name: "weighted"}
 	ref1 := newRef("openai-provider", "gpt-4o", "openai-chat")
-	ref1.Weight = intPtr(80)
+	ref1.Weight = ptr.To(80)
 	ref2 := newRef("azure-provider", "gpt-4o", "openai-chat")
-	ref2.Weight = intPtr(20)
+	ref2.Weight = ptr.To(20)
 
 	reader := &mockModelReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalModel{
 		key: newTestModel("weighted", "models", ref1, ref2),

--- a/pkg/plugins/model-provider-resolver/model_store_test.go
+++ b/pkg/plugins/model-provider-resolver/model_store_test.go
@@ -29,7 +29,7 @@ func TestModelStore_AddAndGetExternalModel(t *testing.T) {
 	store := newInfoStore()
 	key := types.NamespacedName{Namespace: "ns", Name: "external-model"}
 
-	store.addOrUpdateModel(key, &externalModelInfo{refs: []resolvedProviderRef{
+	store.addOrUpdateModel(key, &externalModelInfo{refs: []*resolvedProviderRef{
 		{provider: provider.Anthropic, weight: 1},
 	}})
 
@@ -43,7 +43,7 @@ func TestModelStore_GetModelInfo_NotFound(t *testing.T) {
 	store := newInfoStore()
 	store.addOrUpdateModel(
 		types.NamespacedName{Namespace: "ns", Name: "ext"},
-		&externalModelInfo{refs: []resolvedProviderRef{{provider: provider.OpenAI, weight: 1}}},
+		&externalModelInfo{refs: []*resolvedProviderRef{{provider: provider.OpenAI, weight: 1}}},
 	)
 
 	_, found := store.getModel(types.NamespacedName{Namespace: "ns", Name: "other"})
@@ -53,7 +53,7 @@ func TestModelStore_GetModelInfo_NotFound(t *testing.T) {
 func TestModelStore_DeleteExternalModel(t *testing.T) {
 	store := newInfoStore()
 	key := types.NamespacedName{Namespace: "ns", Name: "ext"}
-	store.addOrUpdateModel(key, &externalModelInfo{refs: []resolvedProviderRef{
+	store.addOrUpdateModel(key, &externalModelInfo{refs: []*resolvedProviderRef{
 		{provider: provider.OpenAI, weight: 1},
 	}})
 
@@ -69,7 +69,7 @@ func TestModelStore_CrossNamespaceIsolation(t *testing.T) {
 	store := newInfoStore()
 	store.addOrUpdateModel(
 		types.NamespacedName{Namespace: "ns-a", Name: "shared-model"},
-		&externalModelInfo{refs: []resolvedProviderRef{{provider: provider.OpenAI, weight: 1}}},
+		&externalModelInfo{refs: []*resolvedProviderRef{{provider: provider.OpenAI, weight: 1}}},
 	)
 
 	_, found := store.getModel(types.NamespacedName{Namespace: "ns-b", Name: "shared-model"})

--- a/pkg/plugins/model-provider-resolver/plugin.go
+++ b/pkg/plugins/model-provider-resolver/plugin.go
@@ -204,22 +204,22 @@ func detectInputAPIFormat(path string) apiformat.APIFormat {
 
 // selectByWeight picks a provider ref using weighted random selection.
 // With a single ref, returns it directly (no randomness).
-func selectByWeight(refs []resolvedProviderRef) *resolvedProviderRef {
+func selectByWeight(refs []*resolvedProviderRef) *resolvedProviderRef {
 	if len(refs) == 1 {
-		return &refs[0]
+		return refs[0]
 	}
 	totalWeight := 0
-	for i := range refs {
-		totalWeight += refs[i].weight
+	for _, ref := range refs {
+		totalWeight += ref.weight
 	}
 	r := rand.IntN(totalWeight)
-	for i := range refs {
-		r -= refs[i].weight
+	for _, ref := range refs {
+		r -= ref.weight
 		if r < 0 {
-			return &refs[i]
+			return ref
 		}
 	}
-	return &refs[len(refs)-1]
+	return refs[len(refs)-1]
 }
 
 func sanitizePath(relativeUrlPath string) string {

--- a/pkg/plugins/model-provider-resolver/plugin_test.go
+++ b/pkg/plugins/model-provider-resolver/plugin_test.go
@@ -39,7 +39,7 @@ func TestProcessRequest_ModelResolved(t *testing.T) {
 	)
 	store.addOrUpdateModel(
 		types.NamespacedName{Namespace: extNS, Name: extName},
-		&externalModelInfo{modelName: extName, refs: []resolvedProviderRef{{
+		&externalModelInfo{modelName: extName, refs: []*resolvedProviderRef{{
 			provider:        provider.Anthropic,
 			targetModel:     targetModel,
 			apiFormat:       apiformat.Messages,
@@ -80,6 +80,27 @@ func TestProcessRequest_ModelResolved(t *testing.T) {
 	require.Equal(t, apiformat.Messages, actualAPIFormat)
 }
 
+func TestProcessRequest_ModelMismatch(t *testing.T) {
+	store := newInfoStore()
+	store.addOrUpdateModel(
+		types.NamespacedName{Namespace: "llm", Name: "gpt4"},
+		&externalModelInfo{modelName: "gpt4", refs: []*resolvedProviderRef{{
+			provider: provider.OpenAI, targetModel: "gpt-4o",
+			apiFormat: apiformat.OpenAIChatCompletions,
+			secretName: "k", secretNamespace: "llm",
+			config: map[string]string{}, weight: 1,
+		}}},
+	)
+	p := &ModelProviderResolverPlugin{store: store}
+	cs := framework.NewCycleState()
+	req := framework.NewInferenceRequest()
+	req.Headers[":path"] = "/llm/gpt4/v1/chat/completions"
+	req.Body["model"] = "wrong-name"
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.Error(t, err, "should error when body model doesn't match modelName")
+}
+
 func TestProcessRequest_ModelNotFound(t *testing.T) {
 	store := newInfoStore()
 	p := &ModelProviderResolverPlugin{store: store}
@@ -113,7 +134,7 @@ func TestProcessRequest_BadPath(t *testing.T) {
 	store := newInfoStore()
 	store.addOrUpdateModel(
 		types.NamespacedName{Namespace: "llm", Name: "ext"},
-		&externalModelInfo{modelName: "ext", refs: []resolvedProviderRef{{
+		&externalModelInfo{modelName: "ext", refs: []*resolvedProviderRef{{
 			provider: provider.OpenAI, targetModel: "gpt-4o",
 			secretName: "k", secretNamespace: "llm",
 			config: map[string]string{}, weight: 1,
@@ -133,7 +154,7 @@ func TestProcessRequest_BadPath(t *testing.T) {
 }
 
 func TestSelectByWeight_SingleRef(t *testing.T) {
-	refs := []resolvedProviderRef{
+	refs := []*resolvedProviderRef{
 		{provider: "openai", weight: 1},
 	}
 	selected := selectByWeight(refs)
@@ -141,7 +162,7 @@ func TestSelectByWeight_SingleRef(t *testing.T) {
 }
 
 func TestSelectByWeight_Distribution(t *testing.T) {
-	refs := []resolvedProviderRef{
+	refs := []*resolvedProviderRef{
 		{provider: "openai", weight: 80},
 		{provider: "anthropic", weight: 20},
 	}
@@ -157,7 +178,7 @@ func TestSelectByWeight_Distribution(t *testing.T) {
 }
 
 func TestSelectByWeight_EqualWeights(t *testing.T) {
-	refs := []resolvedProviderRef{
+	refs := []*resolvedProviderRef{
 		{provider: "a", weight: 1},
 		{provider: "b", weight: 1},
 		{provider: "c", weight: 1},
@@ -178,7 +199,7 @@ func TestProcessRequest_AnthropicMessages(t *testing.T) {
 	store := newInfoStore()
 	store.addOrUpdateModel(
 		types.NamespacedName{Namespace: "llm", Name: "claude"},
-		&externalModelInfo{modelName: "claude", refs: []resolvedProviderRef{{
+		&externalModelInfo{modelName: "claude", refs: []*resolvedProviderRef{{
 			provider: provider.Anthropic, targetModel: "claude-opus-4-6",
 			apiFormat: "messages", secretName: "key", secretNamespace: "llm",
 			config: map[string]string{}, weight: 1,
@@ -207,7 +228,7 @@ func TestProcessRequest_OpenAIResponses(t *testing.T) {
 	store := newInfoStore()
 	store.addOrUpdateModel(
 		types.NamespacedName{Namespace: "llm", Name: "gpt"},
-		&externalModelInfo{modelName: "gpt", refs: []resolvedProviderRef{{
+		&externalModelInfo{modelName: "gpt", refs: []*resolvedProviderRef{{
 			provider: provider.OpenAI, targetModel: "gpt-5.5",
 			apiFormat: "openai-chat", secretName: "key", secretNamespace: "llm",
 			config: map[string]string{}, weight: 1,
@@ -232,7 +253,7 @@ func TestProcessRequest_UnsupportedPath(t *testing.T) {
 	store := newInfoStore()
 	store.addOrUpdateModel(
 		types.NamespacedName{Namespace: "llm", Name: "model"},
-		&externalModelInfo{modelName: "model", refs: []resolvedProviderRef{{
+		&externalModelInfo{modelName: "model", refs: []*resolvedProviderRef{{
 			provider: provider.OpenAI, targetModel: "gpt-4o",
 			apiFormat: "openai-chat", secretName: "key", secretNamespace: "llm",
 			config: map[string]string{}, weight: 1,

--- a/pkg/plugins/model-provider-resolver/store.go
+++ b/pkg/plugins/model-provider-resolver/store.go
@@ -47,7 +47,7 @@ type resolvedProviderRef struct {
 // The plugin selects a provider based on weights at request time.
 type externalModelInfo struct {
 	modelName string
-	refs      []resolvedProviderRef
+	refs      []*resolvedProviderRef
 }
 
 // infoStore is a thread-safe in-memory store for both provider and model info.


### PR DESCRIPTION
Supersedes #313. Rebased cleanly on main after #322 and #323 merged.

Per Nir's review on #308:
- Use `[]*resolvedProviderRef` (pointer slice) to avoid copying structs
- Pass ref as pointer to `resolveRef`
- Use descriptive variable name (`resolvedRef` instead of `rr`)
- Use `k8s.io/utils/ptr.To` instead of custom `intPtr`
- Add `TestProcessRequest_ModelMismatch`

All tests pass, lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added validation to ensure request model names match configured external model entries.

* **Refactor**
  * Optimized internal handling of external model provider references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->