### PR TITLE
Remove hold step for large PRs in workflow

### DIFF
--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -32,20 +32,3 @@ jobs:
               "500": "XL",
               "1000": "XXL"
             }
-
-      - name: Hold large PRs
-        if: contains(steps.size.outputs.sizeLabel, 'XL')
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr edit ${{ github.event.pull_request.number }} \
-            --repo ${{ github.repository }} \
-            --add-label "do-not-merge/hold"
-          
-          gh pr comment ${{ github.event.pull_request.number }} \
-            --repo ${{ github.repository }} \
-            --body "⚠️ **Large PR detected**
-
-          Your PR is large. Please consider breaking it into multiple PRs.
-
-          The \`do-not-merge/hold\` label has been added and can be removed by the reviewers based on their judgement."


### PR DESCRIPTION
Removed the step to hold large PRs and notify users.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined pull request automation workflow to focus exclusively on size-based labeling. Removed the automatic hold mechanisms and advisory comment features that were previously applied to extra-large pull requests. This allows larger contributions to proceed without automated workflow blocking while maintaining size classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->