### PR TITLE
fix: use oc CLI instead of kubectl in E2E container

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -33,11 +33,12 @@ RUN CGO_ENABLED=${CGO_ENABLED} GOEXPERIMENT=strictfipsruntime GOOS=${TARGETOS} G
     go test -c -o /e2e-tests.test ./test/e2e/ \
     -ldflags="-s -w"
 
-# Download FIPS-compliant kubectl from the OpenShift client tarball (rhel9, CGO+OpenSSL).
+# Download FIPS-compliant oc and kubectl from the OpenShift client tarball.
 RUN curl -sL "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OCP_VERSION}/openshift-client-linux-${TARGETARCH}-rhel9-${OCP_VERSION}.tar.gz" | \
     tar -xz -C /tmp/ oc kubectl && \
+    mv /tmp/oc /usr/local/bin/oc && \
     mv /tmp/kubectl /usr/local/bin/kubectl && \
-    chmod +x /usr/local/bin/kubectl
+    chmod +x /usr/local/bin/oc /usr/local/bin/kubectl
 
 ## Stage 2: Runtime
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8@sha256:1bc3c5c15720506a0cf48adfdf8b623dfe704377e007d7bbae8d14876392ca6a
@@ -45,6 +46,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8@sha256:1bc3c5c15720506a0cf4
 WORKDIR /e2e
 
 COPY --from=builder /e2e-tests.test /e2e/e2e-tests.test
+COPY --from=builder /usr/local/bin/oc /usr/local/bin/oc
 COPY --from=builder /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY test/e2e/scripts/entrypoint.sh /e2e/entrypoint.sh
 COPY config/crd/bases/ /e2e/crds/

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -35,6 +35,7 @@ var (
 	simulatorEP   string
 	simulatorFQDN string
 	curlTimeout   = 30 * time.Second
+	kubectlBin    = envOr("KUBECTL_BIN", "kubectl")
 )
 
 func TestE2E(t *testing.T) {
@@ -125,17 +126,17 @@ func createNamespace(name string) {
 }
 
 func kubectlApplyLiteral(yamlContent string) {
-	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd := exec.Command(kubectlBin, "apply", "-f", "-")
 	cmd.Stdin = strings.NewReader(yamlContent)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "kubectl apply failed: %s\n%s\n", err, string(out))
+		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "%s apply failed: %s\n%s\n", kubectlBin, err, string(out))
 	}
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), string(out))
 }
 
 func kubectlDeleteResource(kind, name, namespace string) {
-	cmd := exec.Command("kubectl", "delete", kind, name, "-n", namespace, "--ignore-not-found", "--timeout=30s")
+	cmd := exec.Command(kubectlBin, "delete", kind, name, "-n", namespace, "--ignore-not-found", "--timeout=30s")
 	_, _ = cmd.CombinedOutput()
 }
 

--- a/test/e2e/scripts/entrypoint.sh
+++ b/test/e2e/scripts/entrypoint.sh
@@ -33,25 +33,25 @@ if [[ ! -f "$KUBECONFIG" ]]; then
 fi
 
 echo "Verifying cluster connectivity..."
-if ! kubectl cluster-info --request-timeout=10s >/dev/null 2>&1; then
+if ! oc cluster-info --request-timeout=10s >/dev/null 2>&1; then
     echo "ERROR: Cannot connect to the cluster. Check KUBECONFIG."
     exit 1
 fi
 echo "Cluster connectivity OK."
 
 # Ensure ExternalModel CRD is installed (required for E2E tests).
-if ! kubectl get crd externalmodels.maas.opendatahub.io >/dev/null 2>&1; then
+if ! oc get crd externalmodels.maas.opendatahub.io >/dev/null 2>&1; then
     echo "ExternalModel CRD not found, installing..."
-    kubectl apply -f https://raw.githubusercontent.com/opendatahub-io/models-as-a-service/refs/heads/main/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_externalmodels.yaml
+    oc apply -f https://raw.githubusercontent.com/opendatahub-io/models-as-a-service/refs/heads/main/deployment/base/maas-controller/crd/bases/maas.opendatahub.io_externalmodels.yaml
     echo "ExternalModel CRD installed."
 else
     echo "ExternalModel CRD already installed."
 fi
 
 # Ensure inference.opendatahub.io CRDs are installed.
-if ! kubectl get crd externalproviders.inference.opendatahub.io >/dev/null 2>&1; then
+if ! oc get crd externalproviders.inference.opendatahub.io >/dev/null 2>&1; then
     echo "Installing inference.opendatahub.io CRDs..."
-    kubectl apply -f /e2e/crds/
+    oc apply -f /e2e/crds/
     echo "inference.opendatahub.io CRDs installed."
 else
     echo "inference.opendatahub.io CRDs already installed."


### PR DESCRIPTION
Supersedes #294 (clean rebase from current main).

Adds oc binary to Dockerfile.e2e. Entrypoint script uses oc for cluster operations (matches OpenShift). Go test helpers use configurable KUBECTL_BIN env var (defaults to kubectl for GH Actions CI).

3 files, +13/-10 lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenShift CLI (oc) support to end-to-end testing environment.
  * Added KUBECTL_BIN environment variable to configure kubectl binary location.

* **Improvements**
  * Enhanced test failure messages with detailed diagnostic information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->