### PR TITLE
feat: add path override for cross-cluster routing

### DIFF
--- a/api/inference/v1alpha1/externalmodel_types.go
+++ b/api/inference/v1alpha1/externalmodel_types.go
@@ -78,6 +78,16 @@ type ExternalProviderRef struct {
 	// +kubebuilder:validation:MaxLength=63
 	APIFormat string `json:"apiFormat"`
 
+	// Path sets the outgoing request `:path` pseudo-header for this model-provider binding.
+	// Must be a valid absolute path (e.g. "/v1/chat/completions" or
+	// "/maas-default-gateway/v1/chat/completions").
+	// Supports {key} placeholders resolved from the merged Config map.
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=512
+	// +kubebuilder:validation:Pattern=`^/.*`
+	Path string `json:"path"`
+
 	// Config holds model-specific configuration as key-value pairs.
 	// Overrides the ExternalProvider config for this model-provider binding.
 	// +optional

--- a/api/inference/v1alpha1/types_test.go
+++ b/api/inference/v1alpha1/types_test.go
@@ -71,6 +71,7 @@ func TestExternalModelDeepCopy(t *testing.T) {
 					Ref:         NameReference{Name: "my-openai"},
 					TargetModel: "gpt-4o",
 					APIFormat:   "openai-chat",
+					Path:        "/v1/chat/completions",
 				},
 			},
 		},

--- a/config/crd/bases/inference.opendatahub.io_externalmodels.yaml
+++ b/config/crd/bases/inference.opendatahub.io_externalmodels.yaml
@@ -105,6 +105,16 @@ spec:
                         Config holds model-specific configuration as key-value pairs.
                         Overrides the ExternalProvider config for this model-provider binding.
                       type: object
+                    path:
+                      description: |-
+                        Path sets the outgoing request `:path` pseudo-header for this model-provider binding.
+                        Must be a valid absolute path (e.g. "/v1/chat/completions" or
+                        "/maas-default-gateway/v1/chat/completions").
+                        Supports {key} placeholders resolved from the merged Config map.
+                      maxLength: 512
+                      minLength: 1
+                      pattern: ^/.*
+                      type: string
                     ref:
                       description: Ref identifies the ExternalProvider CR (must be
                         in the same namespace).
@@ -135,6 +145,7 @@ spec:
                       type: integer
                   required:
                   - apiFormat
+                  - path
                   - ref
                   - targetModel
                   type: object

--- a/deploy/samples/manifests/anthropic.yaml
+++ b/deploy/samples/manifests/anthropic.yaml
@@ -30,3 +30,4 @@ spec:
         name: anthropic
       targetModel: claude-sonnet-4-20250514
       apiFormat: messages
+      path: /v1/messages

--- a/deploy/samples/manifests/multi-provider-weights.yaml
+++ b/deploy/samples/manifests/multi-provider-weights.yaml
@@ -54,9 +54,11 @@ spec:
         name: openai
       targetModel: gpt-4o
       apiFormat: openai-chat
+      path: /v1/chat/completions
       weight: 80
     - ref:
         name: azure
       targetModel: gpt-4o
       apiFormat: openai-chat
+      path: /openai/v1/chat/completions
       weight: 20

--- a/deploy/samples/manifests/openai.yaml
+++ b/deploy/samples/manifests/openai.yaml
@@ -31,3 +31,4 @@ spec:
         name: openai
       targetModel: gpt-4o
       apiFormat: openai-chat
+      path: /v1/chat/completions

--- a/deploy/samples/manifests/vertex-openai.yaml
+++ b/deploy/samples/manifests/vertex-openai.yaml
@@ -33,5 +33,6 @@ spec:
         name: vertex-openai
       targetModel: gemini-2.5-pro
       apiFormat: openai-chat
+      path: /v1/projects/{project}/locations/{location}/endpoints/{endpoint}/chat/completions
       config:
         endpoint: openapi # Vertex AI endpoint name (not network endpoint — that's on the provider)

--- a/pkg/controller/externalmodel/reconciler_test.go
+++ b/pkg/controller/externalmodel/reconciler_test.go
@@ -150,6 +150,7 @@ func newExternalModel(name, namespace, providerName, targetModel string) *infere
 					Ref:         inferencev1alpha1.NameReference{Name: providerName},
 					TargetModel: targetModel,
 					APIFormat:   "openai",
