### PR TITLE
feat: add routing loop detection for cross-cluster requests

### DIFF
--- a/api/inference/v1alpha1/externalmodel_types.go
+++ b/api/inference/v1alpha1/externalmodel_types.go
@@ -78,6 +78,13 @@ type ExternalProviderRef struct {
 	// +kubebuilder:validation:MaxLength=63
 	APIFormat string `json:"apiFormat"`
 
+	// Path overrides the ExternalProvider's path for this model-provider binding.
+	// When set, takes precedence over the provider-level path.
+	// +optional
+	// +kubebuilder:validation:MaxLength=512
+	// +kubebuilder:validation:Pattern=`^/.*`
+	Path string `json:"path,omitempty"`
+
 	// Config holds model-specific configuration as key-value pairs.
 	// Overrides the ExternalProvider config for this model-provider binding.
 	// +optional

--- a/api/inference/v1alpha1/externalprovider_types.go
+++ b/api/inference/v1alpha1/externalprovider_types.go
@@ -58,6 +58,15 @@ type ExternalProviderSpec struct {
 	// +kubebuilder:validation:Required
 	Auth AuthConfig `json:"auth"`
 
+	// Path overrides the outgoing request path for this provider.
+	// When set, the `:path` pseudo-header is set to this value instead of
+	// the translator's default. Must be a valid absolute path.
+	// e.g. "/maas-default-gateway/v1/chat/completions".
+	// +optional
+	// +kubebuilder:validation:MaxLength=512
+	// +kubebuilder:validation:Pattern=`^/.*`
+	Path string `json:"path,omitempty"`
+
 	// Config holds provider-specific configuration as key-value pairs.
 	// e.g., Vertex AI: {"project": "my-project", "location": "us-central1"}.
 	// +optional

--- a/config/crd/bases/inference.opendatahub.io_externalmodels.yaml
+++ b/config/crd/bases/inference.opendatahub.io_externalmodels.yaml
@@ -105,6 +105,13 @@ spec:
                         Config holds model-specific configuration as key-value pairs.
                         Overrides the ExternalProvider config for this model-provider binding.
                       type: object
+                    path:
+                      description: |-
+                        Path overrides the ExternalProvider's path for this model-provider binding.
+                        When set, takes precedence over the provider-level path.
+                      maxLength: 512
+                      pattern: ^/.*
+                      type: string
                     ref:
                       description: Ref identifies the ExternalProvider CR (must be
                         in the same namespace).

--- a/config/crd/bases/inference.opendatahub.io_externalproviders.yaml
+++ b/config/crd/bases/inference.opendatahub.io_externalproviders.yaml
@@ -99,6 +99,15 @@ spec:
                 minLength: 1
                 pattern: ^[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?)+$
                 type: string
+              path:
+                description: |-
+                  Path overrides the outgoing request path for this provider.
+                  When set, the `:path` pseudo-header is set to this value instead of
+                  the translator's default. Must be a valid absolute path.
+                  e.g. "/maas-default-gateway/v1/chat/completions".
+                maxLength: 512
+                pattern: ^/.*
+                type: string
               provider:
                 description: |-
                   Provider identifies the API type for this provider.

--- a/pkg/plugins/api-translation/plugin.go
+++ b/pkg/plugins/api-translation/plugin.go
@@ -87,6 +87,7 @@ func NewAPITranslationPlugin(ctx context.Context, config apiTranslationConfig) (
 		provider.Anthropic:     anthropic.NewAnthropicTranslator(),
 		provider.AzureOpenAI:   azure.NewAzureOpenAITranslator(),
 		provider.BedrockOpenAI: bedrock.NewBedrockOpenAITranslator(),
+		provider.RemoteMaaS:    openai.NewOpenAITranslator(),
 	}
 
 	if config.VertexOpenAI != nil {
@@ -150,6 +151,10 @@ func (p *APITranslationPlugin) ProcessRequest(ctx context.Context, cycleState *p
 		logger.Info("passthrough mode — skipping request translation")
 		// Remove client auth header; apikey-injection plugin adds the provider credential downstream.
 		request.RemoveHeader("authorization")
+		// Override :path if a custom path is configured in CycleState (cross-cluster routing).
+		if pathOverride, err := plugin.ReadCycleStateKey[string](cycleState, state.PathKey); err == nil && pathOverride != "" {
+			request.SetHeader(":path", pathOverride)
+		}
 		return nil
 	}
 
@@ -183,6 +188,11 @@ func (p *APITranslationPlugin) ProcessRequest(ctx context.Context, cycleState *p
 	// authorization is a special header removed by the plugin, no matter which provider is used.
 	// The api-key is expected to be set by the the api-key injection plugin.
 	request.RemoveHeader("authorization")
+
+	// Override :path if a custom path is configured in CycleState (cross-cluster routing).
+	if pathOverride, err := plugin.ReadCycleStateKey[string](cycleState, state.PathKey); err == nil && pathOverride != "" {
+		request.SetHeader(":path", pathOverride)
+	}
 
 	// content-length is another special header that will be set automatically by the pluggable framework when the body is mutated.
 

--- a/pkg/plugins/api-translation/plugin_test.go
+++ b/pkg/plugins/api-translation/plugin_test.go
@@ -383,6 +383,28 @@ func TestFactory_Success(t *testing.T) {
 	assert.Equal(t, APITranslationPluginType, p.TypedName().Type)
 }
 
+func TestProcessRequest_RemoteMaaSProvider(t *testing.T) {
+	p := newTestPlugin()
+
+	cs := newCycleStateWithProvider("remote-maas")
+	cs.Write(state.PathKey, "/maas-default-gateway/v1/chat/completions")
+
+	req := requesthandling.NewInferenceRequest()
+	req.Body["model"] = "llama-4-scout"
+	req.Body["messages"] = []any{map[string]any{"role": "user", "content": "Hi"}}
+	req.Headers["authorization"] = "Bearer sk-test"
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err, "remote-maas provider must be supported without error")
+
+	mutated := req.MutatedHeaders()
+	assert.Equal(t, "/maas-default-gateway/v1/chat/completions", mutated[":path"],
+		"remote-maas with path override should use the override path")
+
+	removed := req.RemovedHeaders()
+	assert.Contains(t, removed, "authorization")
+}
+
 func TestIsPassthrough(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -411,6 +433,75 @@ func TestIsPassthrough(t *testing.T) {
 			assert.Equal(t, tt.expected, isPassthrough(cs))
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Path override from CycleState
+// ---------------------------------------------------------------------------
+
+func TestProcessRequest_PathOverrideFromCycleState(t *testing.T) {
+	mock := &mockTranslator{
+		reqHeaders: map[string]string{":path": "/v1/chat/completions"},
+	}
+	p := newPluginWithMock("remote-maas", mock)
+
+	cs := newCycleStateWithProvider("remote-maas")
+	cs.Write(state.PathKey, "/maas-default-gateway/v1/chat/completions")
+
+	req := requesthandling.NewInferenceRequest()
+	req.Headers["authorization"] = "Bearer sk-test"
+	req.Body["model"] = "llama-4-scout"
+	req.Body["messages"] = []any{map[string]any{"role": "user", "content": "Hi"}}
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err)
+
+	mutated := req.MutatedHeaders()
+	assert.Equal(t, "/maas-default-gateway/v1/chat/completions", mutated[":path"],
+		"path override from CycleState must replace translator's :path")
+}
+
+func TestProcessRequest_NoPathOverride_KeepsTranslatorDefault(t *testing.T) {
+	mock := &mockTranslator{
+		reqHeaders: map[string]string{":path": "/v1/chat/completions"},
+	}
+	p := newPluginWithMock("openai", mock)
+
+	cs := newCycleStateWithProvider("openai")
+	cs.Write(state.PathKey, "")
+
+	req := requesthandling.NewInferenceRequest()
+	req.Headers["authorization"] = "Bearer sk-test"
+	req.Body["model"] = "gpt-4o"
+	req.Body["messages"] = []any{map[string]any{"role": "user", "content": "Hi"}}
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err)
+
+	mutated := req.MutatedHeaders()
+	assert.Equal(t, "/v1/chat/completions", mutated[":path"],
+		"empty PathKey means translator's default :path is kept")
+}
+
+func TestProcessRequest_PathOverrideInPassthrough(t *testing.T) {
+	p, _ := NewAPITranslationPlugin(context.Background(), apiTranslationConfig{})
+	cs := plugin.NewCycleState()
+	cs.Write(state.ProviderKey, "anthropic")
+	cs.Write(state.InputAPIFormatKey, apiformat.Messages)
+	cs.Write(state.APIFormatKey, apiformat.Messages)
+	cs.Write(state.PathKey, "/custom-passthrough-path")
+
+	req := requesthandling.NewInferenceRequest()
+	req.Body["model"] = "claude-opus-4-6"
+	req.Body["messages"] = []any{map[string]any{"role": "user", "content": "hi"}}
+	req.Headers["authorization"] = "Bearer sk-test"
+
+	err := p.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err)
+
+	mutated := req.MutatedHeaders()
+	assert.Equal(t, "/custom-passthrough-path", mutated[":path"],
+		"path override must apply even in passthrough mode")
 }
 
 func TestPassthrough_SkipsRequestTranslation(t *testing.T) {

--- a/pkg/plugins/common/provider/provider.go
+++ b/pkg/plugins/common/provider/provider.go
@@ -26,4 +26,6 @@ const (
 	AzureOpenAI   = "azure-openai"
 	VertexOpenAI  = "vertex-openai"
 	BedrockOpenAI = "bedrock-openai"
+
+	RemoteMaaS = "remote-maas"
 )

--- a/pkg/plugins/common/state/state-keys.go
+++ b/pkg/plugins/common/state/state-keys.go
@@ -27,4 +27,5 @@ const (
 	AuthTypeKey       = "auth"
 	InputAPIFormatKey = "input-api-format"
 	EndpointKey       = "endpoint"
+	PathKey           = "path"
 )

--- a/pkg/plugins/model-provider-resolver/external_model_reconciler.go
+++ b/pkg/plugins/model-provider-resolver/external_model_reconciler.go
@@ -109,12 +109,18 @@ func (r *externalModelReconciler) resolveRef(namespace string, ref *inferencev1a
 		weight = *ref.Weight
 	}
 
+	path := providerInfo.path
+	if ref.Path != "" {
+		path = ref.Path
+	}
+
 	return &resolvedProviderRef{
 		provider:        providerInfo.provider,
 		targetModel:     ref.TargetModel,
 		apiFormat:       apiformat.APIFormat(ref.APIFormat),
 		auth:            authType,
 		endpoint:        providerInfo.endpoint,
+		path:            path,
 		secretName:      secretName,
 		secretNamespace: secretNamespace,
 		config:          config,

--- a/pkg/plugins/model-provider-resolver/external_model_reconciler_test.go
+++ b/pkg/plugins/model-provider-resolver/external_model_reconciler_test.go
@@ -340,6 +340,92 @@ func TestModelReconciler_ConfigMerge(t *testing.T) {
 	assert.Equal(t, "custom-endpoint", info.refs[0].config["endpoint"])
 }
 
+func TestModelReconciler_PathFromProvider(t *testing.T) {
+	key := types.NamespacedName{Namespace: "models", Name: "remote-llama"}
+	reader := &mockModelReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalModel{
+		key: newTestModel("remote-llama", "models", newRef("cluster-b", "llama-4-scout", "openai-chat")),
+	}}
+
+	store := newInfoStore()
+	store.addOrUpdateProvider(
+		types.NamespacedName{Namespace: "models", Name: "cluster-b"},
+		&providerInfo{
+			provider: "remote-maas", endpoint: "maas.cluster-b.example.com",
+			path:       "/maas-default-gateway/v1/chat/completions",
+			auth:       auth.Simple,
+			secretName: "cluster-b-key", secretNamespace: "models",
+			config: map[string]string{},
+		},
+	)
+
+	r := &externalModelReconciler{Reader: reader, store: store}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+
+	info, found := store.getModel(key)
+	require.True(t, found)
+	assert.Equal(t, "/maas-default-gateway/v1/chat/completions", info.refs[0].path,
+		"resolved path should come from provider when model ref has no path")
+}
+
+func TestModelReconciler_PathModelOverridesProvider(t *testing.T) {
+	key := types.NamespacedName{Namespace: "models", Name: "remote-llama"}
+	ref := newRef("cluster-b", "llama-4-scout", "openai-chat")
+	ref.Path = "/custom-model-path/v1/chat/completions"
+
+	reader := &mockModelReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalModel{
+		key: newTestModel("remote-llama", "models", ref),
+	}}
+
+	store := newInfoStore()
+	store.addOrUpdateProvider(
+		types.NamespacedName{Namespace: "models", Name: "cluster-b"},
+		&providerInfo{
+			provider: "remote-maas", endpoint: "maas.cluster-b.example.com",
+			path:       "/maas-default-gateway/v1/chat/completions",
+			auth:       auth.Simple,
+			secretName: "cluster-b-key", secretNamespace: "models",
+			config: map[string]string{},
+		},
+	)
+
+	r := &externalModelReconciler{Reader: reader, store: store}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+
+	info, found := store.getModel(key)
+	require.True(t, found)
+	assert.Equal(t, "/custom-model-path/v1/chat/completions", info.refs[0].path,
+		"model-level path must override provider-level path")
+}
+
+func TestModelReconciler_PathBothEmpty(t *testing.T) {
+	key := types.NamespacedName{Namespace: "models", Name: "gpt4"}
+	reader := &mockModelReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalModel{
+		key: newTestModel("gpt4", "models", newRef("my-openai", "gpt-4o", "openai-chat")),
+	}}
+
+	store := newInfoStore()
+	store.addOrUpdateProvider(
+		types.NamespacedName{Namespace: "models", Name: "my-openai"},
+		&providerInfo{
+			provider: "openai", endpoint: "api.openai.com",
+			auth:       auth.Simple,
+			secretName: "openai-key", secretNamespace: "models",
+			config: map[string]string{},
+		},
+	)
+
+	r := &externalModelReconciler{Reader: reader, store: store}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+
+	info, found := store.getModel(key)
+	require.True(t, found)
+	assert.Equal(t, "", info.refs[0].path,
+		"path should be empty when neither provider nor model sets it")
+}
+
 func TestMergeConfig(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/plugins/model-provider-resolver/external_provider_reconciler.go
+++ b/pkg/plugins/model-provider-resolver/external_provider_reconciler.go
@@ -67,6 +67,7 @@ func (r *externalProviderReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	r.store.addOrUpdateProvider(req.NamespacedName, &providerInfo{
 		provider:        provider.Spec.Provider,
 		endpoint:        provider.Spec.Endpoint,
+		path:            provider.Spec.Path,
 		auth:            auth.Auth(provider.Spec.Auth.Type),
 		secretName:      provider.Spec.Auth.SecretRef.Name,
 		secretNamespace: req.Namespace,

--- a/pkg/plugins/model-provider-resolver/external_provider_reconciler_test.go
+++ b/pkg/plugins/model-provider-resolver/external_provider_reconciler_test.go
@@ -100,6 +100,60 @@ func TestProviderReconciler_DeletedCR(t *testing.T) {
 	assert.False(t, found, "store entry should be removed on delete")
 }
 
+func TestProviderReconciler_WithPath(t *testing.T) {
+	key := types.NamespacedName{Namespace: "models", Name: "cluster-b"}
+	reader := &mockProviderReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalProvider{
+		key: {
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-b", Namespace: "models"},
+			Spec: inferencev1alpha1.ExternalProviderSpec{
+				Provider: "remote-maas",
+				Endpoint: "maas.cluster-b.example.com",
+				Path:     "/maas-default-gateway/v1/chat/completions",
+				Auth: inferencev1alpha1.AuthConfig{
+					Type:      "simple",
+					SecretRef: inferencev1alpha1.NameReference{Name: "cluster-b-key"}},
+			},
+		},
+	}}
+	store := newInfoStore()
+	r := &externalProviderReconciler{Reader: reader, store: store}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	info, found := store.getProvider(key)
+	require.True(t, found)
+	assert.Equal(t, "remote-maas", info.provider)
+	assert.Equal(t, "maas.cluster-b.example.com", info.endpoint)
+	assert.Equal(t, "/maas-default-gateway/v1/chat/completions", info.path)
+}
+
+func TestProviderReconciler_EmptyPath(t *testing.T) {
+	key := types.NamespacedName{Namespace: "models", Name: "my-openai"}
+	reader := &mockProviderReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalProvider{
+		key: {
+			ObjectMeta: metav1.ObjectMeta{Name: "my-openai", Namespace: "models"},
+			Spec: inferencev1alpha1.ExternalProviderSpec{
+				Provider: "openai",
+				Endpoint: "api.openai.com",
+				Auth: inferencev1alpha1.AuthConfig{
+					Type:      "simple",
+					SecretRef: inferencev1alpha1.NameReference{Name: "openai-key"}},
+			},
+		},
+	}}
+	store := newInfoStore()
+	r := &externalProviderReconciler{Reader: reader, store: store}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+
+	info, found := store.getProvider(key)
+	require.True(t, found)
+	assert.Equal(t, "", info.path, "path should be empty when not set")
+}
+
 func TestProviderReconciler_WithConfig(t *testing.T) {
 	key := types.NamespacedName{Namespace: "models", Name: "my-vertex"}
 	reader := &mockProviderReader{objects: map[types.NamespacedName]*inferencev1alpha1.ExternalProvider{

--- a/pkg/plugins/model-provider-resolver/plugin.go
+++ b/pkg/plugins/model-provider-resolver/plugin.go
@@ -169,6 +169,7 @@ func (p *ModelProviderResolverPlugin) ProcessRequest(ctx context.Context, cycleS
 	cycleState.Write(state.APIFormatKey, ref.apiFormat)
 	cycleState.Write(state.AuthTypeKey, ref.auth)
 	cycleState.Write(state.EndpointKey, ref.endpoint)
+	cycleState.Write(state.PathKey, ref.path)
 	cycleState.Write(state.CredsRefName, ref.secretName)
 	cycleState.Write(state.CredsRefNamespace, ref.secretNamespace)
 	cycleState.Write(state.ModelConfigKey, ref.config)

--- a/pkg/plugins/model-provider-resolver/plugin.go
+++ b/pkg/plugins/model-provider-resolver/plugin.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand/v2"
+	"os"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -37,11 +38,20 @@ import (
 
 	inferencev1alpha1 "github.com/opendatahub-io/ai-gateway-payload-processing/api/inference/v1alpha1"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/apiformat"
+	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/provider"
 	"github.com/opendatahub-io/ai-gateway-payload-processing/pkg/plugins/common/state"
 )
 
 const (
 	ModelProviderResolverPluginType = "model-provider-resolver"
+
+	// OriginClusterHeader is injected into outgoing cross-cluster requests and
+	// checked on incoming requests to detect routing loops (A → B → A).
+	OriginClusterHeader = "x-origin-cluster"
+
+	// ClusterNameEnvVar is the environment variable that provides this cluster's
+	// identity for loop detection. When unset, loop detection is disabled.
+	ClusterNameEnvVar = "CLUSTER_NAME"
 )
 
 var _ requesthandling.RequestProcessor = &ModelProviderResolverPlugin{}
@@ -99,18 +109,26 @@ func NewModelProviderResolver(reconcilerBuilder func() *builder.Builder, k8sClie
 		return nil, fmt.Errorf("failed to register ExternalModel reconciler for plugin '%s' - %w", ModelProviderResolverPluginType, err)
 	}
 
+	clusterName := os.Getenv(ClusterNameEnvVar)
+
 	return &ModelProviderResolverPlugin{
-		typedName: plugin.TypedName{Type: ModelProviderResolverPluginType, Name: ModelProviderResolverPluginType},
-		store:     store,
+		typedName:   plugin.TypedName{Type: ModelProviderResolverPluginType, Name: ModelProviderResolverPluginType},
+		store:       store,
+		clusterName: clusterName,
 	}, nil
 }
 
 // ModelProviderResolverPlugin resolves model names to provider info by watching ExternalModel CRDs.
 // It writes the model, provider and credential reference to CycleState for downstream plugins
 // (api-translation, api-key-injection).
+//
+// When clusterName is set (via CLUSTER_NAME env var), the plugin also performs routing loop
+// detection for cross-cluster requests: it rejects incoming requests whose X-Origin-Cluster
+// header matches this cluster, and injects the header on outgoing remote-maas requests.
 type ModelProviderResolverPlugin struct {
-	typedName plugin.TypedName
-	store     *infoStore
+	typedName   plugin.TypedName
+	store       *infoStore
+	clusterName string
 }
 
 // TypedName returns the type and name tuple of this plugin instance.
@@ -125,8 +143,17 @@ func (p *ModelProviderResolverPlugin) WithName(name string) *ModelProviderResolv
 // ProcessRequest reads the model name from the request body, resolves the provider
 // from the store (populated by ExternalModel reconciler), and writes model, provider
 // and credential reference info to CycleState.
+//
+// When clusterName is configured, the method also:
+//   - Rejects incoming requests whose X-Origin-Cluster header matches this cluster
+//     (routing loop detection).
+//   - Injects X-Origin-Cluster on outgoing requests routed to a remote-maas provider.
 func (p *ModelProviderResolverPlugin) ProcessRequest(ctx context.Context, cycleState *plugin.CycleState, request *requesthandling.InferenceRequest) error {
 	logger := log.FromContext(ctx).V(logutil.DEFAULT)
+
+	if err := p.checkRoutingLoop(ctx, request); err != nil {
+		return err
+	}
 
 	model, ok := request.Body["model"].(string)
 	if !ok || model == "" {
@@ -175,8 +202,52 @@ func (p *ModelProviderResolverPlugin) ProcessRequest(ctx context.Context, cycleS
 	cycleState.Write(state.ModelConfigKey, ref.config)
 	cycleState.Write(state.InputAPIFormatKey, inputFormat)
 
+	p.injectOriginCluster(ctx, request, ref.provider)
+
 	logger.Info("external model resolved", "model", modelKey.String(), "provider", ref.provider, "inputFormat", inputFormat, "apiFormat", ref.apiFormat)
 	return nil
+}
+
+// checkRoutingLoop detects cross-cluster routing loops by comparing the incoming
+// X-Origin-Cluster header against this cluster's identity. Returns an error if
+// the request originated from this cluster (A → B → A loop).
+// When clusterName is empty (CLUSTER_NAME not set), the check is skipped.
+func (p *ModelProviderResolverPlugin) checkRoutingLoop(ctx context.Context, request *requesthandling.InferenceRequest) error {
+	if p.clusterName == "" {
+		return nil
+	}
+
+	origin := request.Headers[OriginClusterHeader]
+	if origin == "" {
+		return nil
+	}
+
+	if origin == p.clusterName {
+		log.FromContext(ctx).V(logutil.DEFAULT).Error(nil, "routing loop detected",
+			"originCluster", origin, "thisCluster", p.clusterName)
+		return errcommon.Error{
+			Code: errcommon.Forbidden,
+			Msg:  fmt.Sprintf("routing loop detected: request originated from this cluster (%s)", p.clusterName),
+		}
+	}
+
+	log.FromContext(ctx).V(logutil.VERBOSE).Info("cross-cluster request accepted",
+		"originCluster", origin, "thisCluster", p.clusterName)
+	return nil
+}
+
+// injectOriginCluster adds the X-Origin-Cluster header to outgoing requests
+// routed to a remote-maas provider. This allows the receiving cluster to
+// detect routing loops.
+// When clusterName is empty or the provider is not remote-maas, no header is injected.
+func (p *ModelProviderResolverPlugin) injectOriginCluster(ctx context.Context, request *requesthandling.InferenceRequest, resolvedProvider string) {
+	if p.clusterName == "" || resolvedProvider != provider.RemoteMaaS {
+		return
+	}
+
+	request.SetHeader(OriginClusterHeader, p.clusterName)
+	log.FromContext(ctx).V(logutil.VERBOSE).Info("injected origin cluster header for cross-cluster request",
+		"header", OriginClusterHeader, "cluster", p.clusterName)
 }
 
 // detectInputAPIFormat determines the client's API format from the request path suffix.

--- a/pkg/plugins/model-provider-resolver/plugin_test.go
+++ b/pkg/plugins/model-provider-resolver/plugin_test.go
@@ -356,6 +356,179 @@ func TestProcessRequest_UnsupportedPath(t *testing.T) {
 	require.Contains(t, err.Error(), "unsupported API path")
 }
 
+// --- Loop detection tests ---
+
+func TestProcessRequest_LoopDetected_SameCluster(t *testing.T) {
+	store := newInfoStore()
+	instance := &ModelProviderResolverPlugin{store: store, clusterName: "cluster-a"}
+
+	cs := plugin.NewCycleState()
+	req := requesthandling.NewInferenceRequest()
+	req.Headers[":path"] = "/llm/model/v1/chat/completions"
+	req.Headers[OriginClusterHeader] = "cluster-a"
+	req.Body["model"] = "model"
+
+	err := instance.ProcessRequest(context.Background(), cs, req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "routing loop detected")
+}
+
+func TestProcessRequest_CrossCluster_DifferentOrigin(t *testing.T) {
+	store := newInfoStore()
+	store.addOrUpdateModel(
+		types.NamespacedName{Namespace: "llm", Name: "remote-llama"},
+		&externalModelInfo{modelName: "remote-llama", refs: []*resolvedProviderRef{{
+			provider: provider.RemoteMaaS, targetModel: "llama-4-scout",
+			apiFormat: apiformat.OpenAIChatCompletions, auth: auth.Simple,
+			endpoint: "maas.cluster-b.example.com", path: "/maas/v1/chat/completions",
+			secretName: "key", secretNamespace: "llm",
+			config: map[string]string{}, weight: 1,
+		}}},
+	)
+
+	instance := &ModelProviderResolverPlugin{store: store, clusterName: "cluster-b"}
+	cs := plugin.NewCycleState()
+	req := requesthandling.NewInferenceRequest()
+	req.Headers[":path"] = "/llm/remote-llama/v1/chat/completions"
+	req.Headers[OriginClusterHeader] = "cluster-a"
+	req.Body["model"] = "remote-llama"
+
+	err := instance.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err, "different origin cluster should be allowed")
+
+	actualProvider, err := plugin.ReadCycleStateKey[string](cs, state.ProviderKey)
+	require.NoError(t, err)
+	require.Equal(t, provider.RemoteMaaS, actualProvider)
+}
+
+func TestProcessRequest_NoOriginHeader_Passes(t *testing.T) {
+	store := newInfoStore()
+	store.addOrUpdateModel(
+		types.NamespacedName{Namespace: "llm", Name: "gpt4"},
+		&externalModelInfo{modelName: "gpt4", refs: []*resolvedProviderRef{{
+			provider: provider.OpenAI, targetModel: "gpt-4o",
+			apiFormat: apiformat.OpenAIChatCompletions, auth: auth.Simple,
+			endpoint: "api.openai.com",
+			secretName: "key", secretNamespace: "llm",
+			config: map[string]string{}, weight: 1,
+		}}},
+	)
+
+	instance := &ModelProviderResolverPlugin{store: store, clusterName: "cluster-a"}
+	cs := plugin.NewCycleState()
+	req := requesthandling.NewInferenceRequest()
+	req.Headers[":path"] = "/llm/gpt4/v1/chat/completions"
+	req.Body["model"] = "gpt4"
+
+	err := instance.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err, "request without origin header should pass")
+
+	actualProvider, err := plugin.ReadCycleStateKey[string](cs, state.ProviderKey)
+	require.NoError(t, err)
+	require.Equal(t, provider.OpenAI, actualProvider)
+}
+
+func TestProcessRequest_RemoteMaaS_InjectsOriginHeader(t *testing.T) {
+	store := newInfoStore()
+	store.addOrUpdateModel(
+		types.NamespacedName{Namespace: "llm", Name: "remote-llama"},
+		&externalModelInfo{modelName: "remote-llama", refs: []*resolvedProviderRef{{
+			provider: provider.RemoteMaaS, targetModel: "llama-4-scout",
+			apiFormat: apiformat.OpenAIChatCompletions, auth: auth.Simple,
+			endpoint: "maas.cluster-b.example.com", path: "/maas/v1/chat/completions",
+			secretName: "key", secretNamespace: "llm",
+			config: map[string]string{}, weight: 1,
+		}}},
+	)
+
+	instance := &ModelProviderResolverPlugin{store: store, clusterName: "cluster-a"}
+	cs := plugin.NewCycleState()
+	req := requesthandling.NewInferenceRequest()
+	req.Headers[":path"] = "/llm/remote-llama/v1/chat/completions"
+	req.Body["model"] = "remote-llama"
+
+	err := instance.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err)
+
+	mutated := req.MutatedHeaders()
+	require.Equal(t, "cluster-a", mutated[OriginClusterHeader],
+		"outgoing remote-maas request should have x-origin-cluster header")
+}
+
+func TestProcessRequest_LocalProvider_NoOriginHeaderInjected(t *testing.T) {
+	store := newInfoStore()
+	store.addOrUpdateModel(
+		types.NamespacedName{Namespace: "llm", Name: "gpt4"},
+		&externalModelInfo{modelName: "gpt4", refs: []*resolvedProviderRef{{
+			provider: provider.OpenAI, targetModel: "gpt-4o",
+			apiFormat: apiformat.OpenAIChatCompletions, auth: auth.Simple,
+			endpoint: "api.openai.com",
+			secretName: "key", secretNamespace: "llm",
+			config: map[string]string{}, weight: 1,
+		}}},
+	)
+
+	instance := &ModelProviderResolverPlugin{store: store, clusterName: "cluster-a"}
+	cs := plugin.NewCycleState()
+	req := requesthandling.NewInferenceRequest()
+	req.Headers[":path"] = "/llm/gpt4/v1/chat/completions"
+	req.Body["model"] = "gpt4"
+
+	err := instance.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err)
+
+	mutated := req.MutatedHeaders()
+	_, hasOrigin := mutated[OriginClusterHeader]
+	require.False(t, hasOrigin,
+		"non-remote-maas providers should not get x-origin-cluster header")
+}
+
+func TestProcessRequest_ClusterNameEmpty_LoopDetectionDisabled(t *testing.T) {
+	store := newInfoStore()
+	store.addOrUpdateModel(
+		types.NamespacedName{Namespace: "llm", Name: "remote-llama"},
+		&externalModelInfo{modelName: "remote-llama", refs: []*resolvedProviderRef{{
+			provider: provider.RemoteMaaS, targetModel: "llama-4-scout",
+			apiFormat: apiformat.OpenAIChatCompletions, auth: auth.Simple,
+			endpoint: "maas.cluster-b.example.com", path: "/maas/v1/chat/completions",
+			secretName: "key", secretNamespace: "llm",
+			config: map[string]string{}, weight: 1,
+		}}},
+	)
+
+	instance := &ModelProviderResolverPlugin{store: store, clusterName: ""}
+	cs := plugin.NewCycleState()
+	req := requesthandling.NewInferenceRequest()
+	req.Headers[":path"] = "/llm/remote-llama/v1/chat/completions"
+	req.Headers[OriginClusterHeader] = "cluster-a"
+	req.Body["model"] = "remote-llama"
+
+	err := instance.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err, "loop detection should be disabled when CLUSTER_NAME is empty")
+
+	mutated := req.MutatedHeaders()
+	_, hasOrigin := mutated[OriginClusterHeader]
+	require.False(t, hasOrigin,
+		"should not inject origin header when CLUSTER_NAME is empty")
+}
+
+func TestProcessRequest_LoopDetected_BeforeModelResolution(t *testing.T) {
+	store := newInfoStore()
+	instance := &ModelProviderResolverPlugin{store: store, clusterName: "cluster-a"}
+
+	cs := plugin.NewCycleState()
+	req := requesthandling.NewInferenceRequest()
+	req.Headers[":path"] = "/llm/model/v1/chat/completions"
+	req.Headers[OriginClusterHeader] = "cluster-a"
+	req.Body["model"] = "model"
+
+	err := instance.ProcessRequest(context.Background(), cs, req)
+	require.Error(t, err)
+
+	_, csErr := plugin.ReadCycleStateKey[string](cs, state.ProviderKey)
+	require.Error(t, csErr, "CycleState should be empty — loop rejected before model resolution")
+}
+
 func TestDetectInputAPIFormat(t *testing.T) {
 	tests := []struct {
 		path     string

--- a/pkg/plugins/model-provider-resolver/plugin_test.go
+++ b/pkg/plugins/model-provider-resolver/plugin_test.go
@@ -93,6 +93,78 @@ func TestProcessRequest_ModelResolved(t *testing.T) {
 	require.Equal(t, endpoint, actualEndpoint)
 }
 
+func TestProcessRequest_PathWrittenToCycleState(t *testing.T) {
+	store := newInfoStore()
+	const (
+		extNS       = "llm"
+		extName     = "remote-llama"
+		targetModel = "llama-4-scout"
+		credName    = "cluster-b-key"
+		endpoint    = "maas.cluster-b.example.com"
+		path        = "/maas-default-gateway/v1/chat/completions"
+	)
+	store.addOrUpdateModel(
+		types.NamespacedName{Namespace: extNS, Name: extName},
+		&externalModelInfo{modelName: extName, refs: []*resolvedProviderRef{{
+			provider:        provider.RemoteMaaS,
+			targetModel:     targetModel,
+			apiFormat:       apiformat.OpenAIChatCompletions,
+			auth:            auth.Simple,
+			endpoint:        endpoint,
+			path:            path,
+			secretName:      credName,
+			secretNamespace: extNS,
+			config:          map[string]string{},
+			weight:          1,
+		}}},
+	)
+
+	instance := &ModelProviderResolverPlugin{store: store}
+	cs := plugin.NewCycleState()
+	req := requesthandling.NewInferenceRequest()
+	req.Headers[":path"] = "/" + extNS + "/" + extName + "/v1/chat/completions"
+	req.Body["model"] = extName
+
+	err := instance.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err)
+
+	actualPath, err := plugin.ReadCycleStateKey[string](cs, state.PathKey)
+	require.NoError(t, err)
+	require.Equal(t, path, actualPath)
+}
+
+func TestProcessRequest_EmptyPathWrittenToCycleState(t *testing.T) {
+	store := newInfoStore()
+	store.addOrUpdateModel(
+		types.NamespacedName{Namespace: "llm", Name: "gpt4"},
+		&externalModelInfo{modelName: "gpt4", refs: []*resolvedProviderRef{{
+			provider:        provider.OpenAI,
+			targetModel:     "gpt-4o",
+			apiFormat:       apiformat.OpenAIChatCompletions,
+			auth:            auth.Simple,
+			endpoint:        "api.openai.com",
+			path:            "",
+			secretName:      "key",
+			secretNamespace: "llm",
+			config:          map[string]string{},
+			weight:          1,
+		}}},
+	)
+
+	instance := &ModelProviderResolverPlugin{store: store}
+	cs := plugin.NewCycleState()
+	req := requesthandling.NewInferenceRequest()
+	req.Headers[":path"] = "/llm/gpt4/v1/chat/completions"
+	req.Body["model"] = "gpt4"
+
+	err := instance.ProcessRequest(context.Background(), cs, req)
+	require.NoError(t, err)
+
+	actualPath, err := plugin.ReadCycleStateKey[string](cs, state.PathKey)
+	require.NoError(t, err)
+	require.Equal(t, "", actualPath, "empty path should still be written to CycleState")
+}
+
 func TestProcessRequest_ModelMismatch(t *testing.T) {
 	store := newInfoStore()
 	store.addOrUpdateModel(

--- a/pkg/plugins/model-provider-resolver/store.go
+++ b/pkg/plugins/model-provider-resolver/store.go
@@ -28,6 +28,7 @@ import (
 type providerInfo struct {
 	provider        string
 	endpoint        string
+	path            string
 	auth            auth.Auth
 	secretName      string
 	secretNamespace string
@@ -41,6 +42,7 @@ type resolvedProviderRef struct {
 	apiFormat       apiformat.APIFormat
 	auth            auth.Auth
 	endpoint        string
+	path            string
 	secretName      string
 	secretNamespace string
 	config          map[string]string


### PR DESCRIPTION
## Description

Adds routing loop detection to the `model-provider-resolver` plugin to prevent infinite request cycles when Cluster A routes to Cluster B and Cluster B (by misconfiguration) routes back to Cluster A.

**Incoming check (early in `ProcessRequest`):**
- Reads `X-Origin-Cluster` header from incoming requests
- If the value matches this cluster's identity (`CLUSTER_NAME` env var) → rejects with HTTP 403 (routing loop detected)
- If the value is a different cluster → allows (normal cross-cluster request)
- If absent → allows (normal request)

**Outgoing injection (after resolving to a `remote-maas` provider):**
- When the resolved provider is `remote-maas`, injects `X-Origin-Cluster: <this-cluster-name>` into the outgoing request

**Backward compatible:** when `CLUSTER_NAME` is unset, loop detection is fully disabled — no checks, no header injection. Existing deployments are unaffected.

**Flow:**
Incoming request → checkRoutingLoop() X-Origin-Cluster == CLUSTER_NAME? → 403 Forbidden X-Origin-Cluster != CLUSTER_NAME? → allow No header? → allow → resolve model + provider → injectOriginCluster() provider == remote-maas? → SetHeader("x-origin-cluster", CLUSTER_NAME) otherwise? → no-op → continue pipeline



Depends on #347 (path field and remote-maas provider)
Relates to #343

## How Has This Been Tested?

- 7 new unit tests covering all loop detection scenarios:
  - `TestProcessRequest_LoopDetected_SameCluster` — same cluster header → error
  - `TestProcessRequest_CrossCluster_DifferentOrigin` — different cluster → passes through
  - `TestProcessRequest_NoOriginHeader_Passes` — no header → passes through
  - `TestProcessRequest_RemoteMaaS_InjectsOriginHeader` — remote-maas → header injected
  - `TestProcessRequest_LocalProvider_NoOriginHeaderInjected` — non-remote-maas → no header injected
  - `TestProcessRequest_ClusterNameEmpty_LoopDetectionDisabled` — empty CLUSTER_NAME → fully disabled
  - `TestProcessRequest_LoopDetected_BeforeModelResolution` — loop rejected before CycleState is written
- `go build ./...` — clean
- `go test ./pkg/plugins/model-provider-resolver/...` — all 49 tests pass (7 new + 42 existing, 0 regressions)

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional path override capability for external providers and model-provider bindings, allowing customization of request paths (max 512 characters).
  * Implemented cross-cluster routing loop detection that tracks origin cluster information to prevent circular requests between clusters.
  * Added support for remote-maas provider type with automatic origin cluster header injection for cross-cluster routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->