### PR TITLE
feat: resolve ExternalModel by body model name for single-URL routing

### DIFF
--- a/pkg/plugins/model-provider-resolver/plugin.go
+++ b/pkg/plugins/model-provider-resolver/plugin.go
@@ -136,30 +136,24 @@ func (p *ModelProviderResolverPlugin) ProcessRequest(ctx context.Context, cycleS
 	log.FromContext(ctx).V(logutil.VERBOSE).Info("received incoming request", "path", request.Headers[":path"])
 	relativePath := sanitizePath(request.Headers[":path"])
 
-	segments := strings.Split(relativePath, "/")
-	if len(segments) < 2 || segments[0] == "" || segments[1] == "" {
-		log.FromContext(ctx).V(logutil.VERBOSE).Info("wasn't able to parse namespaced name from path", "path", relativePath)
-		return nil
+	// Resolve by model name: prefer X-Gateway-Model-Name header (set by body-field-to-header),
+	// fall back to request body model field. This supports both single-URL and per-model-URL patterns.
+	modelName := request.Headers["x-gateway-model-name"]
+	if modelName == "" {
+		modelName = model
 	}
 
-	modelKey := types.NamespacedName{Namespace: segments[0], Name: segments[1]}
-	log.FromContext(ctx).V(logutil.VERBOSE).Info("exported namespaced name from path", "key", modelKey)
-
-	modelInfo, found := p.store.getModel(modelKey)
+	modelInfo, modelKey, found := p.store.getModelByName(modelName)
 	if !found {
 		return nil // not an external model — pass through for internal models
 	}
 
+	logger.Info("resolved model by name", "modelName", modelName, "key", modelKey.String())
+
 	inputFormat := detectInputAPIFormat(relativePath)
 	if inputFormat == "" {
 		logger.Error(nil, "unsupported API path for external model", "model", modelKey.String(), "path", relativePath)
-		return errcommon.Error{Code: errcommon.BadRequest, Msg: fmt.Sprintf("unsupported API path: %s", relativePath)}
-	}
-
-	// model in request body must match the ExternalModel's client-facing name
-	if modelInfo.modelName != model {
-		logger.Error(nil, "model mismatch between request body and ExternalModel", "requestModel", model, "externalModel", modelInfo.modelName)
-		return errcommon.Error{Code: errcommon.NotFound, Msg: fmt.Sprintf("model in request body '%s' doesn't match ExternalModel", model)}
+		return errcommon.Error{Code: errcommon.BadRequest, Msg: "unsupported API endpoint"}
 	}
 
 	ref := selectByWeight(modelInfo.refs)
@@ -182,11 +176,11 @@ func (p *ModelProviderResolverPlugin) ProcessRequest(ctx context.Context, cycleS
 // detectInputAPIFormat determines the client's API format from the request path suffix.
 func detectInputAPIFormat(path string) apiformat.APIFormat {
 	switch {
-	case strings.HasSuffix(path, "/v1/chat/completions"):
+	case strings.HasSuffix(path, "/v1/chat/completions"), path == "v1/chat/completions":
 		return apiformat.OpenAIChatCompletions
-	case strings.HasSuffix(path, "/v1/messages"):
+	case strings.HasSuffix(path, "/v1/messages"), path == "v1/messages":
 		return apiformat.Messages
-	case strings.HasSuffix(path, "/v1/responses"):
+	case strings.HasSuffix(path, "/v1/responses"), path == "v1/responses":
 		return apiformat.OpenAIResponses
 	default:
 		return ""

--- a/pkg/plugins/model-provider-resolver/plugin_test.go
+++ b/pkg/plugins/model-provider-resolver/plugin_test.go
@@ -133,7 +133,7 @@ func TestProcessRequest_PathWrittenToCycleState(t *testing.T) {
 	require.Equal(t, path, actualPath)
 }
 
-func TestProcessRequest_ModelMismatch(t *testing.T) {
+func TestProcessRequest_UnknownModelPassesThrough(t *testing.T) {
 	store := newInfoStore()
 	store.addOrUpdateModel(
 		types.NamespacedName{Namespace: "llm", Name: "gpt4"},
@@ -148,10 +148,13 @@ func TestProcessRequest_ModelMismatch(t *testing.T) {
 	cs := plugin.NewCycleState()
 	req := requesthandling.NewInferenceRequest()
 	req.Headers[":path"] = "/llm/gpt4/v1/chat/completions"
-	req.Body["model"] = "wrong-name"
+	req.Body["model"] = "unknown-model"
 
 	err := instance.ProcessRequest(context.Background(), cs, req)
-	require.Error(t, err, "should error when body model doesn't match modelName")
+	require.NoError(t, err, "unknown model name should pass through for internal models")
+
+	_, provErr := plugin.ReadCycleStateKey[string](cs, state.ProviderKey)
+	require.Error(t, provErr, "provider should not be set for unknown models")
 }
 
 func TestProcessRequest_ModelNotFound(t *testing.T) {
@@ -321,7 +324,7 @@ func TestProcessRequest_UnsupportedPath(t *testing.T) {
 
 	err := instance.ProcessRequest(context.Background(), cs, req)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "unsupported API path")
+	require.Contains(t, err.Error(), "unsupported API endpoint")
 }
 
 func TestDetectInputAPIFormat(t *testing.T) {

--- a/pkg/plugins/model-provider-resolver/store.go
+++ b/pkg/plugins/model-provider-resolver/store.go
@@ -129,3 +129,18 @@ func (s *infoStore) getModel(key types.NamespacedName) (*externalModelInfo, bool
 	info, ok := modelsByNamespace[key.Name]
 	return info, ok
 }
+
+// getModelByName finds an ExternalModel by its client-facing modelName across all namespaces.
+func (s *infoStore) getModelByName(modelName string) (*externalModelInfo, types.NamespacedName, bool) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	for ns, models := range s.models {
+		for name, info := range models {
+			if info.modelName == modelName {
+				return info, types.NamespacedName{Namespace: ns, Name: name}, true
+			}
+		}
+	}
+	return nil, types.NamespacedName{}, false
+}


### PR DESCRIPTION
## Summary
- Replace path-based resolution (extracting namespace/name from URL segments) with body-model-name lookup via `getModelByName`
- Enables single-URL routing (`POST /v1/chat/completions` with model only in body) — no model in the URL path
- Resolver prefers `X-Gateway-Model-Name` header (set by body-field-to-header) with fallback to body `model` field
- Fixes `detectInputAPIFormat` for bare paths after `sanitizePath` strips the leading slash

## Context
MaaS already supports single-URL routing:
- PR #948 (MaaS) adds pre-auth ext_proc that sets `X-Gateway-Model-Name` from the body
- MaaS controller generates header-based HTTPRoute rules matching on `X-Gateway-Model-Name`

The only gap was in the IPP resolver which only did path-based extraction. This PR closes that gap.

## Test plan
- [ ] Single URL `/v1/chat/completions` with `model: gpt-5.5` resolves to correct ExternalModel
- [ ] Single URL `/v1/messages` with `model: claude-haiku-4-5-20251001` resolves correctly
- [ ] Per-model URLs (`/llm/ext-openai/v1/chat/completions`) continue to work via body model fallback
- [ ] Models with same name in different namespaces resolve correctly

## Risk analysis
**Risk rating:** 2
**Why:** Changes resolution logic in model-provider-resolver which is on the critical path. However, the change is straightforward (lookup by modelName field instead of path segments) and both URL patterns are covered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model selection now resolves by model name from the request header, with a fallback to the request body when the header is not provided.
* **Bug Fixes**
  * Improved model lookup to find matching models by name across namespaces.
  * Relaxed strict model name validation to avoid rejecting requests when naming doesn’t match exactly.
  * Updated the “unsupported API” error message to be clearer and no longer include the raw endpoint path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->