### PR TITLE
refactor: move legacy controller to WithCustomControllers, replace sleep with Eventually

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ IPP plugins enable custom request/response mutations of both headers and body, a
 ## Pre-Requisites
 
 The target cluster must have `ExternalModel` and `ExternalProvider` CRDs deployed.  
-If you're running this deployment after `model-as-a-service`, the CRDs are already included.
-If you're running this repo as a standalone, deploy the CRDs before running the helm chart:
 
 ```bash
 kubectl apply -f config/crd/bases/

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ kubectl apply -f config/crd/bases/
     --namespace ${GATEWAY_NAMESPACE} \
     --dependency-update \
     --set upstreamIpp.inferenceGateway.name=${GATEWAY_NAME} \
+    --set upstreamIpp.provider.istio.envoyFilter.operation=INSERT_AFTER \
     --set upstreamIpp.provider.istio.envoyFilter.anchorSubFilter=extensions.istio.io/wasmplugin/${GATEWAY_NAMESPACE}.kuadrant-${GATEWAY_NAME} \
     --set upstreamIpp.payloadProcessor.env[0].name=GATEWAY_NAME \
     --set upstreamIpp.payloadProcessor.env[0].value=${GATEWAY_NAME} \

--- a/README.md
+++ b/README.md
@@ -1,22 +1,20 @@
 # AI Gateway Payload Processing
 
-This repository contains Payload Processing plugins that will be connected to an AI Gateway via a pluggable BBR (Body Based Routing) framework developed as part of the [Kubernetes Inference Gateway](https://github.com/kubernetes-sigs/gateway-api-inference-extension).
+This repository contains Payload Processing plugins that will be connected to an AI Gateway via a pluggable IPP (Inference Payload Processor) framework developed as part of [llm-d](https://github.com/llm-d/llm-d-inference-payload-processor).
 
-BBR plugins enable custom request/response mutations of both headers and body, allowing advanced capabilities such as promoting the model from a field in the body to a header and routing to a selected endpoint accordingly.
+IPP plugins enable custom request/response mutations of both headers and body, allowing advanced capabilities such as promoting the model from a field in the body to a header and routing to a selected endpoint accordingly.
 
 ## Pre-Requisites
 
-The target cluster must have `ExternalModel` CRD deployed.  
-If you're running this deployment after `model-as-a-service`, the CRD is already included.
-if you're running this repo as a standalone, you need to deploy the CRD before running the helm chart.
+The target cluster must have `ExternalModel` and `ExternalProvider` CRDs deployed.  
+If you're running this deployment after `model-as-a-service`, the CRDs are already included.
+If you're running this repo as a standalone, deploy the CRDs before running the helm chart:
+
+```bash
+kubectl apply -f config/crd/bases/
+```
 
 ## Install Payload Processing
-
-1. If ExternalModel CRD is not deployed in your cluster, deploy it using the following:
-
-    ```bash
-    kubectl apply -f https://raw.githubusercontent.com/opendatahub-io/models-as-a-service/refs/heads/main/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_externalmodels.yaml
-    ```
 
 1. Set `GATEWAY_NAME` and `GATEWAY_NAMESPACE` variables. The chart **must be
    installed in the same namespace as the Gateway** for the Istio EnvoyFilter
@@ -30,7 +28,7 @@ if you're running this repo as a standalone, you need to deploy the CRD before r
 1.  Clean local copy of upstream chart to avoid using stale version:
 
     ```bash
-    rm ./deploy/payload-processing/charts/body-based-routing-v0.tgz
+    rm -f ./deploy/payload-processing/charts/payload-processor-*.tgz
     ```
 
 1.  Install `payload-processing` helm chart:
@@ -39,13 +37,21 @@ if you're running this repo as a standalone, you need to deploy the CRD before r
     helm install payload-processing ./deploy/payload-processing \
     --namespace ${GATEWAY_NAMESPACE} \
     --dependency-update \
-    --set upstreamBbr.inferenceGateway.name=${GATEWAY_NAME} \
-    --set upstreamBbr.provider.istio.envoyFilter.anchorSubFilter=extensions.istio.io/wasmplugin/${GATEWAY_NAMESPACE}.kuadrant-${GATEWAY_NAME}
+    --set upstreamIpp.inferenceGateway.name=${GATEWAY_NAME} \
+    --set upstreamIpp.provider.istio.envoyFilter.anchorSubFilter=extensions.istio.io/wasmplugin/${GATEWAY_NAMESPACE}.kuadrant-${GATEWAY_NAME} \
+    --set upstreamIpp.payloadProcessor.env[0].name=GATEWAY_NAME \
+    --set upstreamIpp.payloadProcessor.env[0].value=${GATEWAY_NAME} \
+    --set upstreamIpp.payloadProcessor.env[1].name=GATEWAY_NAMESPACE \
+    --set upstreamIpp.payloadProcessor.env[1].value=${GATEWAY_NAMESPACE}
     ```
 
     > **Important**: The payload processing ext proc is attached to a Gateway.
     > As a mandatory requirement, `--namespace` must match the namespace where the
     > Gateway resource lives.
