### PR TITLE
update api key injection plugin mapping by auth type

### DIFF
--- a/pkg/plugins/apikey-injection/auth-generator/sigv4_auth_generator.go
+++ b/pkg/plugins/apikey-injection/auth-generator/sigv4_auth_generator.go
@@ -47,6 +47,10 @@ const (
 // compile-time interface check
 var _ AuthHeadersGenerator = &SigV4AuthGenerator{}
 
+func NewSigV4AuthGenerator() *SigV4AuthGenerator {
+	return &SigV4AuthGenerator{}
+}
+
 // SigV4AuthGenerator generates AWS Signature Version 4 authentication headers.
 type SigV4AuthGenerator struct{}
 

--- a/pkg/plugins/apikey-injection/auth-generator/simple_auth_generator.go
+++ b/pkg/plugins/apikey-injection/auth-generator/simple_auth_generator.go
@@ -19,38 +19,78 @@ package authgenerator
 import (
 	"fmt"
 
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/auth"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/state"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
 )
 
 // apiKeyField is the field name in the credentials map that holds the API key.
-const apiKeyField = "api-key"
+const (
+	apiKeyField            = "api-key"
+	defaultAuthHeader      = "Authorization"
+	defaultAuthValuePrefix = "Bearer "
+)
 
 // compile-time interface check
 var _ AuthHeadersGenerator = &SimpleAuthGenerator{}
 
+func NewSimpleAuthGenerator() *SimpleAuthGenerator {
+	return &SimpleAuthGenerator{}
+}
+
 // SimpleAuthGenerator generates a single auth header from an API key.
-// HeaderName is the HTTP header (e.g. "Authorization", "x-api-key").
-// HeaderValuePrefix is prepended to the key (e.g. "Bearer "); use "" for raw keys.
+// ExtractRequestData resolves the header name and value prefix from the model
+// config in CycleState (defaults are injected by the provider reconciler).
+// GenerateAuthHeaders reads those values from the merged credentials map.
 // Requires the credentials map to contain an "api-key" field.
-type SimpleAuthGenerator struct {
-	HeaderName        string
-	HeaderValuePrefix string
+type SimpleAuthGenerator struct{}
+
+// ExtractRequestData resolves the auth header name and value prefix from the
+// model config in CycleState. Provider-specific defaults (e.g. "x-api-key" for
+// Anthropic) are injected into the config by the provider reconciler. If not
+// set, falls back to "Authorization" with "Bearer " prefix.
+func (g *SimpleAuthGenerator) ExtractRequestData(cycleState *framework.CycleState, _ *framework.InferenceRequest) (map[string]string, error) {
+	config, err := framework.ReadCycleStateKey[map[string]string](cycleState, state.ModelConfigKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract config from cycle state - %w", err)
+	}
+
+	authHeader := defaultAuthHeader
+	authValuePrefix := defaultAuthValuePrefix
+
+	if headerName, ok := config[auth.SimpleAuthHeaderName]; ok {
+		authHeader = headerName
+		authValuePrefix = "" // non-default header implies no prefix unless explicitly set
+	}
+	if valuePrefix, ok := config[auth.SimpleAuthValuePrefix]; ok {
+		authValuePrefix = valuePrefix
+	}
+
+	return map[string]string{
+		auth.SimpleAuthHeaderName:  authHeader,
+		auth.SimpleAuthValuePrefix: authValuePrefix,
+	}, nil
 }
 
-// ExtractRequestData is a no-op for SimpleAuthGenerator — API key auth doesn't need request data.
-func (g *SimpleAuthGenerator) ExtractRequestData(_ *framework.CycleState, _ *framework.InferenceRequest) (map[string]string, error) {
-	return nil, nil
-}
-
-// GenerateAuthHeaders extracts the "api-key" field from credentials and returns
+// GenerateAuthHeaders extracts the relevant fields from credentialsData and returns
 // the header name and formatted value. Returns an error if the field is missing.
-func (g *SimpleAuthGenerator) GenerateAuthHeaders(credentials map[string]string) (map[string]string, error) {
-	apiKey, ok := credentials[apiKeyField]
+func (g *SimpleAuthGenerator) GenerateAuthHeaders(credentialsData map[string]string) (map[string]string, error) {
+	apiKey, ok := credentialsData[apiKeyField]
 	if !ok {
 		return nil, fmt.Errorf("credentials missing required field %s", apiKeyField)
 	}
 
+	headerName, ok := credentialsData[auth.SimpleAuthHeaderName]
+	if !ok {
+		return nil, fmt.Errorf("credentials missing required field %s", auth.SimpleAuthHeaderName)
+	}
+
+	valuePrefix, ok := credentialsData[auth.SimpleAuthValuePrefix]
+	if !ok {
+		return nil, fmt.Errorf("credentials missing required field %s", auth.SimpleAuthValuePrefix)
+	}
+
 	return map[string]string{
-		g.HeaderName: fmt.Sprintf("%s%s", g.HeaderValuePrefix, apiKey),
+		headerName: fmt.Sprintf("%s%s", valuePrefix, apiKey),
 	}, nil
 }

--- a/pkg/plugins/apikey-injection/auth-generator/simple_auth_generator.go
+++ b/pkg/plugins/apikey-injection/auth-generator/simple_auth_generator.go
@@ -60,10 +60,10 @@ func (g *SimpleAuthGenerator) ExtractRequestData(cycleState *framework.CycleStat
 
 	if headerName, ok := config[auth.SimpleAuthHeaderName]; ok {
 		authHeader = headerName
-		authValuePrefix = "" // non-default header implies no prefix unless explicitly set
-	}
-	if valuePrefix, ok := config[auth.SimpleAuthValuePrefix]; ok {
-		authValuePrefix = valuePrefix
+		authValuePrefix = ""                                           // non-default header implies no prefix unless explicitly set
+		if valuePrefix, ok := config[auth.SimpleAuthValuePrefix]; ok { // valuePrefix can be set only if header name is set
+			authValuePrefix = valuePrefix
+		}
 	}
 
 	return map[string]string{

--- a/pkg/plugins/apikey-injection/auth-generator/simple_auth_generator.go
+++ b/pkg/plugins/apikey-injection/auth-generator/simple_auth_generator.go
@@ -58,7 +58,7 @@ func (g *SimpleAuthGenerator) ExtractRequestData(cycleState *framework.CycleStat
 	authHeader := defaultAuthHeader
 	authValuePrefix := defaultAuthValuePrefix
 
-	if headerName, ok := config[auth.SimpleAuthHeaderName]; ok {
+	if headerName, ok := config[auth.SimpleAuthHeaderName]; ok && headerName != "" {
 		authHeader = headerName
 		authValuePrefix = ""                                           // non-default header implies no prefix unless explicitly set
 		if valuePrefix, ok := config[auth.SimpleAuthValuePrefix]; ok { // valuePrefix can be set only if header name is set

--- a/pkg/plugins/apikey-injection/auth-generator/simple_auth_generator_test.go
+++ b/pkg/plugins/apikey-injection/auth-generator/simple_auth_generator_test.go
@@ -38,8 +38,9 @@ func TestSimpleGenerateAuthHeaders(t *testing.T) {
 		{
 			name: "Bearer prefix (OpenAI style)",
 			credentials: map[string]string{
-				"api-key":                 "sk-test-key",
-				auth.SimpleAuthHeaderName: "Authorization", auth.SimpleAuthValuePrefix: "Bearer ",
+				"api-key":                  "sk-test-key",
+				auth.SimpleAuthHeaderName:  "Authorization",
+				auth.SimpleAuthValuePrefix: "Bearer ",
 			},
 			wantHeaders: map[string]string{
 				"Authorization": "Bearer sk-test-key",
@@ -48,8 +49,9 @@ func TestSimpleGenerateAuthHeaders(t *testing.T) {
 		{
 			name: "raw key without prefix (Anthropic style)",
 			credentials: map[string]string{
-				"api-key":                 "ant-key-123",
-				auth.SimpleAuthHeaderName: "x-api-key", auth.SimpleAuthValuePrefix: "",
+				"api-key":                  "ant-key-123",
+				auth.SimpleAuthHeaderName:  "x-api-key",
+				auth.SimpleAuthValuePrefix: "",
 			},
 			wantHeaders: map[string]string{
 				"x-api-key": "ant-key-123",
@@ -58,8 +60,9 @@ func TestSimpleGenerateAuthHeaders(t *testing.T) {
 		{
 			name: "missing api-key field returns error",
 			credentials: map[string]string{
-				"wrong-field":             "some-value",
-				auth.SimpleAuthHeaderName: "Authorization", auth.SimpleAuthValuePrefix: "Bearer ",
+				"wrong-field":              "some-value",
+				auth.SimpleAuthHeaderName:  "Authorization",
+				auth.SimpleAuthValuePrefix: "Bearer ",
 			},
 			wantErr: true,
 		},
@@ -124,7 +127,7 @@ func TestSimpleExtractRequestData(t *testing.T) {
 			wantValuePrefix: "Bearer ",
 		},
 		{
-			name:            "config with custom header name clears prefix",
+			name:            "config with custom header name clears value prefix",
 			config:          map[string]string{auth.SimpleAuthHeaderName: "x-api-key"},
 			wantHeaderName:  "x-api-key",
 			wantValuePrefix: "",
@@ -136,10 +139,10 @@ func TestSimpleExtractRequestData(t *testing.T) {
 			wantValuePrefix: "Key ",
 		},
 		{
-			name:            "config with value prefix only keeps default header",
+			name:            "config with value prefix only is ignored without header name",
 			config:          map[string]string{auth.SimpleAuthValuePrefix: "Token "},
 			wantHeaderName:  "Authorization",
-			wantValuePrefix: "Token ",
+			wantValuePrefix: "Bearer ",
 		},
 	}
 
@@ -159,10 +162,8 @@ func TestSimpleExtractRequestData(t *testing.T) {
 }
 
 func TestSimpleExtractRequestData_MissingModelConfigKey(t *testing.T) {
-	cs := framework.NewCycleState()
-
 	generator := NewSimpleAuthGenerator()
-	_, err := generator.ExtractRequestData(cs, framework.NewInferenceRequest())
+	_, err := generator.ExtractRequestData(framework.NewCycleState(), framework.NewInferenceRequest())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to extract config from cycle state")
 }

--- a/pkg/plugins/apikey-injection/auth-generator/simple_auth_generator_test.go
+++ b/pkg/plugins/apikey-injection/auth-generator/simple_auth_generator_test.go
@@ -21,51 +21,74 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
+
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/auth"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/state"
 )
 
-func TestSimpleAuthHeadersGenerator(t *testing.T) {
+func TestSimpleGenerateAuthHeaders(t *testing.T) {
 	tests := []struct {
-		name         string
-		headerName   string
-		headerPrefix string
-		credentials  map[string]string
-		wantHeaders  map[string]string
-		wantErr      bool
+		name        string
+		credentials map[string]string
+		wantHeaders map[string]string
+		wantErr     bool
 	}{
 		{
-			name:         "Bearer prefix (OpenAI style)",
-			headerName:   "Authorization",
-			headerPrefix: "Bearer ",
-			credentials:  map[string]string{"api-key": "sk-test-key"},
+			name: "Bearer prefix (OpenAI style)",
+			credentials: map[string]string{
+				"api-key":                 "sk-test-key",
+				auth.SimpleAuthHeaderName: "Authorization", auth.SimpleAuthValuePrefix: "Bearer ",
+			},
 			wantHeaders: map[string]string{
 				"Authorization": "Bearer sk-test-key",
 			},
 		},
 		{
-			name:        "raw key without prefix (Anthropic style)",
-			headerName:  "x-api-key",
-			credentials: map[string]string{"api-key": "ant-key-123"},
+			name: "raw key without prefix (Anthropic style)",
+			credentials: map[string]string{
+				"api-key":                 "ant-key-123",
+				auth.SimpleAuthHeaderName: "x-api-key", auth.SimpleAuthValuePrefix: "",
+			},
 			wantHeaders: map[string]string{
 				"x-api-key": "ant-key-123",
 			},
 		},
 		{
-			name:        "missing api-key field returns error",
-			headerName:  "Authorization",
-			credentials: map[string]string{"wrong-field": "some-value"},
-			wantErr:     true,
+			name: "missing api-key field returns error",
+			credentials: map[string]string{
+				"wrong-field":             "some-value",
+				auth.SimpleAuthHeaderName: "Authorization", auth.SimpleAuthValuePrefix: "Bearer ",
+			},
+			wantErr: true,
 		},
 		{
 			name:        "empty credentials returns error",
-			headerName:  "Authorization",
 			credentials: map[string]string{},
 			wantErr:     true,
+		},
+		{
+			name: "missing authHeaderName returns error",
+			credentials: map[string]string{
+				"api-key":                  "sk-test-key",
+				auth.SimpleAuthValuePrefix: "Bearer ",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing authValuePrefix returns error",
+			credentials: map[string]string{
+				"api-key":                 "sk-test-key",
+				auth.SimpleAuthHeaderName: "Authorization",
+			},
+			wantErr: true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			generator := &SimpleAuthGenerator{HeaderName: test.headerName, HeaderValuePrefix: test.headerPrefix}
+			generator := NewSimpleAuthGenerator()
 			authHeaders, err := generator.GenerateAuthHeaders(test.credentials)
 
 			if test.wantErr {
@@ -85,4 +108,61 @@ func TestSimpleAuthHeadersGenerator(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSimpleExtractRequestData(t *testing.T) {
+	tests := []struct {
+		name            string
+		config          map[string]string
+		wantHeaderName  string
+		wantValuePrefix string
+	}{
+		{
+			name:            "no config defaults to Authorization Bearer",
+			config:          map[string]string{},
+			wantHeaderName:  "Authorization",
+			wantValuePrefix: "Bearer ",
+		},
+		{
+			name:            "config with custom header name clears prefix",
+			config:          map[string]string{auth.SimpleAuthHeaderName: "x-api-key"},
+			wantHeaderName:  "x-api-key",
+			wantValuePrefix: "",
+		},
+		{
+			name:            "config with header name and explicit prefix",
+			config:          map[string]string{auth.SimpleAuthHeaderName: "x-api-key", auth.SimpleAuthValuePrefix: "Key "},
+			wantHeaderName:  "x-api-key",
+			wantValuePrefix: "Key ",
+		},
+		{
+			name:            "config with value prefix only keeps default header",
+			config:          map[string]string{auth.SimpleAuthValuePrefix: "Token "},
+			wantHeaderName:  "Authorization",
+			wantValuePrefix: "Token ",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cs := framework.NewCycleState()
+			cs.Write(state.ModelConfigKey, test.config)
+
+			generator := NewSimpleAuthGenerator()
+			result, err := generator.ExtractRequestData(cs, framework.NewInferenceRequest())
+
+			require.NoError(t, err)
+			require.Equal(t, test.wantHeaderName, result[auth.SimpleAuthHeaderName])
+			require.Equal(t, test.wantValuePrefix, result[auth.SimpleAuthValuePrefix])
+		})
+	}
+}
+
+func TestSimpleExtractRequestData_MissingModelConfigKey(t *testing.T) {
+	cs := framework.NewCycleState()
+
+	generator := NewSimpleAuthGenerator()
+	_, err := generator.ExtractRequestData(cs, framework.NewInferenceRequest())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to extract config from cycle state")
 }

--- a/pkg/plugins/apikey-injection/auth-generator/simple_auth_generator_test.go
+++ b/pkg/plugins/apikey-injection/auth-generator/simple_auth_generator_test.go
@@ -139,6 +139,12 @@ func TestSimpleExtractRequestData(t *testing.T) {
 			wantValuePrefix: "Key ",
 		},
 		{
+			name:            "config with empty header name defaults to Authorization Bearer",
+			config:          map[string]string{auth.SimpleAuthHeaderName: ""},
+			wantHeaderName:  "Authorization",
+			wantValuePrefix: "Bearer ",
+		},
+		{
 			name:            "config with value prefix only is ignored without header name",
 			config:          map[string]string{auth.SimpleAuthValuePrefix: "Token "},
 			wantHeaderName:  "Authorization",

--- a/pkg/plugins/apikey-injection/plugin.go
+++ b/pkg/plugins/apikey-injection/plugin.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 
 	authgenerator "github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/apikey-injection/auth-generator"
-	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/provider"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/auth"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/state"
 )
 
@@ -70,28 +70,20 @@ func NewAPIKeyInjectionPlugin(reconcilerBuilder func() *builder.Builder, clientR
 			Type: APIKeyInjectionPluginType,
 			Name: APIKeyInjectionPluginType,
 		},
-		// TODO(#310): Replace static provider→generator mapping with dynamic selection
-		// based on ExternalProvider.spec.auth.type once reconciler wiring lands.
-		authHeadersGenerators: map[string]authgenerator.AuthHeadersGenerator{
-			provider.OpenAI:      &authgenerator.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
-			provider.Anthropic:   &authgenerator.SimpleAuthGenerator{HeaderName: "x-api-key"},
-			provider.AzureOpenAI: &authgenerator.SimpleAuthGenerator{HeaderName: "api-key"},
-			// provider.Vertex uses the native GenerateContent API — not used in 3.4 ExternalModel flow.
-			// provider.Vertex:     &auth.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
-			provider.VertexOpenAI:  &authgenerator.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
-			provider.BedrockOpenAI: &authgenerator.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "Bearer "},
-			provider.AWSBedrock:    &authgenerator.SigV4AuthGenerator{},
+		authHeadersGenerators: map[auth.Auth]authgenerator.AuthHeadersGenerator{
+			auth.Simple: authgenerator.NewSimpleAuthGenerator(),
+			auth.SigV4:  authgenerator.NewSigV4AuthGenerator(),
 		},
 		store: store,
 	}), nil
 }
 
 // ApiKeyInjectionPlugin injects an API key from a Kubernetes Secret into the request headers.
-// The Secret is identified by its namespaced name from CycleState. The provider (e.g., openai, anthropic)
-// determines which header name and value format are used.
+// The Secret is identified by its namespaced name from CycleState. The Auth.Type (from the CR)
+// determines which header(s) and value(s) format are used.
 type ApiKeyInjectionPlugin struct {
 	typedName             plugin.TypedName
-	authHeadersGenerators map[string]authgenerator.AuthHeadersGenerator
+	authHeadersGenerators map[auth.Auth]authgenerator.AuthHeadersGenerator
 	store                 *secretStore
 }
 
@@ -106,66 +98,66 @@ func (p *ApiKeyInjectionPlugin) WithName(name string) *ApiKeyInjectionPlugin {
 	return p
 }
 
-// ProcessRequest reads the credential Secret reference and provider from CycleState (written by model-provider-resolver),
-// looks up the API key in the store, and injects provider-specific auth headers into the request.
+// ProcessRequest reads the credential Secret reference and authType from CycleState (written by model-provider-resolver),
+// looks up the API key in the store, and injects auth headers into the request.
 func (p *ApiKeyInjectionPlugin) ProcessRequest(ctx context.Context, cycleState *framework.CycleState, request *framework.InferenceRequest) error {
 	logger := log.FromContext(ctx).V(logutil.DEFAULT)
 
-	// Check if this is an external model (provider set by model-provider-resolver).
-	// Internal models have no provider in CycleState and don't need API key injection.
-	providerName, err := framework.ReadCycleStateKey[string](cycleState, state.ProviderKey)
-	if err != nil || providerName == "" {
+	// Check if this is an external model (authType set by model-provider-resolver).
+	// Internal models have no authType in CycleState and don't need API key injection.
+	authType, err := framework.ReadCycleStateKey[auth.Auth](cycleState, state.AuthTypeKey)
+	if err != nil || authType == "" {
 		return nil
 	}
 
 	credsName, err := framework.ReadCycleStateKey[string](cycleState, state.CredsRefName)
 	if err != nil || credsName == "" {
-		logger.Error(err, "credentialRef name missing", "provider", providerName)
-		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("provider '%s' is missing credentialRef", providerName)}
+		logger.Error(err, "credentialRef name missing", "authType", authType)
+		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("authType '%s' is missing credentialRef", authType)}
 	}
 	credsNamespace, err := framework.ReadCycleStateKey[string](cycleState, state.CredsRefNamespace)
 	if err != nil || credsNamespace == "" {
-		logger.Error(err, "credentialRef namespace missing", "provider", providerName)
-		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("provider '%s' is missing credentialRef namespace", providerName)}
+		logger.Error(err, "credentialRef namespace missing", "authType", authType)
+		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("authType '%s' is missing credentialRef namespace", authType)}
 	}
 
-	credentials, found := p.store.get(credsNamespace, credsName)
+	credentialsData, found := p.store.get(credsNamespace, credsName)
 	if !found {
-		logger.Error(nil, "credentials not found in store", "provider", providerName)
-		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("provider '%s' credentials not found", providerName)}
+		logger.Error(nil, "credentials not found in store", "authType", authType)
+		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("authType '%s' credentials not found", authType)}
 	}
 
-	generator, ok := p.authHeadersGenerators[providerName]
+	generator, ok := p.authHeadersGenerators[authType]
 	if !ok {
-		logger.Error(nil, "unsupported provider for auth generation", "provider", providerName)
-		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("unsupported provider - '%s'", providerName)}
+		logger.Error(nil, "unsupported auth type for auth generation", "authType", authType)
+		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("unsupported authType - '%s'", authType)}
 	}
 
 	extraData, err := generator.ExtractRequestData(cycleState, request)
 	if err != nil {
-		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("failed to extract request data for provider '%s': %v", providerName, err)}
+		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("failed to extract request data for authType '%s': %v", authType, err)}
 	}
 	if len(extraData) > 0 {
-		merged := make(map[string]string, len(credentials)+len(extraData))
-		for k, v := range credentials {
+		merged := make(map[string]string, len(credentialsData)+len(extraData))
+		for k, v := range credentialsData {
 			merged[k] = v
 		}
 		for k, v := range extraData {
 			merged[k] = v
 		}
-		credentials = merged
+		credentialsData = merged
 	}
 
-	authHeaders, err := generator.GenerateAuthHeaders(credentials)
+	authHeaders, err := generator.GenerateAuthHeaders(credentialsData)
 	if err != nil {
-		logger.Error(err, "auth header generation failed", "provider", providerName)
-		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("failed to generate auth headers for provider '%s': %v", providerName, err)}
+		logger.Error(err, "auth header generation failed", "authType", authType)
+		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("failed to generate auth headers for authType '%s': %v", authType, err)}
 	}
 
 	for headerKey, headerValue := range authHeaders {
 		request.SetHeader(headerKey, headerValue)
 	}
 
-	logger.Info("auth headers injected", "provider", providerName)
+	logger.Info("auth headers injected", "authType", authType)
 	return nil
 }

--- a/pkg/plugins/apikey-injection/plugin.go
+++ b/pkg/plugins/apikey-injection/plugin.go
@@ -139,7 +139,7 @@ func (p *ApiKeyInjectionPlugin) ProcessRequest(ctx context.Context, cycleState *
 		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("failed to extract request data for authType '%s': %v", authType, err)}
 	}
 	if len(extraData) > 0 {
-		merged := make(map[string]string, len(credentialsData))
+		merged := make(map[string]string, len(credentialsData)+len(extraData))
 		maps.Copy(merged, credentialsData)
 		maps.Copy(merged, extraData)
 		credentialsData = merged

--- a/pkg/plugins/apikey-injection/plugin.go
+++ b/pkg/plugins/apikey-injection/plugin.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -138,13 +139,9 @@ func (p *ApiKeyInjectionPlugin) ProcessRequest(ctx context.Context, cycleState *
 		return errcommon.Error{Code: errcommon.Internal, Msg: fmt.Sprintf("failed to extract request data for authType '%s': %v", authType, err)}
 	}
 	if len(extraData) > 0 {
-		merged := make(map[string]string, len(credentialsData)+len(extraData))
-		for k, v := range credentialsData {
-			merged[k] = v
-		}
-		for k, v := range extraData {
-			merged[k] = v
-		}
+		merged := make(map[string]string, len(credentialsData))
+		maps.Copy(merged, credentialsData)
+		maps.Copy(merged, extraData)
 		credentialsData = merged
 	}
 

--- a/pkg/plugins/apikey-injection/plugin_test.go
+++ b/pkg/plugins/apikey-injection/plugin_test.go
@@ -78,9 +78,7 @@ func newCycleState(credsNamespace, credsName string, authType auth.Auth) *framew
 	cs := framework.NewCycleState()
 	cs.Write(state.CredsRefName, credsName)
 	cs.Write(state.CredsRefNamespace, credsNamespace)
-	if authType != "" {
-		cs.Write(state.AuthTypeKey, authType)
-	}
+	cs.Write(state.AuthTypeKey, authType)
 	return cs
 }
 
@@ -88,7 +86,6 @@ func TestProcessRequest(t *testing.T) {
 	tests := []struct {
 		name              string
 		secrets           []*corev1.Secret
-		request           *framework.InferenceRequest
 		prepareCycleState func() *framework.CycleState
 		wantHeaders       map[string]string
 		errorContains     string
@@ -96,7 +93,6 @@ func TestProcessRequest(t *testing.T) {
 		{
 			name:    "simple auth with default Bearer prefix (OpenAI style)",
 			secrets: []*corev1.Secret{testSecret("default", "openai-key", map[string]string{"api-key": "sk-test-key"})},
-			request: framework.NewInferenceRequest(),
 			prepareCycleState: func() *framework.CycleState {
 				return newSimpleCycleState("default", "openai-key", map[string]string{})
 			},
@@ -107,7 +103,6 @@ func TestProcessRequest(t *testing.T) {
 		{
 			name:    "simple auth with config-injected header (Anthropic style)",
 			secrets: []*corev1.Secret{testSecret("default", "anthropic-key", map[string]string{"api-key": "ant-key-123"})},
-			request: framework.NewInferenceRequest(),
 			prepareCycleState: func() *framework.CycleState {
 				return newSimpleCycleState("default", "anthropic-key", map[string]string{auth.SimpleAuthHeaderName: "x-api-key"})
 			},
@@ -118,21 +113,18 @@ func TestProcessRequest(t *testing.T) {
 		{
 			name:              "unknown auth type — request fails",
 			secrets:           []*corev1.Secret{testSecret("default", "no-auth", map[string]string{"api-key": "sk-key"})},
-			request:           framework.NewInferenceRequest(),
 			prepareCycleState: func() *framework.CycleState { return newCycleState("default", "no-auth", "unknown-auth-type") },
 			errorContains:     "unsupported authType",
 		},
 		{
 			name:              "internal model no auth type - skip gracefully",
 			secrets:           []*corev1.Secret{testSecret("default", "no-auth", map[string]string{"api-key": "sk-key"})},
-			request:           framework.NewInferenceRequest(),
 			prepareCycleState: func() *framework.CycleState { return framework.NewCycleState() },
 			wantHeaders:       map[string]string{},
 		},
 		{
 			name:    "missing credentials ref results in error",
 			secrets: []*corev1.Secret{testSecret("default", "no-creds", map[string]string{"api-key": "sk-key"})},
-			request: framework.NewInferenceRequest(),
 			prepareCycleState: func() *framework.CycleState {
 				cs := framework.NewCycleState()
 				cs.Write(state.AuthTypeKey, auth.Simple) // external model has auth type but no creds
@@ -143,7 +135,6 @@ func TestProcessRequest(t *testing.T) {
 		{
 			name:    "credentials not found results in error",
 			secrets: []*corev1.Secret{},
-			request: framework.NewInferenceRequest(),
 			prepareCycleState: func() *framework.CycleState {
 				return newSimpleCycleState("default", "unknown", map[string]string{})
 			},
@@ -152,7 +143,6 @@ func TestProcessRequest(t *testing.T) {
 		{
 			name:    "missing api-key field in credentials results in error",
 			secrets: []*corev1.Secret{testSecret("default", "wrong-fields", map[string]string{"wrong-field": "value"})},
-			request: framework.NewInferenceRequest(),
 			prepareCycleState: func() *framework.CycleState {
 				return newSimpleCycleState("default", "wrong-fields", map[string]string{})
 			},
@@ -168,13 +158,14 @@ func TestProcessRequest(t *testing.T) {
 			}
 
 			plugin := newTestPlugin(store)
-			err := plugin.ProcessRequest(context.Background(), test.prepareCycleState(), test.request)
+			request := framework.NewInferenceRequest()
+			err := plugin.ProcessRequest(context.Background(), test.prepareCycleState(), request)
 			if test.errorContains != "" {
 				require.ErrorContains(t, err, test.errorContains)
 				return
 			}
 			require.NoError(t, err)
-			if diff := cmp.Diff(test.wantHeaders, test.request.Headers, cmpopts.SortMaps(func(a, b string) bool { return a < b }), cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(test.wantHeaders, request.Headers, cmpopts.SortMaps(func(a, b string) bool { return a < b }), cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("headers mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/plugins/apikey-injection/plugin_test.go
+++ b/pkg/plugins/apikey-injection/plugin_test.go
@@ -29,14 +29,8 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
 
 	authgenerator "github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/apikey-injection/auth-generator"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/auth"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/state"
-)
-
-const (
-	// Synthetic provider names for unit tests.
-	testProviderWithPrefix    = "provider-with-prefix"
-	testProviderWithoutPrefix = "provider-without-prefix"
-	testProviderSigV4         = "provider-sigv4"
 )
 
 // newTestPlugin creates an apiKeyInjectionPlugin for unit tests, bypassing the
@@ -44,10 +38,9 @@ const (
 func newTestPlugin(store *secretStore) *ApiKeyInjectionPlugin {
 	return &ApiKeyInjectionPlugin{
 		typedName: plugin.TypedName{Type: APIKeyInjectionPluginType, Name: APIKeyInjectionPluginType},
-		authHeadersGenerators: map[string]authgenerator.AuthHeadersGenerator{
-			testProviderWithPrefix:    &authgenerator.SimpleAuthGenerator{HeaderName: "Authorization", HeaderValuePrefix: "prefix "},
-			testProviderWithoutPrefix: &authgenerator.SimpleAuthGenerator{HeaderName: "x-api-key"},
-			testProviderSigV4:         &authgenerator.SigV4AuthGenerator{},
+		authHeadersGenerators: map[auth.Auth]authgenerator.AuthHeadersGenerator{
+			auth.Simple: authgenerator.NewSimpleAuthGenerator(),
+			auth.SigV4:  authgenerator.NewSigV4AuthGenerator(),
 		},
 		store: store,
 	}
@@ -63,21 +56,30 @@ func newBedrockRequest() *framework.InferenceRequest {
 	return req
 }
 
-// newSigV4CycleState builds a CycleState with credential ref, sigv4 test provider, endpoint, and config.
+// newSigV4CycleState builds a CycleState with credential ref, sigv4 auth type, endpoint, and config.
 func newSigV4CycleState(credsNamespace, credsName string) *framework.CycleState {
-	cs := newCycleState(credsNamespace, credsName, testProviderSigV4)
+	cs := newCycleState(credsNamespace, credsName, auth.SigV4)
 	cs.Write(state.EndpointKey, "bedrock-runtime.us-east-1.amazonaws.com")
 	cs.Write(state.ModelConfigKey, map[string]string{"service": "bedrock"})
 	return cs
 }
 
-// newCycleState builds a CycleState with credential ref and optional provider.
-func newCycleState(credsNamespace, credsName, providerName string) *framework.CycleState {
+// newSimpleCycleState builds a CycleState with credential ref, simple auth type,
+// and config. The config simulates what the provider reconciler would inject
+// (e.g. authHeaderName for providers like Anthropic/Azure).
+func newSimpleCycleState(credsNamespace, credsName string, config map[string]string) *framework.CycleState {
+	cs := newCycleState(credsNamespace, credsName, auth.Simple)
+	cs.Write(state.ModelConfigKey, config)
+	return cs
+}
+
+// newCycleState builds a CycleState with credential ref and auth type.
+func newCycleState(credsNamespace, credsName string, authType auth.Auth) *framework.CycleState {
 	cs := framework.NewCycleState()
 	cs.Write(state.CredsRefName, credsName)
 	cs.Write(state.CredsRefNamespace, credsNamespace)
-	if providerName != "" {
-		cs.Write(state.ProviderKey, providerName)
+	if authType != "" {
+		cs.Write(state.AuthTypeKey, authType)
 	}
 	return cs
 }
@@ -92,46 +94,48 @@ func TestProcessRequest(t *testing.T) {
 		errorContains     string
 	}{
 		{
-			name:              "provider that has simple generator with prefix",
-			secrets:           []*corev1.Secret{testSecret("default", "openai-key", map[string]string{"api-key": "sk-test-key"})},
-			request:           framework.NewInferenceRequest(),
-			prepareCycleState: func() *framework.CycleState { return newCycleState("default", "openai-key", testProviderWithPrefix) },
+			name:    "simple auth with default Bearer prefix (OpenAI style)",
+			secrets: []*corev1.Secret{testSecret("default", "openai-key", map[string]string{"api-key": "sk-test-key"})},
+			request: framework.NewInferenceRequest(),
+			prepareCycleState: func() *framework.CycleState {
+				return newSimpleCycleState("default", "openai-key", map[string]string{})
+			},
 			wantHeaders: map[string]string{
-				"Authorization": "prefix sk-test-key",
+				"Authorization": "Bearer sk-test-key",
 			},
 		},
 		{
-			name:    "provider that has simple generator without prefix",
+			name:    "simple auth with config-injected header (Anthropic style)",
 			secrets: []*corev1.Secret{testSecret("default", "anthropic-key", map[string]string{"api-key": "ant-key-123"})},
 			request: framework.NewInferenceRequest(),
 			prepareCycleState: func() *framework.CycleState {
-				return newCycleState("default", "anthropic-key", testProviderWithoutPrefix)
+				return newSimpleCycleState("default", "anthropic-key", map[string]string{auth.SimpleAuthHeaderName: "x-api-key"})
 			},
 			wantHeaders: map[string]string{
 				"x-api-key": "ant-key-123",
 			},
 		},
 		{
-			name:              "unknown provider — request fails",
-			secrets:           []*corev1.Secret{testSecret("default", "no-provider", map[string]string{"api-key": "sk-key"})},
+			name:              "unknown auth type — request fails",
+			secrets:           []*corev1.Secret{testSecret("default", "no-auth", map[string]string{"api-key": "sk-key"})},
 			request:           framework.NewInferenceRequest(),
-			prepareCycleState: func() *framework.CycleState { return newCycleState("default", "no-provider", "some-unknown-provider") },
-			errorContains:     "unsupported provider",
+			prepareCycleState: func() *framework.CycleState { return newCycleState("default", "no-auth", "unknown-auth-type") },
+			errorContains:     "unsupported authType",
 		},
 		{
-			name:              "internal model no provider - skip gracefully",
-			secrets:           []*corev1.Secret{testSecret("default", "no-provider", map[string]string{"api-key": "sk-key"})},
+			name:              "internal model no auth type - skip gracefully",
+			secrets:           []*corev1.Secret{testSecret("default", "no-auth", map[string]string{"api-key": "sk-key"})},
 			request:           framework.NewInferenceRequest(),
 			prepareCycleState: func() *framework.CycleState { return framework.NewCycleState() },
 			wantHeaders:       map[string]string{},
 		},
 		{
 			name:    "missing credentials ref results in error",
-			secrets: []*corev1.Secret{testSecret("default", "no-provider", map[string]string{"api-key": "sk-key"})},
+			secrets: []*corev1.Secret{testSecret("default", "no-creds", map[string]string{"api-key": "sk-key"})},
 			request: framework.NewInferenceRequest(),
 			prepareCycleState: func() *framework.CycleState {
 				cs := framework.NewCycleState()
-				cs.Write(state.ProviderKey, testProviderWithPrefix) // external model has provider but no creds
+				cs.Write(state.AuthTypeKey, auth.Simple) // external model has auth type but no creds
 				return cs
 			},
 			errorContains: "missing credentialRef",
@@ -141,7 +145,7 @@ func TestProcessRequest(t *testing.T) {
 			secrets: []*corev1.Secret{},
 			request: framework.NewInferenceRequest(),
 			prepareCycleState: func() *framework.CycleState {
-				return newCycleState("default", "unknown", testProviderWithPrefix)
+				return newSimpleCycleState("default", "unknown", map[string]string{})
 			},
 			errorContains: "credentials not found",
 		},
@@ -150,7 +154,7 @@ func TestProcessRequest(t *testing.T) {
 			secrets: []*corev1.Secret{testSecret("default", "wrong-fields", map[string]string{"wrong-field": "value"})},
 			request: framework.NewInferenceRequest(),
 			prepareCycleState: func() *framework.CycleState {
-				return newCycleState("default", "wrong-fields", testProviderWithPrefix)
+				return newSimpleCycleState("default", "wrong-fields", map[string]string{})
 			},
 			errorContains: "failed to generate auth headers",
 		},
@@ -221,7 +225,7 @@ func TestProcessRequest_AWSBedrock(t *testing.T) {
 				"aws-access-key-id":     "AKIAIOSFODNN7EXAMPLE",
 				"aws-secret-access-key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
 			})},
-			prepareCycleState: func() *framework.CycleState { return newCycleState("default", "bedrock-creds", testProviderSigV4) },
+			prepareCycleState: func() *framework.CycleState { return newCycleState("default", "bedrock-creds", auth.SigV4) },
 			errorContains:     "failed to extract request data",
 		},
 		{

--- a/pkg/plugins/common/auth/auth.go
+++ b/pkg/plugins/common/auth/auth.go
@@ -20,6 +20,11 @@ type Auth string
 
 const (
 	Simple Auth = "simple"
-	SigV4  Auth = "sigv4"  // not used yet
+	SigV4  Auth = "sigv4"
 	OAuth2 Auth = "oauth2" // not used yet
+)
+
+const (
+	SimpleAuthHeaderName  = "authHeaderName"
+	SimpleAuthValuePrefix = "authValuePrefix"
 )

--- a/pkg/plugins/common/provider/provider.go
+++ b/pkg/plugins/common/provider/provider.go
@@ -26,5 +26,4 @@ const (
 	AzureOpenAI   = "azure-openai"
 	VertexOpenAI  = "vertex-openai"
 	BedrockOpenAI = "bedrock-openai"
-	AWSBedrock    = "aws-bedrock"
 )

--- a/pkg/plugins/common/state/state-keys.go
+++ b/pkg/plugins/common/state/state-keys.go
@@ -24,6 +24,7 @@ const (
 	CredsRefNamespace = "credential-ref-namespace"
 	ModelConfigKey    = "model-config"
 	APIFormatKey      = "api-format"
+	AuthTypeKey       = "auth"
 	InputAPIFormatKey = "input-api-format"
 	EndpointKey       = "endpoint"
 )

--- a/pkg/plugins/model-provider-resolver/external_model_reconciler.go
+++ b/pkg/plugins/model-provider-resolver/external_model_reconciler.go
@@ -30,6 +30,7 @@ import (
 
 	inferencev1alpha1 "github.com/opendatahub-io/ai-gateway-payload-processing/api/inference/v1alpha1"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/apiformat"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/auth"
 )
 
 const providerRequeueDelay = 5 * time.Second
@@ -96,9 +97,11 @@ func (r *externalModelReconciler) resolveRef(namespace string, ref *inferencev1a
 
 	secretName := providerInfo.secretName
 	secretNamespace := providerInfo.secretNamespace
+	authType := providerInfo.auth
 	if ref.Auth != nil {
 		secretName = ref.Auth.SecretRef.Name
 		secretNamespace = namespace
+		authType = auth.Auth(ref.Auth.Type)
 	}
 
 	weight := 1
@@ -110,6 +113,7 @@ func (r *externalModelReconciler) resolveRef(namespace string, ref *inferencev1a
 		provider:        providerInfo.provider,
 		targetModel:     ref.TargetModel,
 		apiFormat:       apiformat.APIFormat(ref.APIFormat),
+		auth:            authType,
 		endpoint:        providerInfo.endpoint,
 		secretName:      secretName,
 		secretNamespace: secretNamespace,

--- a/pkg/plugins/model-provider-resolver/external_model_reconciler_test.go
+++ b/pkg/plugins/model-provider-resolver/external_model_reconciler_test.go
@@ -32,6 +32,7 @@ import (
 
 	inferencev1alpha1 "github.com/opendatahub-io/ai-gateway-payload-processing/api/inference/v1alpha1"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/apiformat"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/auth"
 )
 
 type mockModelReader struct {
@@ -79,6 +80,7 @@ func TestModelReconciler_HappyPath(t *testing.T) {
 		types.NamespacedName{Namespace: "models", Name: "my-openai"},
 		&providerInfo{
 			provider: "openai", endpoint: "api.openai.com",
+			auth:            auth.Simple,
 			secretName: "openai-key", secretNamespace: "models",
 			config: map[string]string{},
 		},
@@ -96,6 +98,7 @@ func TestModelReconciler_HappyPath(t *testing.T) {
 	assert.Equal(t, "openai", info.refs[0].provider)
 	assert.Equal(t, "gpt-4o", info.refs[0].targetModel)
 	assert.Equal(t, apiformat.OpenAIChatCompletions, info.refs[0].apiFormat)
+	assert.Equal(t, auth.Simple, info.refs[0].auth)
 	assert.Equal(t, "openai-key", info.refs[0].secretName)
 	assert.Equal(t, 1, info.refs[0].weight)
 }
@@ -239,7 +242,7 @@ func TestModelReconciler_AuthOverride(t *testing.T) {
 	store.addOrUpdateProvider(
 		types.NamespacedName{Namespace: "models", Name: "my-openai"},
 		&providerInfo{provider: "openai", endpoint: "api.openai.com",
-			secretName: "provider-key", secretNamespace: "models", config: map[string]string{}},
+			auth: auth.SigV4, secretName: "provider-key", secretNamespace: "models", config: map[string]string{}},
 	)
 
 	r := &externalModelReconciler{Reader: reader, store: store}
@@ -249,6 +252,7 @@ func TestModelReconciler_AuthOverride(t *testing.T) {
 
 	info, found := store.getModel(key)
 	require.True(t, found)
+	assert.Equal(t, auth.Simple, info.refs[0].auth, "model-level auth overrides provider-level auth")
 	assert.Equal(t, "model-specific-key", info.refs[0].secretName)
 	assert.Equal(t, "models", info.refs[0].secretNamespace)
 }

--- a/pkg/plugins/model-provider-resolver/external_provider_reconciler.go
+++ b/pkg/plugins/model-provider-resolver/external_provider_reconciler.go
@@ -19,6 +19,7 @@ package model_provider_resolver
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -30,6 +31,16 @@ import (
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/auth"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/provider"
 )
+
+// defaultAuthHeaders maps providers that use a non-standard auth header name.
+// Providers not listed here fall back to "Authorization" with "Bearer " prefix
+// in the auth generator.
+var defaultAuthHeaders = map[string]string{
+	provider.Anthropic: "x-api-key",
+	provider.Azure:     "api-key",
+	// TODO to be removed
+	provider.AzureOpenAI: "api-key",
+}
 
 type externalProviderReconciler struct {
 	client.Reader
@@ -52,11 +63,7 @@ func (r *externalProviderReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, nil
 	}
 
-	config := provider.Spec.Config
-	if config == nil {
-		config = map[string]string{}
-	}
-	applyAuthDefaults(config, provider.Spec.Provider)
+	config := buildConfigWithDefaults(provider.Spec.Provider, provider.Spec.Config)
 	r.store.addOrUpdateProvider(req.NamespacedName, &providerInfo{
 		provider:        provider.Spec.Provider,
 		endpoint:        provider.Spec.Endpoint,
@@ -70,23 +77,13 @@ func (r *externalProviderReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	return ctrl.Result{}, nil
 }
 
-// defaultAuthHeaders maps providers that use a non-standard auth header name.
-// Providers not listed here fall back to "Authorization" with "Bearer " prefix
-// in the auth generator.
-var defaultAuthHeaders = map[string]string{
-	provider.Anthropic:   "x-api-key",
-	provider.Azure:       "api-key",
-	provider.AzureOpenAI: "api-key", // TODO to be removed
-}
-
-// applyAuthDefaults injects provider-specific auth header defaults into the
-// config map when they are not already set by the user.
-func applyAuthDefaults(config map[string]string, providerName string) {
-	headerName, ok := defaultAuthHeaders[providerName]
-	if !ok {
-		return
-	}
-	if _, exists := config[auth.SimpleAuthHeaderName]; !exists {
+// buildConfigWithDefaults returns a config map that starts from provider-specific
+// defaults and then applies any user-supplied values from the CR on top.
+func buildConfigWithDefaults(providerName string, userConfig map[string]string) map[string]string {
+	config := map[string]string{}
+	if headerName, ok := defaultAuthHeaders[providerName]; ok {
 		config[auth.SimpleAuthHeaderName] = headerName
 	}
+	maps.Copy(config, userConfig)
+	return config
 }

--- a/pkg/plugins/model-provider-resolver/external_provider_reconciler.go
+++ b/pkg/plugins/model-provider-resolver/external_provider_reconciler.go
@@ -27,6 +27,8 @@ import (
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 
 	inferencev1alpha1 "github.com/opendatahub-io/ai-gateway-payload-processing/api/inference/v1alpha1"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/auth"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/provider"
 )
 
 type externalProviderReconciler struct {
@@ -54,9 +56,11 @@ func (r *externalProviderReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if config == nil {
 		config = map[string]string{}
 	}
+	applyAuthDefaults(config, provider.Spec.Provider)
 	r.store.addOrUpdateProvider(req.NamespacedName, &providerInfo{
 		provider:        provider.Spec.Provider,
 		endpoint:        provider.Spec.Endpoint,
+		auth:            auth.Auth(provider.Spec.Auth.Type),
 		secretName:      provider.Spec.Auth.SecretRef.Name,
 		secretNamespace: req.Namespace,
 		config:          config,
@@ -64,4 +68,25 @@ func (r *externalProviderReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	logger.Info("updated provider store", "provider", provider.Spec.Provider, "endpoint", provider.Spec.Endpoint)
 	return ctrl.Result{}, nil
+}
+
+// defaultAuthHeaders maps providers that use a non-standard auth header name.
+// Providers not listed here fall back to "Authorization" with "Bearer " prefix
+// in the auth generator.
+var defaultAuthHeaders = map[string]string{
+	provider.Anthropic:   "x-api-key",
+	provider.Azure:       "api-key",
+	provider.AzureOpenAI: "api-key", // TODO to be removed
+}
+
+// applyAuthDefaults injects provider-specific auth header defaults into the
+// config map when they are not already set by the user.
+func applyAuthDefaults(config map[string]string, providerName string) {
+	headerName, ok := defaultAuthHeaders[providerName]
+	if !ok {
+		return
+	}
+	if _, exists := config[auth.SimpleAuthHeaderName]; !exists {
+		config[auth.SimpleAuthHeaderName] = headerName
+	}
 }

--- a/pkg/plugins/model-provider-resolver/external_provider_reconciler_test.go
+++ b/pkg/plugins/model-provider-resolver/external_provider_reconciler_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	inferencev1alpha1 "github.com/opendatahub-io/ai-gateway-payload-processing/api/inference/v1alpha1"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/auth"
 )
 
 type mockProviderReader struct {
@@ -74,8 +75,12 @@ func TestProviderReconciler_ValidCR(t *testing.T) {
 	require.True(t, found)
 	assert.Equal(t, "openai", info.provider)
 	assert.Equal(t, "api.openai.com", info.endpoint)
+	assert.Equal(t, auth.Simple, info.auth)
 	assert.Equal(t, "openai-key", info.secretName)
 	assert.Equal(t, "models", info.secretNamespace)
+	// openai has no special auth header default — config should not contain authHeaderName
+	_, hasAuthHeader := info.config[auth.SimpleAuthHeaderName]
+	assert.False(t, hasAuthHeader, "openai provider should not have auth header default injected")
 }
 
 func TestProviderReconciler_DeletedCR(t *testing.T) {
@@ -119,6 +124,116 @@ func TestProviderReconciler_WithConfig(t *testing.T) {
 
 	info, found := store.getProvider(key)
 	require.True(t, found)
+	assert.Equal(t, auth.Simple, info.auth)
 	assert.Equal(t, "my-project", info.config["project"])
 	assert.Equal(t, "us-central1", info.config["location"])
+}
+
+func TestProviderReconciler_AuthDefaultsInjected(t *testing.T) {
+	key := types.NamespacedName{Namespace: "models", Name: "my-anthropic"}
+	reader := &mockProviderReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalProvider{
+		key: {
+			ObjectMeta: metav1.ObjectMeta{Name: "my-anthropic", Namespace: "models"},
+			Spec: inferencev1alpha1.ExternalProviderSpec{
+				Provider: "anthropic",
+				Endpoint: "api.anthropic.com",
+				Auth: inferencev1alpha1.AuthConfig{
+					Type:      "simple",
+					SecretRef: inferencev1alpha1.NameReference{Name: "anthropic-key"}},
+			},
+		},
+	}}
+	store := newInfoStore()
+	r := &externalProviderReconciler{Reader: reader, store: store}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+
+	info, found := store.getProvider(key)
+	require.True(t, found)
+	assert.Equal(t, "x-api-key", info.config[auth.SimpleAuthHeaderName],
+		"anthropic provider should have authHeaderName default injected")
+}
+
+func TestProviderReconciler_AuthDefaultsNotOverridden(t *testing.T) {
+	key := types.NamespacedName{Namespace: "models", Name: "my-anthropic"}
+	reader := &mockProviderReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalProvider{
+		key: {
+			ObjectMeta: metav1.ObjectMeta{Name: "my-anthropic", Namespace: "models"},
+			Spec: inferencev1alpha1.ExternalProviderSpec{
+				Provider: "anthropic",
+				Endpoint: "api.anthropic.com",
+				Auth: inferencev1alpha1.AuthConfig{
+					Type:      "simple",
+					SecretRef: inferencev1alpha1.NameReference{Name: "anthropic-key"}},
+				Config: map[string]string{auth.SimpleAuthHeaderName: "custom-header"},
+			},
+		},
+	}}
+	store := newInfoStore()
+	r := &externalProviderReconciler{Reader: reader, store: store}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+
+	info, found := store.getProvider(key)
+	require.True(t, found)
+	assert.Equal(t, "custom-header", info.config[auth.SimpleAuthHeaderName],
+		"user-specified config should not be overridden by defaults")
+}
+
+func TestApplyAuthDefaults(t *testing.T) {
+	tests := []struct {
+		name           string
+		providerName   string
+		config         map[string]string
+		wantHeaderName string
+		wantInConfig   bool
+	}{
+		{
+			name:           "anthropic gets x-api-key",
+			providerName:   "anthropic",
+			config:         map[string]string{},
+			wantHeaderName: "x-api-key",
+			wantInConfig:   true,
+		},
+		{
+			name:           "azure gets api-key",
+			providerName:   "azure",
+			config:         map[string]string{},
+			wantHeaderName: "api-key",
+			wantInConfig:   true,
+		},
+		{
+			name:           "azure-openai gets api-key",
+			providerName:   "azure-openai",
+			config:         map[string]string{},
+			wantHeaderName: "api-key",
+			wantInConfig:   true,
+		},
+		{
+			name:         "openai gets no default",
+			providerName: "openai",
+			config:       map[string]string{},
+			wantInConfig: false,
+		},
+		{
+			name:           "user config not overridden",
+			providerName:   "anthropic",
+			config:         map[string]string{auth.SimpleAuthHeaderName: "custom"},
+			wantHeaderName: "custom",
+			wantInConfig:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			applyAuthDefaults(test.config, test.providerName)
+			headerName, exists := test.config[auth.SimpleAuthHeaderName]
+			assert.Equal(t, test.wantInConfig, exists)
+			if test.wantInConfig {
+				assert.Equal(t, test.wantHeaderName, headerName)
+			}
+		})
+	}
 }

--- a/pkg/plugins/model-provider-resolver/external_provider_reconciler_test.go
+++ b/pkg/plugins/model-provider-resolver/external_provider_reconciler_test.go
@@ -182,54 +182,61 @@ func TestProviderReconciler_AuthDefaultsNotOverridden(t *testing.T) {
 		"user-specified config should not be overridden by defaults")
 }
 
-func TestApplyAuthDefaults(t *testing.T) {
+func TestBuildConfigWithDefaults(t *testing.T) {
 	tests := []struct {
 		name           string
 		providerName   string
-		config         map[string]string
+		userConfig     map[string]string
 		wantHeaderName string
 		wantInConfig   bool
 	}{
 		{
 			name:           "anthropic gets x-api-key",
 			providerName:   "anthropic",
-			config:         map[string]string{},
+			userConfig:     map[string]string{},
 			wantHeaderName: "x-api-key",
 			wantInConfig:   true,
 		},
 		{
 			name:           "azure gets api-key",
 			providerName:   "azure",
-			config:         map[string]string{},
+			userConfig:     map[string]string{},
 			wantHeaderName: "api-key",
 			wantInConfig:   true,
 		},
 		{
 			name:           "azure-openai gets api-key",
 			providerName:   "azure-openai",
-			config:         map[string]string{},
+			userConfig:     map[string]string{},
 			wantHeaderName: "api-key",
 			wantInConfig:   true,
 		},
 		{
 			name:         "openai gets no default",
 			providerName: "openai",
-			config:       map[string]string{},
+			userConfig:   map[string]string{},
 			wantInConfig: false,
 		},
 		{
-			name:           "user config not overridden",
+			name:           "user config overrides default",
 			providerName:   "anthropic",
-			config:         map[string]string{auth.SimpleAuthHeaderName: "custom"},
+			userConfig:     map[string]string{auth.SimpleAuthHeaderName: "custom"},
 			wantHeaderName: "custom",
 			wantInConfig:   true,
+		},
+		{
+			name:         "nil user config uses defaults",
+			providerName: "anthropic",
+			userConfig:   nil,
+			wantHeaderName: "x-api-key",
+			wantInConfig: true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			applyAuthDefaults(test.config, test.providerName)
-			headerName, exists := test.config[auth.SimpleAuthHeaderName]
+			config := buildConfigWithDefaults(test.providerName, test.userConfig)
+			headerName, exists := config[auth.SimpleAuthHeaderName]
 			assert.Equal(t, test.wantInConfig, exists)
 			if test.wantInConfig {
 				assert.Equal(t, test.wantHeaderName, headerName)

--- a/pkg/plugins/model-provider-resolver/plugin.go
+++ b/pkg/plugins/model-provider-resolver/plugin.go
@@ -179,6 +179,7 @@ func (p *ModelProviderResolverPlugin) ProcessRequest(ctx context.Context, cycleS
 	cycleState.Write(state.ProviderKey, ref.provider)
 	cycleState.Write(state.ModelKey, ref.targetModel)
 	cycleState.Write(state.APIFormatKey, ref.apiFormat)
+	cycleState.Write(state.AuthTypeKey, ref.auth)
 	cycleState.Write(state.EndpointKey, ref.endpoint)
 	cycleState.Write(state.CredsRefName, ref.secretName)
 	cycleState.Write(state.CredsRefNamespace, ref.secretNamespace)

--- a/pkg/plugins/model-provider-resolver/plugin_test.go
+++ b/pkg/plugins/model-provider-resolver/plugin_test.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/bbr/framework"
 
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/apiformat"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/auth"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/provider"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/state"
 )
@@ -44,6 +45,7 @@ func TestProcessRequest_ModelResolved(t *testing.T) {
 			provider:        provider.Anthropic,
 			targetModel:     targetModel,
 			apiFormat:       apiformat.Messages,
+			auth:            auth.Simple,
 			endpoint:        endpoint,
 			secretName:      credName,
 			secretNamespace: extNS,
@@ -80,6 +82,10 @@ func TestProcessRequest_ModelResolved(t *testing.T) {
 	actualAPIFormat, err := framework.ReadCycleStateKey[apiformat.APIFormat](cs, state.APIFormatKey)
 	require.NoError(t, err)
 	require.Equal(t, apiformat.Messages, actualAPIFormat)
+
+	actualAuthType, err := framework.ReadCycleStateKey[auth.Auth](cs, state.AuthTypeKey)
+	require.NoError(t, err)
+	require.Equal(t, auth.Simple, actualAuthType)
 
 	actualEndpoint, err := framework.ReadCycleStateKey[string](cs, state.EndpointKey)
 	require.NoError(t, err)

--- a/pkg/plugins/model-provider-resolver/store.go
+++ b/pkg/plugins/model-provider-resolver/store.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/apiformat"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/auth"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -27,6 +28,7 @@ import (
 type providerInfo struct {
 	provider        string
 	endpoint        string
+	auth            auth.Auth
 	secretName      string
 	secretNamespace string
 	config          map[string]string
@@ -37,6 +39,7 @@ type resolvedProviderRef struct {
 	provider        string
 	targetModel     string
 	apiFormat       apiformat.APIFormat
+	auth            auth.Auth
 	endpoint        string
 	secretName      string
 	secretNamespace string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
update the apijey injection mapping to be by auth type (from the CR).
Fix: #317 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added authentication-type-based API key injection with support for Simple, SigV4, and OAuth2
  * Added authentication metadata propagation through model/provider resolution
  * Added support for Azure OpenAI, Vertex OpenAI, and Bedrock OpenAI providers

* **Refactor**
  * Updated authentication header generation to be configuration/credentials-driven with sensible defaults

* **Tests**
  * Expanded unit coverage for auth header generation, extraction, and auth defaulting behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->