+					Path:        "/v1/chat/completions",
 				},
 			},
 		},

--- a/pkg/controller/legacymigration/reconciler.go
+++ b/pkg/controller/legacymigration/reconciler.go
@@ -117,6 +117,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 					Ref:         inferencev1alpha1.NameReference{Name: req.Name},
 					TargetModel: targetModel,
 					APIFormat:   mapProviderToAPIFormat(providerName),
+					Path:        mapProviderToDefaultPath(providerName),
 				},
 			},
 		},
@@ -205,4 +206,17 @@ func mapProviderToAPIFormat(provider string) string {
 		return "messages"
 	}
 	return "openai-chat"
+}
+
+func mapProviderToDefaultPath(provider string) string {
+	switch provider {
+	case "anthropic":
+		return "/v1/messages"
+	case "azure", "azure-openai":
+		return "/openai/v1/chat/completions"
+	case "vertex-openai":
+		return "/v1/projects/{project}/locations/{location}/endpoints/{endpoint}/chat/completions"
+	default:
+		return "/v1/chat/completions"
+	}
 }

--- a/pkg/controller/legacymigration/reconciler_test.go
+++ b/pkg/controller/legacymigration/reconciler_test.go
@@ -318,3 +318,24 @@ func TestMapProviderToAPIFormat(t *testing.T) {
 		})
 	}
 }
+
+func TestMapProviderToDefaultPath(t *testing.T) {
+	tests := []struct {
+		provider string
+		path     string
+	}{
+		{"openai", "/v1/chat/completions"},
+		{"anthropic", "/v1/messages"},
+		{"azure", "/openai/v1/chat/completions"},
+		{"azure-openai", "/openai/v1/chat/completions"},
+		{"vertex-openai", "/v1/projects/{project}/locations/{location}/endpoints/{endpoint}/chat/completions"},
+		{"bedrock", "/v1/chat/completions"},
+		{"bedrock-openai", "/v1/chat/completions"},
+		{"unknown", "/v1/chat/completions"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.provider, func(t *testing.T) {
+			assert.Equal(t, tt.path, mapProviderToDefaultPath(tt.provider))
+		})
+	}
+}

--- a/pkg/plugins/api-translation/plugin.go
+++ b/pkg/plugins/api-translation/plugin.go
@@ -134,6 +134,14 @@ func (p *APITranslationPlugin) WithName(name string) *APITranslationPlugin {
 	return p
 }
 
+// applyPathOverride sets the :path pseudo-header from CycleState.
+// Path is a required field on ExternalProviderRef (MinLength=1), so it is always present.
+func applyPathOverride(cycleState *plugin.CycleState, request *requesthandling.InferenceRequest) {
+	if path, err := plugin.ReadCycleStateKey[string](cycleState, state.PathKey); err == nil {
+		request.SetHeader(":path", path)
+	}
+}
+
 // ProcessRequest reads the provider from CycleState (set by an upstream plugin) and translates
 // the request body from OpenAI format to the provider's native format if needed.
 // When the incoming client format matches the upstream API format (passthrough mode),
@@ -150,6 +158,7 @@ func (p *APITranslationPlugin) ProcessRequest(ctx context.Context, cycleState *p
 		logger.Info("passthrough mode — skipping request translation")
 		// Remove client auth header; apikey-injection plugin adds the provider credential downstream.
 		request.RemoveHeader("authorization")
+		applyPathOverride(cycleState, request)
 		return nil
 	}
 