+
+    The `GATEWAY_NAME` and `GATEWAY_NAMESPACE` environment variables are used by
+    the controller reconcilers to set the correct parent ref on HTTPRoutes created
+    for ExternalModel CRs.
 
 ## Cleanup
 
@@ -55,8 +61,8 @@ if you're running this repo as a standalone, you need to deploy the CRD before r
     helm uninstall payload-processing --namespace ${GATEWAY_NAMESPACE}
     ```
 
-1.  Delete the ExternalModel CRD (optionally):
+1.  Delete the CRDs (optionally):
 
     ```bash
-    kubectl delete -f https://raw.githubusercontent.com/opendatahub-io/models-as-a-service/refs/heads/main/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_externalmodels.yaml
+    kubectl delete -f config/crd/bases/
     ```

--- a/cmd/controllers.go
+++ b/cmd/controllers.go
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package main
 
 import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -26,12 +27,12 @@ import (
 	inferencev1alpha1 "github.com/opendatahub-io/ai-gateway-payload-processing/api/inference/v1alpha1"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/controller/externalmodel"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/controller/externalprovider"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/controller/legacymigration"
 )
 
-// ProviderController returns a setup function that registers the ExternalProvider
+// providerController returns a setup function that registers the ExternalProvider
 // controller. It creates Service, ServiceEntry, and DestinationRule resources.
-// Does not use Owns() to avoid cluster-wide Service informers that delay startup.
-func ProviderController() func(client.Client, *ctrlbuilder.Builder) error {
+func providerController() func(client.Client, *ctrlbuilder.Builder) error {
 	return func(c client.Client, b *ctrlbuilder.Builder) error {
 		utilruntime.Must(inferencev1alpha1.AddToScheme(c.Scheme()))
 
@@ -42,10 +43,9 @@ func ProviderController() func(client.Client, *ctrlbuilder.Builder) error {
 	}
 }
 
-// ModelController returns a setup function that registers the ExternalModel
+// modelController returns a setup function that registers the ExternalModel
 // controller. It creates HTTPRoute resources with the specified gateway parent ref.
-// Does not use Owns() to avoid cluster-wide HTTPRoute informers that delay startup.
-func ModelController(gatewayName, gatewayNamespace string) func(client.Client, *ctrlbuilder.Builder) error {
+func modelController(gatewayName, gatewayNamespace string) func(client.Client, *ctrlbuilder.Builder) error {
 	return func(c client.Client, b *ctrlbuilder.Builder) error {
 		utilruntime.Must(inferencev1alpha1.AddToScheme(c.Scheme()))
 		utilruntime.Must(gatewayapiv1.Install(c.Scheme()))
@@ -63,5 +63,20 @@ func ModelController(gatewayName, gatewayNamespace string) func(client.Client, *
 			Watches(&inferencev1alpha1.ExternalProvider{},
 				handler.EnqueueRequestsFromMapFunc(reconciler.MapProviderToModels)).
 			Complete(reconciler)
+	}
+}
+
+// legacyMigrationController returns a setup function that registers the legacy
+// migration controller. It watches maas.opendatahub.io ExternalModel CRs and
+// creates corresponding inference.opendatahub.io ExternalProvider + ExternalModel CRs.
+func legacyMigrationController() func(client.Client, *ctrlbuilder.Builder) error {
+	return func(c client.Client, b *ctrlbuilder.Builder) error {
+		legacyObj := &unstructured.Unstructured{}
+		legacyObj.SetGroupVersionKind(legacymigration.LegacyExternalModelGVK)
+
+		return b.
+			For(legacyObj).
+			Named("legacy-migration").
+			Complete(&legacymigration.Reconciler{Client: c})
 	}
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,7 +28,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"github.com/llm-d/llm-d-inference-payload-processor/cmd/runner"
 
-	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/controllers"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins"
 )
 
@@ -39,11 +38,12 @@ func main() {
 	if err := runner.NewRunner().
 		WithExecutableName("ai-gateway-payload-processing").
 		WithCustomControllers(
-			controllers.ProviderController(),
-			controllers.ModelController(
+			providerController(),
+			modelController(
 				os.Getenv("GATEWAY_NAME"),
 				os.Getenv("GATEWAY_NAMESPACE"),
 			),
+			legacyMigrationController(),
 		).
 		Run(ctrl.SetupSignalHandler()); err != nil {
 		os.Exit(1)

--- a/pkg/plugins/model-provider-resolver/plugin.go
+++ b/pkg/plugins/model-provider-resolver/plugin.go
@@ -23,7 +23,6 @@ import (
 	"math/rand/v2"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -37,7 +36,6 @@ import (
 	"github.com/llm-d/llm-d-inference-payload-processor/pkg/framework/interface/plugin"
 
 	inferencev1alpha1 "github.com/opendatahub-io/ai-gateway-payload-processing/api/inference/v1alpha1"
-	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/controller/legacymigration"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/apiformat"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/state"
 )
@@ -99,16 +97,6 @@ func NewModelProviderResolver(reconcilerBuilder func() *builder.Builder, k8sClie
 		Watches(&inferencev1alpha1.ExternalProvider{}, handler.EnqueueRequestsFromMapFunc(mapProviderToModels)).
 		Complete(modelReconciler); err != nil {
 		return nil, fmt.Errorf("failed to register ExternalModel reconciler for plugin '%s' - %w", ModelProviderResolverPluginType, err)
-	}
-
-	// Legacy: watch maas.opendatahub.io ExternalModels and migrate to new CRs
-	legacyObj := &unstructured.Unstructured{}
-	legacyObj.SetGroupVersionKind(legacymigration.LegacyExternalModelGVK)
-	if err := reconcilerBuilder().
-		For(legacyObj).
-		Named("legacy-migration").
-		Complete(&legacymigration.Reconciler{Client: k8sClient}); err != nil {
-		return nil, fmt.Errorf("failed to register legacy migration reconciler for plugin '%s' - %w", ModelProviderResolverPluginType, err)
 	}
 
 	return &ModelProviderResolverPlugin{

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -89,8 +89,14 @@ spec:
 		createProviderResources(p)
 	}
 
-	ginkgo.By("Waiting for controllers to create networking resources and routes to propagate")
-	time.Sleep(20 * time.Second)
+	ginkgo.By("Waiting for controllers to create networking resources")
+	for _, p := range providers {
+		gomega.Eventually(func() bool {
+			cmd := exec.Command("kubectl", "get", "httproute", p.Name, "-n", nsName, "--no-headers")
+			return cmd.Run() == nil
+		}, 60*time.Second, 2*time.Second).Should(gomega.BeTrue(),
+			fmt.Sprintf("HTTPRoute %s not created by controller", p.Name))
+	}
 }
 
 func cleanupInfra() {


### PR DESCRIPTION
Follow-up to #310 per Nir's review:

1. **Legacy migration controller moved out of plugin** — from plugin.go to WithCustomControllers in cmd/main.go, matching the provider/model controller pattern
2. **E2E sleep replaced with Eventually** — polls for HTTPRoutes to exist instead of fixed 20s sleep

4 files, net +35 lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated docs to shift from BBR (Body Based Routing) to IPP (Inference Payload Processor)
  * Updated prerequisites to require `ExternalModel` and `ExternalProvider` CRDs
  * Revised Helm configuration to use `upstreamIpp.*` values and adjusted local packaging/cleanup steps

* **Tests**
  * Improved e2e reliability by replacing fixed waits with polling until each provider `HTTPRoute` is created

* **Bug Fixes**
  * Adjusted legacy `ExternalModel` migration handling for the relevant legacy path while keeping typed ExternalProvider/ExternalModel behavior intact
<!-- end of auto-generated comment: release notes by coderabbit.ai -->