### PR TITLE
feat(nemo): add redaction support for nemo request and response plugins

### DIFF
--- a/examples/nemo/README.md
+++ b/examples/nemo/README.md
@@ -23,7 +23,7 @@ the `status` field in the response. The status values align with NeMo's internal
 | Status | Behavior | HTTP |
 |--------|----------|------|
 | `passed` | Request/response proceeds normally | 200 |
-| `modified` | Content was redacted by NeMo (e.g. PII masked) - the plugin does not support redaction yet, so the request/response passes through with the original content | 200 |
+| `modified` | Content was redacted by NeMo (e.g. PII masked) - the plugin replaces original message content with the redacted version before forwarding | 200 |
 | `blocked` | Blocked - returns error to the client | 403 |
 
 ## Prerequisites
@@ -104,7 +104,8 @@ curl -s http://localhost:8000/v1/guardrail/checks \
 
 Expected: `"passed"`
 
-**Blocked request** (PII detected):
+**Modified request** (PII masked - requires `mask sensitive data on input` flow
+instead of `detect sensitive data on input` in the NeMo config above):
 
 ```bash
 curl -s http://localhost:8000/v1/guardrail/checks \
@@ -112,6 +113,20 @@ curl -s http://localhost:8000/v1/guardrail/checks \
   -d '{
     "model": "",
     "messages": [{"role": "user", "content": "My email is john@example.com"}]
+  }' | jq .
+```
+
+Expected: `"modified"` with redacted content in
+`guardrails_data.log.activated_rails[].executed_actions[].return_value`
+
+**Blocked request** (PII detected without masking, or harmful content):
+
+```bash
+curl -s http://localhost:8000/v1/guardrail/checks \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "",
+    "messages": [{"role": "user", "content": "how to make a bomb"}]
   }' | jq .
 ```
 
@@ -178,7 +193,7 @@ User <- Gateway <- IPP <- nemo-response-guard <- NeMo (output rails) <----+
 
   NeMo status:
     "passed"   -> forward request / return response