@@ -183,6 +192,8 @@ func (p *APITranslationPlugin) ProcessRequest(ctx context.Context, cycleState *p
 	// authorization is a special header removed by the plugin, no matter which provider is used.
 	// The api-key is expected to be set by the the api-key injection plugin.
 	request.RemoveHeader("authorization")
+
+	applyPathOverride(cycleState, request)
 
 	// content-length is another special header that will be set automatically by the pluggable framework when the body is mutated.
 

--- a/pkg/plugins/api-translation/plugin_test.go
+++ b/pkg/plugins/api-translation/plugin_test.go
@@ -383,6 +383,28 @@ func TestFactory_Success(t *testing.T) {
 	assert.Equal(t, APITranslationPluginType, p.TypedName().Type)
 }
 
+func TestProcessRequest_OpenAIWithPathOverride(t *testing.T) {
+	p := newTestPlugin()
+
+	cs := newCycleStateWithProvider("openai")
+	cs.Write(state.PathKey, "/maas-default-gateway/v1/chat/completions")
+
+	req := requesthandling.NewInferenceRequest()
+	req.Body["model"] = "llama-4-scout"
+	req.Body["messages"] = []any{map[string]any{"role": "user", "content": "Hi"}}
+	req.Headers["authorization"] = "Bearer sk-test"
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err, "openai provider with path override must be supported without error")
+
+	mutated := req.MutatedHeaders()
+	assert.Equal(t, "/maas-default-gateway/v1/chat/completions", mutated[":path"],
+		"openai with path override should use the override path")
+
+	removed := req.RemovedHeaders()
+	assert.Contains(t, removed, "authorization")
+}
+
 func TestIsPassthrough(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -411,6 +433,53 @@ func TestIsPassthrough(t *testing.T) {
 			assert.Equal(t, tt.expected, isPassthrough(cs))
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Path override from CycleState
+// ---------------------------------------------------------------------------
+
+func TestProcessRequest_PathOverrideFromCycleState(t *testing.T) {
+	mock := &mockTranslator{
+		reqHeaders: map[string]string{":path": "/v1/chat/completions"},
+	}
+	p := newPluginWithMock("openai", mock)
+
+	cs := newCycleStateWithProvider("openai")
+	cs.Write(state.PathKey, "/maas-default-gateway/v1/chat/completions")
+
+	req := requesthandling.NewInferenceRequest()
+	req.Headers["authorization"] = "Bearer sk-test"
+	req.Body["model"] = "llama-4-scout"
+	req.Body["messages"] = []any{map[string]any{"role": "user", "content": "Hi"}}
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err)
+
+	mutated := req.MutatedHeaders()
+	assert.Equal(t, "/maas-default-gateway/v1/chat/completions", mutated[":path"],
+		"path override from CycleState must replace translator's :path")
+}
+
+func TestProcessRequest_PathOverrideInPassthrough(t *testing.T) {
+	p, _ := NewAPITranslationPlugin(context.Background(), apiTranslationConfig{})
+	cs := plugin.NewCycleState()
+	cs.Write(state.ProviderKey, "anthropic")
+	cs.Write(state.InputAPIFormatKey, apiformat.Messages)
+	cs.Write(state.APIFormatKey, apiformat.Messages)
+	cs.Write(state.PathKey, "/custom-passthrough-path")
+
+	req := requesthandling.NewInferenceRequest()
+	req.Body["model"] = "claude-opus-4-6"
+	req.Body["messages"] = []any{map[string]any{"role": "user", "content": "hi"}}
+	req.Headers["authorization"] = "Bearer sk-test"
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err)
+
+	mutated := req.MutatedHeaders()
+	assert.Equal(t, "/custom-passthrough-path", mutated[":path"],
+		"path override must apply even in passthrough mode")
 }
 
 func TestPassthrough_SkipsRequestTranslation(t *testing.T) {

--- a/pkg/plugins/common/state/state-keys.go
+++ b/pkg/plugins/common/state/state-keys.go
@@ -27,4 +27,5 @@ const (
 	AuthTypeKey       = "auth"
 	InputAPIFormatKey = "input-api-format"
 	EndpointKey       = "endpoint"
+	PathKey           = "path"
 )

--- a/pkg/plugins/model-provider-resolver/external_model_reconciler.go
+++ b/pkg/plugins/model-provider-resolver/external_model_reconciler.go
@@ -19,6 +19,7 @@ package model_provider_resolver
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -34,6 +35,18 @@ import (
 )
 
 const providerRequeueDelay = 5 * time.Second
+
+// resolvePathPlaceholders substitutes {key} placeholders in path with values
+// from the config map. Unresolved placeholders are left as-is.
+func resolvePathPlaceholders(path string, config map[string]string) string {
+	if path == "" || !strings.Contains(path, "{") {
+		return path
+	}
+	for k, v := range config {
+		path = strings.ReplaceAll(path, "{"+k+"}", v)
+	}
+	return path
+}
 
 // externalModelReconciler watches inference.opendatahub.io ExternalModel CRDs
 // and resolves provider info from the provider store.
@@ -109,12 +122,15 @@ func (r *externalModelReconciler) resolveRef(namespace string, ref *inferencev1a
 		weight = *ref.Weight
 	}
 
+	path := resolvePathPlaceholders(ref.Path, config)
+
 	return &resolvedProviderRef{
 		provider:        providerInfo.provider,
 		targetModel:     ref.TargetModel,
 		apiFormat:       apiformat.APIFormat(ref.APIFormat),
 		auth:            authType,
 		endpoint:        providerInfo.endpoint,
+		path:            path,
 		secretName:      secretName,
 		secretNamespace: secretNamespace,
 		config:          config,

--- a/pkg/plugins/model-provider-resolver/external_model_reconciler_test.go
+++ b/pkg/plugins/model-provider-resolver/external_model_reconciler_test.go
@@ -59,18 +59,19 @@ func newTestModel(name, ns string, refs ...inferencev1alpha1.ExternalProviderRef
 	}
 }
 
-func newRef(providerName, targetModel, apiFormat string) inferencev1alpha1.ExternalProviderRef {
+func newRef(providerName, targetModel, apiFormat, path string) inferencev1alpha1.ExternalProviderRef {
 	return inferencev1alpha1.ExternalProviderRef{
 		Ref:         inferencev1alpha1.NameReference{Name: providerName},
 		TargetModel: targetModel,
 		APIFormat:   apiFormat,
+		Path:        path,
 	}
 }
 
 func TestModelReconciler_HappyPath(t *testing.T) {
 	key := types.NamespacedName{Namespace: "models", Name: "gpt4"}
 	reader := &mockModelReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalModel{
-		key: newTestModel("gpt4", "models", newRef("my-openai", "gpt-4o", "openai-chat")),
+		key: newTestModel("gpt4", "models", newRef("my-openai", "gpt-4o", "openai-chat", "/v1/chat/completions")),
 	}}
 
 	store := newInfoStore()
@@ -103,7 +104,7 @@ func TestModelReconciler_HappyPath(t *testing.T) {
 
 func TestModelReconciler_ModelNameOverride(t *testing.T) {
 	key := types.NamespacedName{Namespace: "models", Name: "gpt4"}
-	model := newTestModel("gpt4", "models", newRef("my-openai", "gpt-4o", "openai-chat"))
+	model := newTestModel("gpt4", "models", newRef("my-openai", "gpt-4o", "openai-chat", "/v1/chat/completions"))
 	model.Spec.ModelName = "gpt-4o"
 
 	reader := &mockModelReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalModel{
@@ -150,7 +151,7 @@ func TestModelReconciler_DeletedCR(t *testing.T) {
 func TestModelReconciler_ProviderNotAvailable(t *testing.T) {
 	key := types.NamespacedName{Namespace: "models", Name: "orphan"}
 	reader := &mockModelReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalModel{
-		key: newTestModel("orphan", "models", newRef("missing-provider", "gpt-4o", "openai-chat")),
+		key: newTestModel("orphan", "models", newRef("missing-provider", "gpt-4o", "openai-chat", "/v1/chat/completions")),
 	}}
 
 	store := newInfoStore()
@@ -168,8 +169,8 @@ func TestModelReconciler_MultiRefAllResolved(t *testing.T) {
 	key := types.NamespacedName{Namespace: "models", Name: "multi"}
 	reader := &mockModelReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalModel{
 		key: newTestModel("multi", "models",
-			newRef("openai-provider", "gpt-4o", "openai-chat"),
-			newRef("azure-provider", "gpt-4o", "openai-chat"),
+			newRef("openai-provider", "gpt-4o", "openai-chat", "/v1/chat/completions"),
+			newRef("azure-provider", "gpt-4o", "openai-chat", "/v1/chat/completions"),
 		),
 	}}
 
@@ -201,8 +202,8 @@ func TestModelReconciler_MultiRefPartialAvailability(t *testing.T) {
 	key := types.NamespacedName{Namespace: "models", Name: "partial"}
 	reader := &mockModelReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalModel{
 		key: newTestModel("partial", "models",
-			newRef("unavailable-provider", "gpt-4o", "openai-chat"),
-			newRef("available-provider", "claude-sonnet", "messages"),
+			newRef("unavailable-provider", "gpt-4o", "openai-chat", "/v1/chat/completions"),
+			newRef("available-provider", "claude-sonnet", "messages", "/v1/messages"),
 		),
 	}}
 
@@ -226,7 +227,7 @@ func TestModelReconciler_MultiRefPartialAvailability(t *testing.T) {
 
 func TestModelReconciler_AuthOverride(t *testing.T) {
 	key := types.NamespacedName{Namespace: "models", Name: "auth-override"}
-	ref := newRef("my-openai", "gpt-4o", "openai-chat")
+	ref := newRef("my-openai", "gpt-4o", "openai-chat", "/v1/chat/completions")
 	ref.Auth = &inferencev1alpha1.AuthConfig{
 		Type:      "simple",
 		SecretRef: inferencev1alpha1.NameReference{Name: "model-specific-key"},
@@ -257,9 +258,9 @@ func TestModelReconciler_AuthOverride(t *testing.T) {
 
 func TestModelReconciler_WeightFromCRD(t *testing.T) {
 	key := types.NamespacedName{Namespace: "models", Name: "weighted"}
-	ref1 := newRef("openai-provider", "gpt-4o", "openai-chat")
+	ref1 := newRef("openai-provider", "gpt-4o", "openai-chat", "/v1/chat/completions")
 	ref1.Weight = ptr.To(80)
-	ref2 := newRef("azure-provider", "gpt-4o", "openai-chat")
+	ref2 := newRef("azure-provider", "gpt-4o", "openai-chat", "/v1/chat/completions")
 	ref2.Weight = ptr.To(20)
 
 	reader := &mockModelReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalModel{
@@ -293,7 +294,7 @@ func TestModelReconciler_WeightFromCRD(t *testing.T) {
 func TestModelReconciler_WeightDefaultsToOne(t *testing.T) {
 	key := types.NamespacedName{Namespace: "models", Name: "no-weight"}
 	reader := &mockModelReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalModel{
-		key: newTestModel("no-weight", "models", newRef("my-openai", "gpt-4o", "openai-chat")),
+		key: newTestModel("no-weight", "models", newRef("my-openai", "gpt-4o", "openai-chat", "/v1/chat/completions")),
 	}}
 
 	store := newInfoStore()
@@ -314,7 +315,7 @@ func TestModelReconciler_WeightDefaultsToOne(t *testing.T) {
 
 func TestModelReconciler_ConfigMerge(t *testing.T) {
 	key := types.NamespacedName{Namespace: "models", Name: "config-merge"}
-	ref := newRef("my-vertex", "gemini-pro", "openai-chat")
+	ref := newRef("my-vertex", "gemini-pro", "openai-chat", "/v1/chat/completions")
 	ref.Config = map[string]string{"endpoint": "custom-endpoint"}
 
 	reader := &mockModelReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalModel{
@@ -338,6 +339,83 @@ func TestModelReconciler_ConfigMerge(t *testing.T) {
 	assert.Equal(t, "my-project", info.refs[0].config["project"])
 	assert.Equal(t, "us-central1", info.refs[0].config["location"])
 	assert.Equal(t, "custom-endpoint", info.refs[0].config["endpoint"])
+}
+
+func TestModelReconciler_PathStoredFromRef(t *testing.T) {
+	key := types.NamespacedName{Namespace: "models", Name: "remote-llama"}
+	reader := &mockModelReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalModel{
+		key: newTestModel("remote-llama", "models", newRef("cluster-b", "llama-4-scout", "openai-chat", "/maas-default-gateway/v1/chat/completions")),
+	}}
+
+	store := newInfoStore()
+	store.addOrUpdateProvider(
+		types.NamespacedName{Namespace: "models", Name: "cluster-b"},
+		&providerInfo{
+			provider: "openai", endpoint: "maas.cluster-b.example.com",
+			auth:       auth.Simple,
+			secretName: "cluster-b-key", secretNamespace: "models",
+			config: map[string]string{},
+		},
+	)
+
+	r := &externalModelReconciler{Reader: reader, store: store}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+
+	info, found := store.getModel(key)
+	require.True(t, found)
+	assert.Equal(t, "/maas-default-gateway/v1/chat/completions", info.refs[0].path,
+		"resolved path should come from the model ref's required path field")
+}
+
+func TestModelReconciler_PathPlaceholderResolution(t *testing.T) {
+	key := types.NamespacedName{Namespace: "models", Name: "vertex-model"}
+	reader := &mockModelReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalModel{
+		key: newTestModel("vertex-model", "models", newRef("gcp-vertex", "gemini-pro", "openai-chat", "/v1/{project}/{location}/publishers/google/models/{model}:generateContent")),
+	}}
+
+	store := newInfoStore()
+	store.addOrUpdateProvider(
+		types.NamespacedName{Namespace: "models", Name: "gcp-vertex"},
+		&providerInfo{
+			provider: "vertex", endpoint: "us-central1-aiplatform.googleapis.com",
+			auth:       auth.Simple,
+			secretName: "vertex-key", secretNamespace: "models",
+			config: map[string]string{"project": "my-project", "location": "us-central1"},
+		},
+	)
+
+	r := &externalModelReconciler{Reader: reader, store: store}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+
+	info, found := store.getModel(key)
+	require.True(t, found)
+	assert.Equal(t, "/v1/my-project/us-central1/publishers/google/models/{model}:generateContent",
+		info.refs[0].path,
+		"placeholders present in config should be resolved; unknown placeholders stay as-is")
+}
+
+func TestResolvePathPlaceholders(t *testing.T) {
+	tests := []struct {
+		name   string
+		path   string
+		config map[string]string
+		want   string
+	}{
+		{"empty path", "", nil, ""},
+		{"no placeholders", "/v1/chat/completions", map[string]string{"k": "v"}, "/v1/chat/completions"},
+		{"single placeholder", "/v1/{project}/chat", map[string]string{"project": "my-proj"}, "/v1/my-proj/chat"},
+		{"multiple placeholders", "/{location}/{project}/models", map[string]string{"location": "us", "project": "p1"}, "/us/p1/models"},
+		{"unresolved placeholder stays", "/v1/{unknown}/chat", map[string]string{"other": "val"}, "/v1/{unknown}/chat"},
+		{"nil config", "/v1/{key}/x", nil, "/v1/{key}/x"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolvePathPlaceholders(tt.path, tt.config)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestMergeConfig(t *testing.T) {

--- a/pkg/plugins/model-provider-resolver/plugin.go
+++ b/pkg/plugins/model-provider-resolver/plugin.go
@@ -169,6 +169,7 @@ func (p *ModelProviderResolverPlugin) ProcessRequest(ctx context.Context, cycleS
 	cycleState.Write(state.APIFormatKey, ref.apiFormat)
 	cycleState.Write(state.AuthTypeKey, ref.auth)
 	cycleState.Write(state.EndpointKey, ref.endpoint)
+	cycleState.Write(state.PathKey, ref.path)
 	cycleState.Write(state.CredsRefName, ref.secretName)
 	cycleState.Write(state.CredsRefNamespace, ref.secretNamespace)
 	cycleState.Write(state.ModelConfigKey, ref.config)

--- a/pkg/plugins/model-provider-resolver/plugin_test.go
+++ b/pkg/plugins/model-provider-resolver/plugin_test.go
@@ -93,6 +93,46 @@ func TestProcessRequest_ModelResolved(t *testing.T) {
 	require.Equal(t, endpoint, actualEndpoint)
 }
 
+func TestProcessRequest_PathWrittenToCycleState(t *testing.T) {
+	store := newInfoStore()
+	const (
+		extNS       = "llm"
+		extName     = "remote-llama"
+		targetModel = "llama-4-scout"
+		credName    = "cluster-b-key"
+		endpoint    = "maas.cluster-b.example.com"
+		path        = "/maas-default-gateway/v1/chat/completions"
+	)
+	store.addOrUpdateModel(
+		types.NamespacedName{Namespace: extNS, Name: extName},
+		&externalModelInfo{modelName: extName, refs: []*resolvedProviderRef{{
+			provider:        provider.OpenAI,
+			targetModel:     targetModel,
+			apiFormat:       apiformat.OpenAIChatCompletions,
+			auth:            auth.Simple,
+			endpoint:        endpoint,
+			path:            path,
+			secretName:      credName,
+			secretNamespace: extNS,
+			config:          map[string]string{},
+			weight:          1,
+		}}},
+	)
+
+	instance := &ModelProviderResolverPlugin{store: store}
+	cs := plugin.NewCycleState()
+	req := requesthandling.NewInferenceRequest()
+	req.Headers[":path"] = "/" + extNS + "/" + extName + "/v1/chat/completions"
+	req.Body["model"] = extName
+
+	err := instance.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err)
+
+	actualPath, err := plugin.ReadCycleStateKey[string](cs, state.PathKey)
+	require.NoError(t, err)
+	require.Equal(t, path, actualPath)
+}
+
 func TestProcessRequest_ModelMismatch(t *testing.T) {
 	store := newInfoStore()
 	store.addOrUpdateModel(

--- a/pkg/plugins/model-provider-resolver/store.go
+++ b/pkg/plugins/model-provider-resolver/store.go
@@ -41,6 +41,7 @@ type resolvedProviderRef struct {
 	apiFormat       apiformat.APIFormat
 	auth            auth.Auth
 	endpoint        string
+	path            string // outgoing :path from ExternalProviderRef (required field)
 	secretName      string
 	secretNamespace string
 	config          map[string]string

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -85,7 +85,21 @@ spec:
         name: %s
       targetModel: %s
       apiFormat: %s
-`, p.Name, nsName, p.Name, p.Name, p.Provider))
+      path: %s
+`, p.Name, nsName, p.Name, p.Name, p.Provider, defaultPathForProvider(p.Provider)))
+}
+
+func defaultPathForProvider(provider string) string {
+	switch provider {
+	case "anthropic":
+		return "/v1/messages"
+	case "azure-openai":
+		return "/openai/v1/chat/completions"
+	case "vertex-openai":
+		return "/v1/projects/test-project/locations/us-central1/endpoints/openapi/chat/completions"
+	default:
+		return "/v1/chat/completions"
+	}
 }
 
 func deleteProviderResources(p Provider) {


### PR DESCRIPTION
## Summary

Adds a **required** `path` field to `ExternalProviderRef` (within `ExternalModel`) that sets the outgoing request `:path` pseudo-header, enabling cross-cluster routing to a remote MaaS gateway.

- Adds required `path` field (`string`) to `ExternalProviderRef` with `MinLength=1`, `MaxLength=512`, pattern `^/.*` validation
- Path supports `{key}` placeholders resolved from the merged provider/model `Config` map (e.g. `/v1/{project}/{location}/chat/completions`)
- Propagates resolved path through `CycleState` → `PathKey`
- `api-translation` plugin reads `PathKey` and sets `:path` header (both translate and passthrough branches)

## Design

```
ExternalModel.spec.externalProviderRefs[].path (required)
  ↓ placeholders resolved from merged Config map
  ↓ stored by
model-provider-resolver → CycleState["path"]
  ↓ consumed by
api-translation → request.SetHeader(":path", path)
```

Path is required on ExternalModel (not on ExternalProvider) to align with the architectural direction where API translation is based on input/output format rather than provider type — making provider-level path assumptions invalid.

## Test Plan

- [x] Unit tests: model reconciler resolves path (placeholder resolution), CycleState propagation, header override in api-translation (translate + passthrough branches)
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] All existing tests pass (no regressions)
- [x] CRD validation: missing path rejected by API server (`Required value`)
- [x] E2E: Kind cluster + Istio + BBR deployed with full plugin chain, CRDs accepted

Closes #342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now configure a request path for external model bindings, including support for provider-specific paths and placeholder values.
  * Sample manifests were updated to show path-based routing for common providers.

* **Bug Fixes**
  * Requests now use the configured path consistently during model translation and passthrough flows.
  * Legacy migrations now preserve or infer appropriate default paths for existing provider setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->