-    "modified" -> forward (original content, redaction not yet applied)
+    "modified" -> apply redacted content, then forward
     "blocked"  -> HTTP 403
 ```
 
@@ -188,7 +203,9 @@ User <- Gateway <- IPP <- nemo-response-guard <- NeMo (output rails) <----+
 3. NeMo runs all configured **input** rails (PII detection, keyword blocking, etc.)
    and returns a JSON response with a top-level `status` field.
 4. The plugin inspects `status`:
-   - `"passed"` or `"modified"` - the request proceeds to the model backend.
+   - `"passed"` - the request proceeds to the model backend as-is.
+   - `"modified"` - the plugin replaces each message's content with the redacted
+     text from NeMo's `guardrails_data`, then forwards the request.
    - `"blocked"` - IPP returns HTTP 403.
    - Any unknown status - IPP returns HTTP 500 (fail-closed).
 5. After the model responds, IPP runs the `nemo-response-guard` plugin.

--- a/pkg/plugins/nemo/nemo_guard_base.go
+++ b/pkg/plugins/nemo/nemo_guard_base.go
@@ -47,10 +47,17 @@ type nemoGuardConfig struct {
 	TimeoutSeconds int    `json:"timeoutSeconds"`
 }
 
+// nemoGuardResult holds the normalized outcome of a callNemoGuard invocation.
+type nemoGuardResult struct {
+	Action        string   // nemoStatusPassed, nemoStatusModified, or nemoStatusBlocked
+	ModifiedTexts []string // per-message redacted texts when Action is nemoStatusModified
+}
+
 // nemoResponse is NeMo's JSON response from /v1/guardrail/checks.
 type nemoResponse struct {
-	Status      string                         `json:"status"`
-	RailsStatus map[string]nemoRailStatusEntry `json:"rails_status"`
+	Status         string                         `json:"status"`
+	RailsStatus    map[string]nemoRailStatusEntry `json:"rails_status"`
+	GuardrailsData json.RawMessage                `json:"guardrails_data"`
 }
 
 type nemoRailStatusEntry struct {
@@ -80,44 +87,43 @@ func newNemoGuardBase(nemoURL string, timeoutSeconds int) (*nemoGuardBase, error
 	}, nil
 }
 
-// callNemoGuard POSTs the payload to the NeMo guardrail checks endpoint, parses the
-// response, and returns an error with the corresponding error code if the content is
-// blocked or NeMo is unreachable. The caller is responsible for constructing the
-// client-facing errcommon.Error from the returned values.
-func (b *nemoGuardBase) callNemoGuard(ctx context.Context, payload []byte) (string, error) {
+// callNemoGuard POSTs the payload to the configured NeMo endpoint, parses the response,
+// and returns a nemoGuardResult with the normalized action. Returns an errcommon.Error
+// if NeMo is unreachable or the response cannot be parsed.
+func (b *nemoGuardBase) callNemoGuard(ctx context.Context, payload []byte, phase string) (*nemoGuardResult, error) {
 	logger := log.FromContext(ctx).V(logutil.DEFAULT)
 	log.FromContext(ctx).V(logutil.VERBOSE).Info("calling NeMo guardrails")
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, b.nemoURL, bytes.NewReader(payload))
 	if err != nil {
 		logger.Error(err, "failed to create NeMo request")
-		return errcommon.Internal, fmt.Errorf("failed to create nemo request: %w", err)
+		return nil, errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("failed to create nemo request: %v", err)}
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	resp, err := b.httpClient.Do(httpReq)
 	if err != nil {
 		logger.Error(err, "NeMo guardrail call failed")
-		return errcommon.ServiceUnavailable, fmt.Errorf("nemo call failed: %w", err)
+		return nil, errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: fmt.Sprintf("nemo call failed: %v", err)}
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		logger.Error(nil, "NeMo guardrail unexpected status", "statusCode", resp.StatusCode)
-		return errcommon.ServiceUnavailable, fmt.Errorf("unexpected status %d", resp.StatusCode)
+		return nil, errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: fmt.Sprintf("unexpected status %d", resp.StatusCode)}
 	}
 
 	limited := io.LimitReader(resp.Body, maxNemoResponseBytes)
 	body, err := io.ReadAll(limited)
 	if err != nil {
 		logger.Error(err, "failed to read NeMo response")
-		return errcommon.ServiceUnavailable, fmt.Errorf("failed to read nemo response: %w", err)
+		return nil, errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: fmt.Sprintf("failed to read nemo response: %v", err)}
 	}
 
 	var nemoResp nemoResponse
 	if err := json.Unmarshal(body, &nemoResp); err != nil {
 		logger.Error(err, "failed to decode NeMo response")
-		return errcommon.ServiceUnavailable, fmt.Errorf("failed to decode nemo response: %w", err)
+		return nil, errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: fmt.Sprintf("failed to decode nemo response: %v", err)}
 	}
 
 	status := strings.TrimSpace(nemoResp.Status)
@@ -125,12 +131,16 @@ func (b *nemoGuardBase) callNemoGuard(ctx context.Context, payload []byte) (stri
 	switch status {
 	case nemoStatusPassed:
 		logger.Info("allowed by NeMo guardrails")
-		return "", nil
+		return &nemoGuardResult{Action: nemoStatusPassed}, nil
 
 	case nemoStatusModified:
-		// TODO: support redaction by applying NeMo's masked content to the request/response body.
-		logger.Info("content modified by NeMo guardrails (redaction not yet applied)")
-		return "", nil
+		modifiedMessages := extractModifiedTexts(nemoResp.GuardrailsData)
+		if len(modifiedMessages) == 0 {
+			logger.Error(nil, "NeMo returned modified status but no redacted content found (fail-closed)")
+			return nil, errcommon.Error{Code: errcommon.Internal, Msg: "NeMo returned modified status but no redacted content found"}
+		}
+		logger.Info("content modified by NeMo guardrails", "modifiedMessages", len(modifiedMessages))
+		return &nemoGuardResult{Action: nemoStatusModified, ModifiedTexts: modifiedMessages}, nil
 
 	case nemoStatusBlocked:
 		railsParts := make([]string, 0, len(nemoResp.RailsStatus))
@@ -139,10 +149,45 @@ func (b *nemoGuardBase) callNemoGuard(ctx context.Context, payload []byte) (stri
 		}
 		railsStatus := fmt.Sprintf("[ %s ]", strings.Join(railsParts, " "))
 		log.FromContext(ctx).Info("blocked by NeMo guardrails", "railsStatus", railsStatus)
-		return errcommon.Forbidden, fmt.Errorf("blocked by NeMo guardrails")
+		return &nemoGuardResult{Action: nemoStatusBlocked}, errcommon.Error{Code: errcommon.Forbidden, Msg: fmt.Sprintf("%s blocked by NeMo guardrails", phase)}
 
 	default:
 		logger.Error(nil, "unknown NeMo guardrails status (fail-closed)", "status", nemoResp.Status)
-		return errcommon.Internal, fmt.Errorf("unknown NeMo guardrails status %q", nemoResp.Status)
+		return nil, errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("unknown NeMo guardrails status %q", nemoResp.Status)}
 	}
+}
+
+// extractModifiedTexts collects all non-empty string return values from
+// guardrails_data.log.activated_rails. Each collected string corresponds to a
+// message in the original payload. Non-string return values (e.g. boolean from
+// detect actions) and empty strings are skipped. Returns nil if no results are found.
+func extractModifiedTexts(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var data map[string]any
+	if json.Unmarshal(raw, &data) != nil {
+		return nil
+	}
+	logData, _ := data["log"].(map[string]any)
+	rails, _ := logData["activated_rails"].([]any)
+	if len(rails) == 0 {
+		return nil
+	}
+
+	var modifiedTexts []string
+	for _, rail := range rails {
+		railMap, _ := rail.(map[string]any)
+		actions, _ := railMap["executed_actions"].([]any)
+		for _, action := range actions {
+			actionMap, _ := action.(map[string]any)
+			returnValue, ok := actionMap["return_value"].(string)
+			if !ok || returnValue == "" {
+				continue
+			}
+			modifiedTexts = append(modifiedTexts, returnValue)
+			break
+		}
+	}
+	return modifiedTexts
 }

--- a/pkg/plugins/nemo/request_guard.go
+++ b/pkg/plugins/nemo/request_guard.go
@@ -31,6 +31,8 @@ import (
 const (
 	// NemoRequestGuardPluginType is the plugin type identifier.
 	NemoRequestGuardPluginType = "nemo-request-guard"
+
+	phaseRequest = "request"
 )
 
 // compile-time type validation
@@ -95,8 +97,9 @@ func (p *NemoRequestGuardPlugin) WithName(name string) *NemoRequestGuardPlugin {
 //
 // NeMo always returns HTTP 200 for both allowed and blocked requests. The decision is
 // conveyed through the response body "status" field: "passed" means the request passed
-// all rails, "modified" means content was redacted (currently passed through as-is),
-// and "blocked" means the request is blocked.
+// all rails, "modified" means content was redacted and the plugin replaces all message
+// contents with the redacted versions from NeMo, and "blocked" means the request is
+// blocked.
 func (p *NemoRequestGuardPlugin) ProcessRequest(ctx context.Context, _ *plugin.CycleState, request *requesthandling.InferenceRequest) error {
 	model, ok := request.Body["model"].(string)
 	if !ok {
@@ -111,8 +114,6 @@ func (p *NemoRequestGuardPlugin) ProcessRequest(ctx context.Context, _ *plugin.C
 		return nil // no messages to check (e.g. non-chat request) → allow
 	}
 
-	// "model" field is required by the NeMo OpenAI-compatible API schema but is not used.
-	// the guard model is defined in NeMo's config.yml.
 	reqBody := map[string]any{
 		"model":    model,
 		"messages": messages,
@@ -122,12 +123,33 @@ func (p *NemoRequestGuardPlugin) ProcessRequest(ctx context.Context, _ *plugin.C
 		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("marshal request: %v", err)}
 	}
 
-	code, callErr := p.callNemoGuard(ctx, payload)
+	result, callErr := p.callNemoGuard(ctx, payload, phaseRequest)
 	if callErr != nil {
-		if code == errcommon.Forbidden {
-			return errcommon.Error{Code: code, Msg: "request blocked by NeMo guardrails"}
+		return callErr
+	}
+
+	if result.Action == nemoStatusModified {
+		if err := applyRedactedMessages(request.Body, result.ModifiedTexts); err != nil {
+			return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("failed to apply redacted content: %v", err)}
 		}
-		return errcommon.Error{Code: code, Msg: callErr.Error()}
+		request.SetBody(request.Body)
+	}
+	return nil
+}
+
+// applyRedactedMessages replaces the content of each message in the request body
+// with the corresponding redacted text from NeMo.
+func applyRedactedMessages(body map[string]any, redactedTexts []string) error {
+	msgs, ok := body["messages"].([]any)
+	if !ok {
+		return fmt.Errorf("messages field is not an array")
+	}
+	for i, redacted := range redactedTexts {
+		msg, ok := msgs[i].(map[string]any)
+		if !ok {
+			continue
+		}
+		msg["content"] = redacted
 	}
 	return nil
 }

--- a/pkg/plugins/nemo/request_guard_test.go
+++ b/pkg/plugins/nemo/request_guard_test.go
@@ -37,6 +37,35 @@ func nemoAllowedJSON() map[string]any {
 	return map[string]any{"status": "passed"}
 }
 
+// nemoModifiedJSON builds a NeMo response with status "modified" and the given
+// redacted texts in guardrails_data, matching the real NeMo response shape.
+// Each text corresponds to a mask_sensitive_data action for one message.
+func nemoModifiedJSON(texts ...string) map[string]any {
+	rails := make([]any, 0, len(texts))
+	for _, text := range texts {
+		rails = append(rails, map[string]any{
+			"name": "mask sensitive data on input",
+			"executed_actions": []any{
+				map[string]any{
+					"action_name":  "mask_sensitive_data",
+					"return_value": text,
+				},
+			},
+		})
+	}
+	return map[string]any{
+		"status": "modified",
+		"rails_status": map[string]any{
+			"mask sensitive data on input": map[string]any{"status": "modified"},
+		},
+		"guardrails_data": map[string]any{
+			"log": map[string]any{
+				"activated_rails": rails,
+			},
+		},
+	}
+}
+
 // --- NewNemoRequestGuardPlugin construction ---
 
 func TestNewNemoRequestGuardPlugin(t *testing.T) {
@@ -115,7 +144,17 @@ func TestNemoRequestGuardProcessRequest(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "allow: NeMo returns status modified — passed through (redaction not yet applied)",
+			name: "redact: NeMo returns modified with redacted content",
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewEncoder(w).Encode(nemoModifiedJSON("My email is <EMAIL_ADDRESS>")); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
+			},
+			body:    map[string]any{"model": "gpt-4", "messages": []any{map[string]any{"role": "user", "content": "My email is test@example.com"}}},
+			wantErr: false,
+		},
+		{
+			name: "fail-closed: NeMo returns modified but no redacted content in guardrails_data",
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
 				if err := json.NewEncoder(w).Encode(map[string]any{
 					"status": "modified",
@@ -126,8 +165,10 @@ func TestNemoRequestGuardProcessRequest(t *testing.T) {
 					http.Error(w, err.Error(), http.StatusInternalServerError)
 				}
 			},
-			body:    map[string]any{"model": "gpt-4", "messages": []any{map[string]any{"role": "user", "content": "My email is test@example.com"}}},
-			wantErr: false,
+			body:            map[string]any{"model": "gpt-4", "messages": []any{map[string]any{"role": "user", "content": "My email is test@example.com"}}},
+			wantErr:         true,
+			wantErrContains: "no redacted content found",
+			wantErrCode:     errcommon.Internal,
 		},
 		{
 			name: "fail-closed: unknown status — status allowed is rejected",
@@ -606,6 +647,101 @@ func TestExtractMessages(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// --- Redaction ---
+
+func TestNemoRequestGuardRedaction(t *testing.T) {
+	tests := []struct {
+		name            string
+		nemoResp        map[string]any
+		body            map[string]any
+		wantErr         bool
+		wantErrContains string
+		wantContents    []string // expected content for each message after redaction
+	}{
+		{
+			name:     "redacted content replaces all messages",
+			nemoResp: nemoModifiedJSON("You are helpful", "Hi, my name is <PERSON> and my email is <EMAIL_ADDRESS>"),
+			body: map[string]any{
+				"model": "gpt-4",
+				"messages": []any{
+					map[string]any{"role": "system", "content": "You are helpful"},
+					map[string]any{"role": "user", "content": "Hi, my name is Rob Geada and my email is rgeada@redhat.com"},
+				},
+			},
+			wantContents: []string{"You are helpful", "Hi, my name is <PERSON> and my email is <EMAIL_ADDRESS>"},
+		},
+		{
+			name:     "multi-turn: all messages replaced with NeMo output",
+			nemoResp: nemoModifiedJSON("Hello", "Hi there", "My SSN is <SSN>"),
+			body: map[string]any{
+				"model": "gpt-4",
+				"messages": []any{
+					map[string]any{"role": "user", "content": "Hello"},
+					map[string]any{"role": "assistant", "content": "Hi there"},
+					map[string]any{"role": "user", "content": "My SSN is 123-45-6789"},
+				},
+			},
+			wantContents: []string{"Hello", "Hi there", "My SSN is <SSN>"},
+		},
+		{
+			name:     "model and other fields preserved after redaction",
+			nemoResp: nemoModifiedJSON("You are helpful", "redacted text"),
+			body: map[string]any{
+				"model":      "gpt-4",
+				"max_tokens": float64(100),
+				"messages": []any{
+					map[string]any{"role": "system", "content": "You are helpful"},
+					map[string]any{"role": "user", "content": "original text"},
+				},
+			},
+			wantContents: []string{"You are helpful", "redacted text"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewEncoder(w).Encode(tt.nemoResp); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
+			}))
+			defer srv.Close()
+
+			p, err := NewNemoRequestGuardPlugin(srv.URL, 30)
+			require.NoError(t, err)
+
+			req := requesthandling.NewInferenceRequest()
+			for k, v := range tt.body {
+				req.Body[k] = v
+			}
+
+			err = p.ProcessRequest(context.Background(), plugin.NewCycleState(), req)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantErrContains != "" {
+					assert.Contains(t, err.Error(), tt.wantErrContains)
+				}
+				return
+			}
+			require.NoError(t, err)
+
+			if len(tt.wantContents) > 0 {
+				msgs := req.Body["messages"].([]any)
+				require.Len(t, msgs, len(tt.wantContents))
+				for i, want := range tt.wantContents {
+					msg := msgs[i].(map[string]any)
+					assert.Equal(t, want, msg["content"], "message[%d] content mismatch", i)
+				}
+			}
+
+			if model, ok := tt.body["model"]; ok {
+				assert.Equal(t, model, req.Body["model"])
+			}
 		})
 	}
 }

--- a/pkg/plugins/nemo/response_guard.go
+++ b/pkg/plugins/nemo/response_guard.go
@@ -29,6 +29,8 @@ import (
 const (
 	// NemoResponseGuardPluginType is the plugin type identifier.
 	NemoResponseGuardPluginType = "nemo-response-guard"
+
+	phaseResponse = "response"
 )
 
 // compile-time type validation
@@ -92,8 +94,9 @@ func (p *NemoResponseGuardPlugin) WithName(name string) *NemoResponseGuardPlugin
 //
 // NeMo always returns HTTP 200 for both allowed and blocked responses. The decision is
 // conveyed through the response body "status" field: "passed" means the response passed
-// all rails, "modified" means content was redacted (currently passed through as-is),
-// and "blocked" means the response is blocked.
+// all rails, "modified" means content was redacted and the plugin replaces all choice
+// contents with the redacted versions from NeMo, and "blocked" means the response is
+// blocked.
 func (p *NemoResponseGuardPlugin) ProcessResponse(ctx context.Context, _ *plugin.CycleState, response *requesthandling.InferenceResponse) error {
 	messages, err := extractAssistantMessages(response.Body)
 	if err != nil {
@@ -114,12 +117,40 @@ func (p *NemoResponseGuardPlugin) ProcessResponse(ctx context.Context, _ *plugin
 		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("marshal request: %v", marshalErr)}
 	}
 
-	code, callErr := p.callNemoGuard(ctx, payload)
+	result, callErr := p.callNemoGuard(ctx, payload, phaseResponse)
 	if callErr != nil {
-		if code == errcommon.Forbidden {
-			return errcommon.Error{Code: code, Msg: "response blocked by NeMo guardrails"}
+		return callErr
+	}
+
+	if result.Action == nemoStatusModified {
+		if err := applyRedactedChoices(response.Body, result.ModifiedTexts); err != nil {
+			return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("failed to apply redacted content: %v", err)}
 		}
-		return errcommon.Error{Code: code, Msg: callErr.Error()}
+		response.SetBody(response.Body)
+	}
+	return nil
+}
+
+// applyRedactedChoices replaces the content of each choice in the response body
+// with the corresponding redacted text from NeMo.
+func applyRedactedChoices(body map[string]any, redactedTexts []string) error {
+	choices, ok := body["choices"].([]any)
+	if !ok {
+		return fmt.Errorf("choices field is not an array")
+	}
+	for i, redacted := range redactedTexts {
+		choice, ok := choices[i].(map[string]any)
+		if !ok {
+			continue
+		}
+		msg, ok := choice["message"].(map[string]any)
+		if !ok {
+			msg, ok = choice["delta"].(map[string]any)
+			if !ok {
+				continue
+			}
+		}
+		msg["content"] = redacted
 	}
 	return nil
 }

--- a/pkg/plugins/nemo/response_guard_test.go
+++ b/pkg/plugins/nemo/response_guard_test.go
@@ -123,7 +123,17 @@ func TestNemoResponseGuardProcessResponse(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "allow: NeMo returns status modified — passed through (redaction not yet applied)",
+			name: "redact: NeMo returns modified with redacted content",
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewEncoder(w).Encode(nemoModifiedJSON("The user's email is <EMAIL_ADDRESS>")); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
+			},
+			body:    validResponseBody("The user's email is test@example.com"),
+			wantErr: false,
+		},
+		{
+			name: "fail-closed: NeMo returns modified but no redacted content in guardrails_data",
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
 				if err := json.NewEncoder(w).Encode(map[string]any{
 					"status": "modified",
@@ -134,8 +144,10 @@ func TestNemoResponseGuardProcessResponse(t *testing.T) {
 					http.Error(w, err.Error(), http.StatusInternalServerError)
 				}
 			},
-			body:    validResponseBody("The user's email is test@example.com"),
-			wantErr: false,
+			body:            validResponseBody("The user's email is test@example.com"),
+			wantErr:         true,
+			wantErrContains: "no redacted content found",
+			wantErrCode:     errcommon.Internal,
 		},
 		{
 			name: "fail-closed: unknown status — status success is no longer recognized",
@@ -567,6 +579,121 @@ func TestExtractAssistantMessages(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// --- Redaction ---
+
+func TestNemoResponseGuardRedaction(t *testing.T) {
+	tests := []struct {
+		name            string
+		nemoResp        map[string]any
+		body            map[string]any
+		wantErr         bool
+		wantErrContains string
+		wantContents    []string // expected content for each choice after redaction
+	}{
+		{
+			name:     "redacted content replaces assistant message",
+			nemoResp: nemoModifiedJSON("The user's email is <EMAIL_ADDRESS>"),
+			body: map[string]any{
+				"choices": []any{
+					map[string]any{
+						"message": map[string]any{"role": "assistant", "content": "The user's email is test@example.com"},
+					},
+				},
+			},
+			wantContents: []string{"The user's email is <EMAIL_ADDRESS>"},
+		},
+		{
+			name:     "redacted content replaces all choices in multi-choice response",
+			nemoResp: nemoModifiedJSON("First choice", "Name is <PERSON>"),
+			body: map[string]any{
+				"choices": []any{
+					map[string]any{
+						"message": map[string]any{"role": "assistant", "content": "First choice"},
+					},
+					map[string]any{
+						"message": map[string]any{"role": "assistant", "content": "Name is Rob"},
+					},
+				},
+			},
+			wantContents: []string{"First choice", "Name is <PERSON>"},
+		},
+		{
+			name:     "redacted content replaces streaming delta",
+			nemoResp: nemoModifiedJSON("SSN is <SSN>"),
+			body: map[string]any{
+				"choices": []any{
+					map[string]any{
+						"delta": map[string]any{"role": "assistant", "content": "SSN is 123-45-6789"},
+					},
+				},
+			},
+			wantContents: []string{"SSN is <SSN>"},
+		},
+		{
+			name:     "model field preserved after redaction",
+			nemoResp: nemoModifiedJSON("redacted"),
+			body: map[string]any{
+				"model": "gpt-4",
+				"choices": []any{
+					map[string]any{
+						"message": map[string]any{"role": "assistant", "content": "original"},
+					},
+				},
+			},
+			wantContents: []string{"redacted"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewEncoder(w).Encode(tt.nemoResp); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
+			}))
+			defer srv.Close()
+
+			p, err := NewNemoResponseGuardPlugin(srv.URL, 30)
+			require.NoError(t, err)
+
+			resp := requesthandling.NewInferenceResponse()
+			for k, v := range tt.body {
+				resp.Body[k] = v
+			}
+
+			err = p.ProcessResponse(context.Background(), plugin.NewCycleState(), resp)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantErrContains != "" {
+					assert.Contains(t, err.Error(), tt.wantErrContains)
+				}
+				return
+			}
+			require.NoError(t, err)
+
+			if len(tt.wantContents) > 0 {
+				choices := resp.Body["choices"].([]any)
+				require.Len(t, choices, len(tt.wantContents))
+				for i, want := range tt.wantContents {
+					choice := choices[i].(map[string]any)
+					var content string
+					if msg, ok := choice["message"].(map[string]any); ok {
+						content = msg["content"].(string)
+					} else if delta, ok := choice["delta"].(map[string]any); ok {
+						content = delta["content"].(string)
+					}
+					assert.Equal(t, want, content, "choice[%d] content mismatch", i)
+				}
+			}
+
+			if model, ok := tt.body["model"]; ok {
+				assert.Equal(t, model, resp.Body["model"])
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Implement full redaction logic for the `"modified"` status returned by NeMo's `/v1/guardrail/checks` endpoint
- When NeMo returns `status: "modified"`, the plugins now extract per-message redacted content from `guardrails_data.log.activated_rails[].executed_actions[].return_value` and replace the original message/choice content before forwarding
- Update `callNemoGuard` to return a `nemoGuardResult` struct (with `Action` and `ModifiedTexts`) instead of a raw `(string, error)` tuple, and embed the phase ("request"/"response") in blocked error messages for easier debugging
- Add `request.SetBody()`/`response.SetBody()` calls after in-place body modifications to signal the framework that the body was mutated (required for ext_proc to propagate changes back through Envoy)
- Add comprehensive unit tests covering redaction for both request and response guards.

## Tested

- Unit tests pass for all three status paths (passed, modified, blocked) on both request and response guards
- E2E tested in a Kind cluster with:
  - NeMo ([quay.io/rgeada/nemo-debug:latest](https://quay.io/repository/rgeada/nemo-debug?tab=tags&tag=latest)) configured with PII masking + harmful keyword detection rails
  - Request-side PII redaction: email/phone replaced with `<EMAIL_ADDRESS>`/`<PHONE_NUMBER>`
  - Response-side PII redaction: echo-backend PII response correctly redacted before reaching the client
  - Blocked path: harmful content returns `403 Forbidden` with `"request blocked by NeMo guardrails"` (because of the logic changes I made in `callNemoGuard`)

## Context

- Resolves the redaction work from issue #123
- Empty string `return_value`s are skipped in `extractModifiedTexts` to handle NeMo's behavior of running both input and output rails for assistant messages (a bug I found, and I will discuss it with Rob from the TrustAI team)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NeMo guardrails now automatically apply redacted outputs to both incoming user requests and generated responses when NeMo returns `modified`, updating the affected message/choice content in order.
* **Bug Fixes**
  * Fail-closed behavior: if NeMo reports `modified` but no extractable redacted content is provided, processing now errors instead of continuing.
  * Improved `blocked` error messages to include request/response phase context.
* **Tests**
  * Added/extended request and response redaction scenarios, including multi-choice and streaming delta handling, plus missing-redaction fail-closed assertions.
* **Documentation**
  * Updated the NeMo plugin README and example flows to reflect the `modified` redaction-forwarding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->